### PR TITLE
feat: Multi-agent worktree workflow

### DIFF
--- a/.claude/HISTORY.md
+++ b/.claude/HISTORY.md
@@ -4,6 +4,71 @@
 ---
 ## 2026-05-12
 
+### Session 152 — APT Public Repo Staging Pipeline (Issue #80)
+
+**Goal:** Stage a complete signed APT repo at `output/repo/` for `bookworm` × {arm64, amd64}, validated end-to-end. User pushes to `apt.secubox.in` out-of-band.
+
+**Spec & plan:**
+- Design: `docs/superpowers/specs/2026-05-12-apt-public-repo-staging-design.md`
+- Plan: `docs/superpowers/plans/2026-05-12-apt-public-repo-staging.md`
+
+**Delivered (10 tasks, 9 commits — merged via PR #82, plus `0f1907df` chroot fix):**
+
+| Component | Commit | Purpose |
+|-----------|--------|---------|
+| `scripts/build-packages.sh --filter` + `--dry-run` | `ce82e13d` | Tier-driven build filtering via JSON manifest |
+| `scripts/lib/tier-manifest.sh` + hardening | `6f59de25`, `52463db1` | Resolve `base/tier-lite/tier-standard/tier-pro` → JSON package list |
+| `scripts/stage-gpg-bootstrap.sh` | `3b99bcf4` | Persistent GPG key at `~/.gnupg/secubox/`, writes `FINGERPRINT.txt` |
+| `scripts/stage-apt-repo.sh` | `5f7b8474` | Main orchestrator (GPG → reprepro init → tier loop → check gate) |
+| `scripts/render-deploy-artifacts.sh` | `d6fe14d5` | nginx vhost + DEPLOY.md + install.sh + CMSD-1.0 license copies |
+| `scripts/validate-staged-repo.sh` + chroot fix | `bb58789b`, `0f1907df` | reprepro check + gpg verify + license cmp + chroot apt-update smoke |
+| `.gitignore` for staging artifacts | `197eba63` | Ignore `output/repo/{db,pool,dists,conf,gpg}` and build logs |
+
+**Tooling used:**
+
+- `secubox gen --tier <tier> --board mochabin --out <dir>` (existing Go CLI; emits `manifest.yaml`)
+- `reprepro` with persistent `~/.gnupg/secubox/` keyring (SignWith fingerprint)
+- `dpkg-buildpackage` + `crossbuild-essential-arm64` (already installed)
+- `python3-yaml` (for parsing `secubox gen` output)
+
+**End-to-end validation (base + tier-lite × arm64+amd64):**
+
+- 9 packages published, all `Architecture: all`
+- `reprepro check` clean
+- `gpg --verify InRelease` → Good signature, fingerprint `31848880ED89C1722677D75A25C9E32645166DB9`
+- License files byte-match project root
+- `chroot apt-get update` against `file://output/repo/` succeeds (sees SecuBox repo)
+
+**Important finding (arch:all dominance):**
+
+| Architecture field | Count |
+|--------------------|-------|
+| `all` | 130 |
+| `any` | 2 (`secubox-daemon`, `zkp-hamiltonian`) |
+
+130/132 SecuBox packages are `Architecture: all` — the cross-arch (arm64 vs amd64) split is mostly cosmetic. The two `Architecture: any` packages aren't in `build-packages.sh`'s `PACKAGES=` list, so the `arm64` pool count is currently 0. Adding them is separate work.
+
+**GPG signing key:**
+
+- UID: `SecuBox Package Signing Key (apt.secubox.in) <packages@secubox.in>`
+- Fingerprint: `31848880ED89C1722677D75A25C9E32645166DB9`
+- Home: `~/.gnupg/secubox/` (persistent across rebuilds)
+- Public key: `output/repo/secubox-keyring.gpg` (ASCII-armored) + `.bin`
+
+**Open item (not blocking):**
+
+- TLS cert for `apt.secubox.in` shows `ERR_TLS_CERT_ALTNAME_INVALID` — must be re-issued by certbot for the exact SAN. Recipe is in `output/repo/DEPLOY.md`.
+
+**Next steps (user):**
+
+1. Optional: full pipeline run with `bash scripts/stage-apt-repo.sh` (no flags = all four tiers, 30-90 min).
+2. rsync to `apt.secubox.in` per `output/repo/DEPLOY.md` (excludes `db/`, `gpg/`, `conf/`).
+3. certbot --nginx for cert; verify SAN includes `apt.secubox.in`.
+4. Smoke-test from clean client: `curl -fsSL https://apt.secubox.in/install.sh | sudo bash && sudo apt-get update`.
+5. Close issue #80 on success.
+
+---
+
 ### Session 151 — Fix Sidebar Mobile Mode False-Positive on Touch Desktops
 
 **Goal:** Sidebar of secubox-hub forced mobile mode (hamburger + hidden sidebar) on Firefox PC because the detection logic used `isTouchDevice() || isNarrowViewport()` — any touch signal (touchscreen laptop, Firefox `pointer: coarse`, `maxTouchPoints > 0`) triggered mobile UX at desktop widths.

--- a/.claude/HISTORY.md
+++ b/.claude/HISTORY.md
@@ -4,6 +4,70 @@
 ---
 ## 2026-05-12
 
+### Session 153 — Mitmproxy Route Sync Stability Fix
+
+**Goal:** All `*.gk2.secubox.in` metablogizer sites (arm, zkp, 3d, …) returned "Wrong Domain" page on HTTPS. Investigate, restore service, and harden the auto-sync infrastructure.
+
+**Symptom chain:**
+
+1. User report: `https://arm.gk2.secubox.in/` → "Wrong Domain - SecuBox" landing page.
+2. `~160` metablogizer sites affected (all routed via mitmproxy WAF).
+3. Two systemd timers (`sync-mitmproxy-routes.timer` + `secubox-route-sync.timer`) firing at the same second on the same routes file.
+4. `sync-mitmproxy-routes.service` had been failing with exit code 30/4 for >30 minutes (chronic).
+
+**Root cause (deepest):**
+
+`log()` function in `/usr/local/bin/sync-mitmproxy-routes.sh` wrote to **stdout**. `fix_dead_container_routes()` calls `log "Fixing dead route: …"` and is itself captured via `routes_json=$(fix_dead_container_routes "$routes_json")` — every log line was concatenated into the JSON variable, producing `[date] Fixing dead route: …{"255.gk2..."`. jq then complained `Invalid numeric literal at line 1, column 12`, `set -e` killed the script, and the corrupted JSON got pushed to the mitmproxy container (`lxc-attach … tee /srv/mitmproxy/haproxy-routes.json`). mitmproxy restart-looped on `Failed to load routes: Expecting ',' delimiter`, HAProxy backend `mitmproxy_inspector` went DOWN, every public domain returned **HTTP 503**.
+
+**Additional contributing bugs:**
+
+- `fix_dead_container_routes` returned `$fixed` (a count) instead of `0` — non-zero return tripped `set -e` in the caller's command substitution.
+- `sync-all-routes.sh` step 2 wrote metablogizer routes to port **9080** (nginx default_server → "Wrong Domain") instead of **8900** (where nginx actually listens with `server_name` per metablog site).
+- jq read calls had no error tolerance — any malformed JSON fed in via `$routes_json` aborted the whole script via `set -euo pipefail`.
+- Two systemd services bound to the **same script** (`sync-mitmproxy-routes.service` + `secubox-route-sync.service`) racing on the same file.
+
+**Fixes applied:**
+
+| # | Fix | Cible | Mechanism |
+| --- | --- | --- | --- |
+| 1 | Routes patchées 9080→8900 (165 sites metablog) | `/srv/mitmproxy/haproxy-routes.json` (host + container) | Python script (extract `server_name` from nginx, rewrite port) |
+| 2 | `return $fixed` → `return 0` | `sync-mitmproxy-routes.sh:fix_dead_container_routes` | sed |
+| 3 | Port metablog 9080 → 8900 in step 2 | `sync-all-routes.sh:62` | sed |
+| 4 | **`log()` writes to stderr** (root-cause fix) | `sync-mitmproxy-routes.sh:log` | adds `>&2` so `$()` capture is clean |
+| 5 | Defensive `2>/dev/null \|\| true` on jq read | `sync-mitmproxy-routes.sh` (2 occurrences) | tolerate corrupted input |
+| 6 | Fallback preserving old `routes_json` on jq write failure | `sync-mitmproxy-routes.sh` (3 occurrences) | `new_rj=$(... \|\| true); [[ -n "$new_rj" ]] && routes_json="$new_rj"` |
+| 7 | `flock -n` guard prevents concurrent runs | `sync-mitmproxy-routes.sh` (head) | `/run/sync-mitmproxy-routes.lock` |
+| 8 | Disable duplicate timer | `systemctl disable --now secubox-route-sync.timer` | systemd |
+
+**Verification (post-fix):**
+
+- `sync-mitmproxy-routes.service` via systemd → exit 0/SUCCESS, "Sync complete".
+- Container routes JSON valid: 244 keys, all metablogizer domains → `[10.100.0.1, 8900]`.
+- mitmproxy: `active`, listening on `0.0.0.0:8080`.
+- HAProxy backend `mitmproxy_inspector srv0 10.100.0.60:8080` op_state=UP.
+- Live tests: `admin.gk2`, `arm.gk2`, `zkp.gk2`, `3d.gk2` all HTTP 200 with correct titles.
+
+**Files modified (versioned in repo):**
+
+- `scripts/sync-mitmproxy-routes.sh` (synced from board `/usr/local/bin/`)
+- `scripts/sync-all-routes.sh` (new in repo, synced from board)
+
+**Backups created on board (timestamped, kept for rollback):**
+
+- `/srv/mitmproxy/haproxy-routes.json.bak.<epoch>` (pre-patch JSON)
+- `/usr/local/bin/sync-mitmproxy-routes.sh.bak.<epoch>` and `.bak.<epoch>-preflock`
+- `/usr/local/bin/sync-all-routes.sh.bak.<epoch>`
+
+**Topology note discovered:**
+
+- Canonical Hub vhosts (nginx `sites-available/secubox-local`): `admin.gk2.secubox.in`, `gk2.secubox.in`, `secubox.maegia.tv`, `c3box.maegia.tv` + LAN aliases.
+- `~165` metablogizer sites listed in `/etc/nginx/sites-enabled/metablogizer`, each `listen 0.0.0.0:8900` with per-site `server_name`, `root /srv/metablogizer/sites/<name>/`.
+- Public flow: HAProxy `https-in` (443) → ACL host match → backend `mitmproxy_inspector` (LXC `10.100.0.60:8080`) → mitmproxy looks up host in `haproxy-routes.json` → upstream `[10.100.0.1, 8900]` → nginx vhost matches `server_name` → serves static site.
+
+**Open follow-up:** the `sync-streamlit-routes.timer` last fired 2026-05-10 (1d 15h ago) and didn't fire since — needs separate investigation. Not blocking metablog/Hub stability.
+
+---
+
 ### Session 152 — APT Public Repo Staging Pipeline (Issue #80)
 
 **Goal:** Stage a complete signed APT repo at `output/repo/` for `bookworm` × {arm64, amd64}, validated end-to-end. User pushes to `apt.secubox.in` out-of-band.

--- a/.claude/HISTORY.md
+++ b/.claude/HISTORY.md
@@ -4,6 +4,63 @@
 ---
 ## 2026-05-12
 
+### Session 154 — Metablogizer Vhosts Audit & Regeneration
+
+**Goal:** User flagged `https://lldh.ganimed.fr/` returning 404. Apply the same diagnostic + fix workflow to all metablogizer vhosts, find every site with broken routing / missing content / port mismatch.
+
+**Trigger case — `lldh.ganimed.fr`:**
+
+- nginx had `server_name lldh.gk2.secubox.in` only (no `.ganimed.fr` alias) → 404 from default_server.
+- mitmproxy route pointed to port `8000` instead of `8900` (where metablog nginx listens).
+- `/srv/metablogizer/sites/lldh/` contained only `La_Livree_dHermes_Galerie-1.zip` (31 MB) + `.git` — no `index.html` to serve.
+
+**Trigger fix (3 steps):**
+
+1. Extracted zip via `python3 -m zipfile` (84 files: `index.html` + `planches/*.jpg`).
+2. Added `lldh.ganimed.fr` to existing `server_name lldh.gk2.secubox.in` block in `/etc/nginx/sites-enabled/metablogizer`, `nginx -t && systemctl reload nginx`.
+3. Patched `/srv/mitmproxy/haproxy-routes.json`: `lldh.ganimed.fr` → `[192.168.1.200, 8900]`, pushed to LXC container, `systemctl restart mitmproxy` (SIGHUP alone wasn't enough — mitmproxy serving cached/wrong content until full restart).
+
+**Systematic audit of all metablog vhosts (Python script in `/tmp` on board):**
+
+Scanned `/etc/nginx/sites-enabled/metablogizer` for every `server_name` → root pair, cross-checked each domain against `/srv/mitmproxy/haproxy-routes.json` and the on-disk `index.html`.
+
+| Metric | Count |
+| --- | --- |
+| Sites scanned | 159 |
+| Server_names total | 162 |
+| OK after fixes | 162 (100%) |
+| `wrong_port` (route ≠ 8900) | 0 |
+| `missing_route` (in nginx, absent from routes) | 1 → `pub.gk2.secubox.in` |
+| `extract_zip` (zip not extracted) | 0 (after lldh) |
+| `no_index_no_zip` real cases | 1 → `werdl` |
+
+**Additional fixes applied:**
+
+- `pub.gk2.secubox.in` → added to mitmproxy routes `[10.100.0.1, 8900]`, mitmproxy restarted. Now HTTP 200 ("GK² · NET — Opérateur Internet & Services Numériques").
+- `werdl/index.html` → symlink to `famille_index.html` (3 HTML files existed: `famille_index`, `famille_bebe-enfant`, `famille_papy-mamy`; preserved originals, no destructive rename). Now HTTP 200 ("Retrouver son téléphone — Pour toute la famille").
+
+**False positive identified:**
+
+- Initial audit flagged `public` as a "site without index", but my regex over-captured: it was matching the trailing `public` in Laravel-style paths `/srv/metablogizer/sites/{money,live,evolution}/public/`. Those parent sites (`money`, `live`, `evolution`) serve fine via their normal `server_name` blocks. No action needed.
+
+**Backups on board:**
+
+- `/srv/mitmproxy/haproxy-routes.json.bak.<epoch>` (pre-patch)
+- `/etc/nginx/sites-enabled/metablogizer.bak.<epoch>` (pre-server_name-add)
+- Symlink for `werdl` is non-destructive (`famille_index.html` untouched).
+
+**Verification (live, fresh HTTPS, no cache):**
+
+- `lldh.ganimed.fr` → 200, 43959 b, "La Livrée d'Hermès"
+- `lldh.gk2.secubox.in` → 200, 43959 b, same content
+- `pub.gk2.secubox.in` → 200, 47584 b, "GK² · NET"
+- `werdl.gk2.secubox.in` → 200, 6017 b, "Retrouver son téléphone"
+- Spot-check `admin.gk2`, `arm.gk2`, `zkp.gk2`, `3d.gk2` from Session 153 still 200 ✅ (no regression).
+
+**Note:** all fixes were applied to live board state (routes JSON, nginx vhost config, site content). The metablogizer vhost config (`/etc/nginx/sites-enabled/metablogizer`) is auto-generated per site by the metablogizer service and is not tracked in the repo, so no repo file changed from this session beyond this HISTORY entry.
+
+---
+
 ### Session 153 — Mitmproxy Route Sync Stability Fix
 
 **Goal:** All `*.gk2.secubox.in` metablogizer sites (arm, zkp, 3d, …) returned "Wrong Domain" page on HTTPS. Investigate, restore service, and harden the auto-sync infrastructure.

--- a/.claude/HISTORY.md
+++ b/.claude/HISTORY.md
@@ -4,6 +4,23 @@
 ---
 ## 2026-05-12
 
+### Session 155 — Multi-Agent Worktree Workflow
+
+**Goal:** Enable parallel multi-agent work via one-branch-per-issue isolated worktrees.
+
+**Delivered:**
+
+- `scripts/agent-worktree.sh` with sub-commands `start`, `list`, `sync`, `finish`, `clean`
+- `scripts/lib/agent-worktree-lib.sh` (slug + label→prefix helpers)
+- Test suite `scripts/tests/test-agent-worktree.sh` (26 cases, no bats dep)
+- `gh` CLI mock at `scripts/tests/fixtures/gh-mock.sh`
+- New section in `CLAUDE.md`: `## 🌿 Multi-Agent Worktree Workflow — Obligatoire`
+- `scripts/README.md` updated with usage
+
+**Issue:** #83. **Spec:** `docs/superpowers/specs/2026-05-12-multi-agent-worktree-workflow-design.md`. **Plan:** `docs/superpowers/plans/2026-05-12-multi-agent-worktree-workflow.md`.
+
+---
+
 ### Session 154 — Metablogizer Vhosts Audit & Regeneration
 
 **Goal:** User flagged `https://lldh.ganimed.fr/` returning 404. Apply the same diagnostic + fix workflow to all metablogizer vhosts, find every site with broken routing / missing content / port mismatch.

--- a/.claude/WIP.md
+++ b/.claude/WIP.md
@@ -1,5 +1,32 @@
 # WIP — Work In Progress
-*Mis à jour : 2026-05-12 (Session 149)*
+*Mis à jour : 2026-05-12 (Session 152)*
+
+---
+
+## ✅ Session 152: APT Public Repo Staging Pipeline (Issue #80)
+
+### Objective
+Stage a signed APT repo at `output/repo/` for bookworm × {arm64, amd64}, validated end-to-end. User pushes to `apt.secubox.in` out-of-band.
+
+### Completed
+- Brainstormed design → `docs/superpowers/specs/2026-05-12-apt-public-repo-staging-design.md`
+- Implementation plan → `docs/superpowers/plans/2026-05-12-apt-public-repo-staging.md`
+- All 10 tasks delivered. Pipeline runs end-to-end on base + tier-lite × arm64+amd64; 9 packages published; all four validation gates pass (`reprepro check`, `gpg --verify InRelease`, license byte-match, chroot `apt-get update`).
+- GPG fingerprint: `31848880ED89C1722677D75A25C9E32645166DB9` (persistent in `~/.gnupg/secubox/`)
+- Deploy artifacts ready: `output/repo/{nginx-apt.conf, DEPLOY.md, install.sh, LICENCE-CMSD-1.0.md, LICENSE-CMSD-1.0.en.md, secubox-keyring.gpg, FINGERPRINT.txt, MANIFEST.txt}`
+
+### Key finding
+130/132 SecuBox packages are `Architecture: all`. Only `secubox-daemon` and `zkp-hamiltonian` are `Architecture: any`, and neither is in `scripts/build-packages.sh`'s PACKAGES list. So the arm64-specific pool is currently empty; adding those two to the build list is separate work.
+
+### Next steps (pending user action)
+1. Optional: full pipeline (`bash scripts/stage-apt-repo.sh`) for all four tiers (30-90 min).
+2. rsync staged tree to `apt.secubox.in` per `output/repo/DEPLOY.md`.
+3. certbot --nginx; verify SAN includes `apt.secubox.in` (fixes the current `ERR_TLS_CERT_ALTNAME_INVALID`).
+4. Validate from clean client: `curl -fsSL https://apt.secubox.in/install.sh | sudo bash && sudo apt-get update`.
+5. Close issue #80.
+
+### Commits (merged via PR #82, plus `0f1907df` follow-up)
+`ce82e13d` `6f59de25` `52463db1` `3b99bcf4` `5f7b8474` `d6fe14d5` `bb58789b` `197eba63` `0f1907df`
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,52 @@ Après chaque module complété :
 
 ---
 
+## 🌿 Multi-Agent Worktree Workflow — Obligatoire
+
+Chaque travail non-trivial doit s'exécuter dans un worktree dédié, créé via
+`scripts/agent-worktree.sh start --issue <#>`. Le checkout principal
+(`~/CyberMindStudio/secubox-deb/secubox-deb/`) est réservé au `master`
+housekeeping et au travail humain — pas aux agents.
+
+### Quand créer un worktree
+
+- Toute issue GitHub avec label `bug`, `enhancement`, `documentation`,
+  `eye-remote`, ou tout label métier (migration, hardware, api, frontend,
+  security, infra)
+- Toute tâche estimée > 30 min ou touchant ≥ 3 fichiers
+- Toute feature/fix qui finira en PR
+
+### Quand NE PAS en créer
+
+- Édition triviale d'un seul fichier de suivi (`HISTORY.md`, `WIP.md`,
+  `TODO.md`)
+- Exploration read-only, réponse à une question
+- Commits administratifs sur master (tags, bumps de version)
+
+### Cycle obligatoire
+
+```text
+gh issue create
+  → scripts/agent-worktree.sh start --issue <#>
+  → cd ~/CyberMindStudio/secubox-deb-worktrees/<#>-<slug>
+  → code + commits (chaque message: "(ref #<#>)")
+  → scripts/agent-worktree.sh finish     # push + PR avec "Closes #<#>"
+  → [user valide et merge la PR]
+  → scripts/agent-worktree.sh clean <#>  # supprime worktree + branche
+```
+
+### Parallélisme
+
+`start` refuse de créer un second worktree pour la même issue. Deux sessions
+Claude (deux terminaux) peuvent travailler simultanément sur deux issues
+distinctes sans collision.
+
+### Source de vérité opérationnelle
+
+`scripts/agent-worktree.sh --help`
+
+---
+
 ## 🔒 Security Policies — Héritées de secubox-openwrt, adaptées Debian
 
 ### WAF Bypass — Interdiction absolue

--- a/docs/superpowers/plans/2026-05-12-multi-agent-worktree-workflow.md
+++ b/docs/superpowers/plans/2026-05-12-multi-agent-worktree-workflow.md
@@ -1,0 +1,1517 @@
+# Multi-Agent Worktree Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `scripts/agent-worktree.sh` (sub-commands `start`/`list`/`sync`/`finish`/`clean`), its test script, and add a `CLAUDE.md` doctrine section, so that every non-trivial task can be run in its own branch and isolated git worktree under `~/CyberMindStudio/secubox-deb-worktrees/`.
+
+**Architecture:** One self-contained Bash script with sub-command dispatch. Helper functions (`derive_slug`, `prefix_from_labels`, etc.) are split into a small sourced library `scripts/lib/agent-worktree-lib.sh` to keep both file sizes manageable and unit-testable in isolation. `gh` and `git` are the only external dependencies and are mockable via `GH_BIN` / `GIT_BIN` env vars for tests.
+
+**Tech Stack:** Bash (POSIX-leaning, `set -euo pipefail`), `gh` CLI for GitHub I/O, `git` for branch/worktree ops, plain shell tests (no bats, since it is not installed on this dev host).
+
+**Spec:** `docs/superpowers/specs/2026-05-12-multi-agent-worktree-workflow-design.md`
+**Tracking issue:** [#83 — Multi-agent worktree workflow](https://github.com/CyberMind-FR/secubox-deb/issues/83)
+
+---
+
+## File Structure
+
+| Path | Responsibility |
+|---|---|
+| `scripts/agent-worktree.sh` | CLI entry point: arg parsing, sub-command dispatch, top-level error handling |
+| `scripts/lib/agent-worktree-lib.sh` | Pure-ish helpers: slug derivation, label→prefix map, path resolution, gh/git wrappers |
+| `scripts/tests/test-agent-worktree.sh` | Test harness; runs each test in a temporary throwaway repo with shimmed `gh` and `git` where appropriate |
+| `scripts/tests/fixtures/gh-mock.sh` | Stub `gh` binary used by tests; emits canned JSON based on `GH_MOCK_*` env vars |
+| `CLAUDE.md` | Add `## 🌿 Multi-Agent Worktree Workflow — Obligatoire` section |
+| `scripts/README.md` | Add "Multi-Agent Worktrees" subsection pointing at the script |
+| `.claude/HISTORY.md` | Final session entry on completion |
+
+`scripts/lib/` already exists (per `ls scripts/`); the new library file slots into it without restructuring.
+
+---
+
+## Conventions used in every task
+
+- Working directory: repo root (`/home/reepost/CyberMindStudio/secubox-deb/secubox-deb`).
+- The whole feature is implemented on branch `feature/83-multi-agent-worktree-workflow` (created in Task 0).
+- Run the test harness via `bash scripts/tests/test-agent-worktree.sh` from the repo root. The harness prints `OK <name>` / `FAIL <name>` per test and exits non-zero if any fail.
+- Commit messages use conventional prefixes (`feat:`, `test:`, `docs:`, `chore:`) and reference the issue, e.g. `feat(scripts): add agent-worktree skeleton (ref #83)`.
+- Every commit ends with the project Co-Authored-By line (per `CLAUDE.md`):
+
+  ```
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  ```
+
+- All file paths in the plan are repo-relative.
+- Shell library functions are tested by *sourcing* the library file in a sub-shell, not by spawning a child process — keeps tests fast and lets us assert on internal variables.
+
+---
+
+## Task 0: Branch, baseline, and helper directories
+
+**Files:**
+- Create: `scripts/lib/` (already exists — verify)
+- Create: `scripts/tests/` (new directory)
+
+- [ ] **Step 1: Create and switch to the feature branch**
+
+```bash
+git fetch origin
+git checkout -b feature/83-multi-agent-worktree-workflow origin/master
+```
+
+Expected: `Switched to a new branch 'feature/83-multi-agent-worktree-workflow'`.
+
+- [ ] **Step 2: Verify `scripts/lib/` exists, create `scripts/tests/`**
+
+```bash
+test -d scripts/lib && echo "lib OK" || mkdir -p scripts/lib
+mkdir -p scripts/tests/fixtures
+ls -d scripts/lib scripts/tests scripts/tests/fixtures
+```
+
+Expected: all three paths printed.
+
+- [ ] **Step 3: Comment the GitHub issue**
+
+```bash
+gh issue comment 83 --body "Implementation started on branch \`feature/83-multi-agent-worktree-workflow\`. Plan: docs/superpowers/plans/2026-05-12-multi-agent-worktree-workflow.md"
+```
+
+Expected: a URL to the comment.
+
+- [ ] **Step 4: Commit the empty test directory (with `.gitkeep`)**
+
+```bash
+echo "# test fixtures for agent-worktree.sh" > scripts/tests/README.md
+git add scripts/tests/README.md
+git commit -m "$(cat <<'EOF'
+chore(scripts): scaffold tests directory for agent-worktree (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: 1 file changed.
+
+---
+
+## Task 1: Mock `gh` fixture for tests
+
+**Files:**
+- Create: `scripts/tests/fixtures/gh-mock.sh`
+
+The mock honors `GH_MOCK_ISSUE_<N>_TITLE`, `GH_MOCK_ISSUE_<N>_LABELS`, `GH_MOCK_ISSUE_<N>_EXIT`, `GH_MOCK_PR_<branch>_STATE`, `GH_MOCK_PR_<branch>_MERGED`. Anything not configured returns exit 2.
+
+- [ ] **Step 1: Create the fixture**
+
+```bash
+cat > scripts/tests/fixtures/gh-mock.sh <<'SHELL'
+#!/usr/bin/env bash
+# Minimal `gh` stand-in for agent-worktree tests.
+# Implements just the verbs the script invokes.
+set -u
+
+cmd="${1:-}"; shift || true
+
+case "$cmd" in
+  auth)
+    sub="${1:-}"
+    if [[ "$sub" == "status" ]]; then
+      if [[ "${GH_MOCK_AUTH:-ok}" == "ok" ]]; then exit 0; else exit 1; fi
+    fi
+    ;;
+  issue)
+    sub="${1:-}"; shift || true
+    case "$sub" in
+      view)
+        num="${1:-}"; shift || true
+        var_exit="GH_MOCK_ISSUE_${num}_EXIT"
+        if [[ -n "${!var_exit:-}" ]]; then exit "${!var_exit}"; fi
+        var_title="GH_MOCK_ISSUE_${num}_TITLE"
+        var_labels="GH_MOCK_ISSUE_${num}_LABELS"
+        title="${!var_title:-Missing title}"
+        labels="${!var_labels:-}"
+        labels_json=""
+        if [[ -n "$labels" ]]; then
+          IFS=',' read -r -a arr <<< "$labels"
+          for l in "${arr[@]}"; do
+            labels_json+="{\"name\":\"$l\"},"
+          done
+          labels_json="${labels_json%,}"
+        fi
+        printf '{"title":%s,"labels":[%s]}\n' "$(printf '"%s"' "$title")" "$labels_json"
+        exit 0
+        ;;
+      comment)
+        # always succeed; record the body in a side file if requested
+        if [[ -n "${GH_MOCK_RECORD:-}" ]]; then
+          echo "comment $*" >> "$GH_MOCK_RECORD"
+        fi
+        exit 0
+        ;;
+    esac
+    ;;
+  pr)
+    sub="${1:-}"; shift || true
+    case "$sub" in
+      view|list)
+        # Look up by --head or by branch arg
+        branch=""
+        for arg in "$@"; do
+          case "$arg" in --head=*) branch="${arg#--head=}";; esac
+        done
+        if [[ -z "$branch" ]]; then branch="${1:-}"; fi
+        var_state="GH_MOCK_PR_${branch//\//_}_STATE"
+        var_merged="GH_MOCK_PR_${branch//\//_}_MERGED"
+        state="${!var_state:-MERGED}"
+        merged="${!var_merged:-2026-05-12T10:00:00Z}"
+        printf '{"state":"%s","mergedAt":"%s"}\n' "$state" "$merged"
+        exit 0
+        ;;
+      create)
+        if [[ -n "${GH_MOCK_RECORD:-}" ]]; then
+          echo "pr create $*" >> "$GH_MOCK_RECORD"
+        fi
+        echo "https://github.com/test/repo/pull/999"
+        exit 0
+        ;;
+    esac
+    ;;
+esac
+echo "gh-mock: unhandled invocation: $cmd $*" >&2
+exit 2
+SHELL
+chmod +x scripts/tests/fixtures/gh-mock.sh
+```
+
+- [ ] **Step 2: Smoke-check the mock manually**
+
+```bash
+GH_MOCK_ISSUE_42_TITLE="Hello world" \
+GH_MOCK_ISSUE_42_LABELS="bug,documentation" \
+  scripts/tests/fixtures/gh-mock.sh issue view 42 --json title,labels
+```
+
+Expected (single line JSON):
+```
+{"title":"Hello world","labels":[{"name":"bug"},{"name":"documentation"}]}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/tests/fixtures/gh-mock.sh
+git commit -m "$(cat <<'EOF'
+test(scripts): add gh CLI mock for agent-worktree tests (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Library skeleton + `derive_slug`
+
+**Files:**
+- Create: `scripts/lib/agent-worktree-lib.sh`
+- Create: `scripts/tests/test-agent-worktree.sh`
+
+The library is sourced, never executed. `derive_slug` lowercases, transliterates accents to ASCII via `iconv`, replaces non-`[a-z0-9]` runs with `-`, trims dashes, truncates to 40 chars, and falls back to `issue` when empty.
+
+- [ ] **Step 1: Write the test harness skeleton + first failing test**
+
+```bash
+cat > scripts/tests/test-agent-worktree.sh <<'SHELL'
+#!/usr/bin/env bash
+# Test harness for scripts/agent-worktree.sh
+# Each `test_*` function is auto-discovered and run in a subshell.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+LIB="$REPO_ROOT/scripts/lib/agent-worktree-lib.sh"
+SCRIPT="$REPO_ROOT/scripts/agent-worktree.sh"
+GH_MOCK="$REPO_ROOT/scripts/tests/fixtures/gh-mock.sh"
+
+pass=0
+fail=0
+failed_names=()
+
+run_test() {
+  local name="$1"
+  local out
+  if out=$(set -e; "$name" 2>&1); then
+    echo "OK   $name"
+    pass=$((pass+1))
+  else
+    echo "FAIL $name"
+    echo "$out" | sed 's/^/     /'
+    fail=$((fail+1))
+    failed_names+=("$name")
+  fi
+}
+
+assert_eq() {
+  local expected="$1" actual="$2" label="${3:-value}"
+  if [[ "$expected" != "$actual" ]]; then
+    echo "$label mismatch: expected '$expected' got '$actual'" >&2
+    return 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "expected to contain '$needle' in: $haystack" >&2
+    return 1
+  fi
+}
+
+# Tests below
+
+test_derive_slug_basic() {
+  source "$LIB"
+  assert_eq "add-tier-manifest-helper-for-apt" "$(derive_slug 'Add tier-manifest helper for APT staging')" "basic slug"
+}
+
+# Auto-discover and run
+mapfile -t tests < <(declare -F | awk '{print $3}' | grep '^test_')
+for t in "${tests[@]}"; do run_test "$t"; done
+
+echo "---"
+echo "passed: $pass  failed: $fail"
+exit $((fail > 0))
+SHELL
+chmod +x scripts/tests/test-agent-worktree.sh
+```
+
+- [ ] **Step 2: Run the harness to confirm the test fails**
+
+```bash
+bash scripts/tests/test-agent-worktree.sh
+```
+
+Expected: `FAIL test_derive_slug_basic` with error mentioning `derive_slug: command not found`. Exit code 1.
+
+- [ ] **Step 3: Implement the library minimally to pass the test**
+
+```bash
+cat > scripts/lib/agent-worktree-lib.sh <<'SHELL'
+# shellcheck shell=bash
+# scripts/lib/agent-worktree-lib.sh
+# Helpers for scripts/agent-worktree.sh. Sourced, never executed.
+
+set -uo pipefail
+
+# Slugify a free-text title into a branch-safe slug.
+# Rules: lowercase, ASCII-fold via iconv, non-[a-z0-9] -> '-', collapse runs,
+# trim leading/trailing '-', max 40 chars, fallback 'issue' when empty.
+derive_slug() {
+  local raw="${1:-}"
+  local s
+  s=$(printf '%s' "$raw" | iconv -f UTF-8 -t ASCII//TRANSLIT 2>/dev/null || printf '%s' "$raw")
+  s=$(printf '%s' "$s" | tr '[:upper:]' '[:lower:]')
+  s=$(printf '%s' "$s" | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')
+  s="${s:0:40}"
+  s="${s%-}"
+  if [[ -z "$s" ]]; then s="issue"; fi
+  printf '%s' "$s"
+}
+SHELL
+```
+
+- [ ] **Step 4: Re-run the harness; confirm the test passes**
+
+```bash
+bash scripts/tests/test-agent-worktree.sh
+```
+
+Expected: `OK   test_derive_slug_basic`. Exit 0.
+
+- [ ] **Step 5: Add the remaining slug edge-case tests, watch them fail then pass**
+
+Append to `scripts/tests/test-agent-worktree.sh` *before* the auto-discover block:
+
+```bash
+test_derive_slug_accents() {
+  source "$LIB"
+  assert_eq "migration-verification-a-valider" "$(derive_slug 'Migration vérification à valider')" "accents"
+}
+
+test_derive_slug_truncate_40() {
+  source "$LIB"
+  local out
+  out=$(derive_slug 'this title is intentionally far too long to fit in forty characters')
+  assert_eq "40" "${#out}" "length"
+  assert_eq "this-title-is-intentionally-far-too-long" "$out" "truncated value"
+}
+
+test_derive_slug_empty_falls_back() {
+  source "$LIB"
+  assert_eq "issue" "$(derive_slug '')" "empty input"
+  assert_eq "issue" "$(derive_slug '日本語のみ')" "all non-ASCII"
+}
+```
+
+Run:
+```bash
+bash scripts/tests/test-agent-worktree.sh
+```
+
+All four `test_derive_slug_*` tests must pass. If `iconv` returns empty for fully non-ASCII inputs, the `[[ -z "$s" ]]` fallback handles it — verify the `日本語のみ` case prints `issue`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/agent-worktree-lib.sh scripts/tests/test-agent-worktree.sh
+git commit -m "$(cat <<'EOF'
+feat(scripts): add agent-worktree library with derive_slug (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `prefix_from_labels` helper
+
+**Files:**
+- Modify: `scripts/lib/agent-worktree-lib.sh`
+- Modify: `scripts/tests/test-agent-worktree.sh`
+
+Spec mapping: `bug|fix` → `fix/`, `documentation` → `docs/`, `infra|chore` → `chore/`, default → `feature/`. First matching label wins (in the order returned by `gh`).
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `scripts/tests/test-agent-worktree.sh` (before the auto-discover block):
+
+```bash
+test_prefix_default_when_no_labels() {
+  source "$LIB"
+  assert_eq "feature/" "$(prefix_from_labels '')" "no labels"
+}
+
+test_prefix_bug_label() {
+  source "$LIB"
+  assert_eq "fix/" "$(prefix_from_labels 'bug')" "bug label"
+  assert_eq "fix/" "$(prefix_from_labels 'fix')" "fix label"
+}
+
+test_prefix_documentation_label() {
+  source "$LIB"
+  assert_eq "docs/" "$(prefix_from_labels 'documentation')" "documentation label"
+}
+
+test_prefix_infra_chore_label() {
+  source "$LIB"
+  assert_eq "chore/" "$(prefix_from_labels 'infra')" "infra label"
+  assert_eq "chore/" "$(prefix_from_labels 'chore')" "chore label"
+}
+
+test_prefix_unknown_label_defaults_feature() {
+  source "$LIB"
+  assert_eq "feature/" "$(prefix_from_labels 'enhancement,question')" "unknown labels"
+}
+
+test_prefix_first_match_wins() {
+  source "$LIB"
+  # bug appears first → fix/, even if documentation also present
+  assert_eq "fix/" "$(prefix_from_labels 'bug,documentation')" "first match"
+}
+```
+
+Run; expect 6 failures with `prefix_from_labels: command not found`.
+
+- [ ] **Step 2: Implement**
+
+Append to `scripts/lib/agent-worktree-lib.sh`:
+
+```bash
+# Map a comma-separated label list to a branch prefix.
+# Mapping: bug|fix -> fix/, documentation -> docs/, infra|chore -> chore/,
+# everything else (including empty) -> feature/. First matching label wins.
+prefix_from_labels() {
+  local labels="${1:-}"
+  local IFS=','
+  local label
+  for label in $labels; do
+    case "$label" in
+      bug|fix)             printf 'fix/';     return 0 ;;
+      documentation)       printf 'docs/';    return 0 ;;
+      infra|chore)         printf 'chore/';   return 0 ;;
+    esac
+  done
+  printf 'feature/'
+}
+```
+
+- [ ] **Step 3: Re-run, all tests pass**
+
+```bash
+bash scripts/tests/test-agent-worktree.sh
+```
+
+Expected: 10 OK, 0 FAIL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/lib/agent-worktree-lib.sh scripts/tests/test-agent-worktree.sh
+git commit -m "$(cat <<'EOF'
+feat(scripts): add prefix_from_labels helper (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Main script skeleton + `--help` + dispatch
+
+**Files:**
+- Create: `scripts/agent-worktree.sh`
+- Modify: `scripts/tests/test-agent-worktree.sh`
+
+- [ ] **Step 1: Failing tests for help and unknown sub-command**
+
+Append before the auto-discover block in `scripts/tests/test-agent-worktree.sh`:
+
+```bash
+test_script_help_exits_zero() {
+  local out
+  out=$(bash "$SCRIPT" --help 2>&1)
+  assert_eq "0" "$?" "help exit"
+  assert_contains "$out" "agent-worktree.sh"
+  assert_contains "$out" "start"
+  assert_contains "$out" "list"
+  assert_contains "$out" "sync"
+  assert_contains "$out" "finish"
+  assert_contains "$out" "clean"
+}
+
+test_script_unknown_subcommand_exits_1() {
+  local out rc
+  out=$(bash "$SCRIPT" wibble 2>&1) ; rc=$?
+  if [[ $rc -ne 1 ]]; then echo "expected rc=1, got $rc; out=$out" >&2; return 1; fi
+  assert_contains "$out" "unknown"
+}
+```
+
+Run; expect failures because the script does not exist.
+
+- [ ] **Step 2: Create the script with sub-command dispatch**
+
+```bash
+cat > scripts/agent-worktree.sh <<'SHELL'
+#!/usr/bin/env bash
+# scripts/agent-worktree.sh
+# Multi-agent worktree workflow helper.
+# See docs/superpowers/specs/2026-05-12-multi-agent-worktree-workflow-design.md
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/agent-worktree-lib.sh
+source "$SCRIPT_DIR/lib/agent-worktree-lib.sh"
+
+WORKTREE_ROOT="${WORKTREE_ROOT:-$HOME/CyberMindStudio/secubox-deb-worktrees}"
+GH_BIN="${GH_BIN:-gh}"
+GIT_BIN="${GIT_BIN:-git}"
+
+usage() {
+  cat <<'USAGE'
+agent-worktree.sh — multi-agent worktree workflow helper
+
+Usage:
+  agent-worktree.sh start  --issue <N> [--dry-run] [--verbose]
+  agent-worktree.sh list   [--verbose]
+  agent-worktree.sh sync   [<N>]
+  agent-worktree.sh finish [--dry-run]
+  agent-worktree.sh clean  <N> [--force]
+  agent-worktree.sh --help
+
+Environment:
+  WORKTREE_ROOT   override worktree root (default: ~/CyberMindStudio/secubox-deb-worktrees)
+  GH_BIN, GIT_BIN override CLI binaries (used by tests)
+
+Exit codes:
+  0 success
+  1 generic / usage
+  2 precondition (issue missing, gh not authed, etc.)
+  3 bad state (dirty tree, conflict, non-merged PR)
+  4 network / remote error
+USAGE
+}
+
+cmd_start()  { echo "start: not implemented" >&2 ; return 1; }
+cmd_list()   { echo "list: not implemented"  >&2 ; return 1; }
+cmd_sync()   { echo "sync: not implemented"  >&2 ; return 1; }
+cmd_finish() { echo "finish: not implemented" >&2; return 1; }
+cmd_clean()  { echo "clean: not implemented" >&2 ; return 1; }
+
+main() {
+  local sub="${1:-}"
+  shift || true
+  case "$sub" in
+    -h|--help|help|"") usage ; return 0 ;;
+    start)  cmd_start  "$@" ;;
+    list)   cmd_list   "$@" ;;
+    sync)   cmd_sync   "$@" ;;
+    finish) cmd_finish "$@" ;;
+    clean)  cmd_clean  "$@" ;;
+    *) echo "unknown sub-command: $sub" >&2 ; usage >&2 ; return 1 ;;
+  esac
+}
+
+main "$@"
+SHELL
+chmod +x scripts/agent-worktree.sh
+```
+
+- [ ] **Step 3: Re-run the harness**
+
+```bash
+bash scripts/tests/test-agent-worktree.sh
+```
+
+Expected: `test_script_help_exits_zero` and `test_script_unknown_subcommand_exits_1` both OK. Previous library tests still OK.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/agent-worktree.sh scripts/tests/test-agent-worktree.sh
+git commit -m "$(cat <<'EOF'
+feat(scripts): add agent-worktree CLI skeleton with help and dispatch (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `start` sub-command — happy path
+
+**Files:**
+- Modify: `scripts/agent-worktree.sh`
+- Modify: `scripts/lib/agent-worktree-lib.sh` (add `branch_from_issue`)
+- Modify: `scripts/tests/test-agent-worktree.sh`
+
+This task implements `start` on a sandbox repo created inside each test. The library exposes `branch_from_issue <N> <gh_json>` that returns the branch name string.
+
+- [ ] **Step 1: Add a sandbox-repo helper to the test harness**
+
+Append above the `# Tests below` line in `scripts/tests/test-agent-worktree.sh`:
+
+```bash
+# Make a throwaway repo with one commit on master; returns its path on stdout.
+make_sandbox_repo() {
+  local dir
+  dir=$(mktemp -d)
+  (
+    cd "$dir"
+    "$GIT_BIN" init -q -b master
+    git config user.email "t@t" ; git config user.name "t"
+    echo "hello" > README.md
+    git add README.md
+    git commit -q -m "init"
+    # Simulate an origin/master so worktree-add can use it
+    git update-ref refs/remotes/origin/master HEAD
+  )
+  printf '%s' "$dir"
+}
+```
+
+- [ ] **Step 2: Failing test for `branch_from_issue`**
+
+Append before the discovery loop:
+
+```bash
+test_branch_from_issue_chore() {
+  source "$LIB"
+  local json='{"title":"Add tier-manifest helper for APT staging","labels":[{"name":"infra"}]}'
+  assert_eq "chore/80-add-tier-manifest-helper-for-apt-stagi" "$(branch_from_issue 80 "$json")" "infra issue"
+}
+
+test_branch_from_issue_default_feature() {
+  source "$LIB"
+  local json='{"title":"Multi-agent worktree workflow","labels":[{"name":"enhancement"}]}'
+  assert_eq "feature/83-multi-agent-worktree-workflow" "$(branch_from_issue 83 "$json")" "default feature"
+}
+```
+
+Run; both fail (`branch_from_issue` undefined).
+
+- [ ] **Step 3: Implement `branch_from_issue` in the library**
+
+Append to `scripts/lib/agent-worktree-lib.sh`:
+
+```bash
+# Extract title and label list from gh JSON (no jq required — minimal parse).
+# Expects the exact shape produced by `gh issue view --json title,labels`.
+_extract_title() {
+  # Match `"title":"..."` allowing escaped quotes inside.
+  printf '%s' "$1" | sed -E 's/.*"title":"((\\.|[^"\\])*)".*/\1/'
+}
+
+_extract_labels() {
+  # Print comma-separated label names from `[{"name":"a"},{"name":"b"}]`.
+  printf '%s' "$1" \
+    | grep -oE '"name":"[^"]+"' \
+    | sed -E 's/"name":"([^"]+)"/\1/' \
+    | paste -sd, -
+}
+
+branch_from_issue() {
+  local num="$1" json="$2"
+  local title labels prefix slug
+  title=$(_extract_title "$json")
+  labels=$(_extract_labels "$json")
+  prefix=$(prefix_from_labels "$labels")
+  slug=$(derive_slug "$title")
+  printf '%s%s-%s' "$prefix" "$num" "$slug"
+}
+```
+
+Verify the truncation math: `chore/` + `80-` + slug (max 40) → 6 + 3 + 40 = 49 chars max. The test asserts the exact 40-char truncated slug.
+
+- [ ] **Step 4: Re-run; both tests pass**
+
+```bash
+bash scripts/tests/test-agent-worktree.sh
+```
+
+- [ ] **Step 5: Failing test for `start` happy path**
+
+Append before the discovery loop:
+
+```bash
+test_start_happy_path() {
+  local repo wt_root
+  repo=$(make_sandbox_repo)
+  wt_root="$(mktemp -d)"
+  trap "rm -rf $repo $wt_root" RETURN
+
+  export GH_BIN="$GH_MOCK"
+  export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_42_TITLE="Hello world"
+  export GH_MOCK_ISSUE_42_LABELS="bug"
+  export WORKTREE_ROOT="$wt_root"
+
+  (cd "$repo" && bash "$SCRIPT" start --issue 42) >/dev/null
+
+  # Branch exists locally
+  (cd "$repo" && git rev-parse --verify "fix/42-hello-world") >/dev/null \
+    || { echo "branch fix/42-hello-world missing" >&2; return 1; }
+
+  # Worktree dir exists
+  test -d "$wt_root/42-hello-world" \
+    || { echo "worktree dir missing" >&2; return 1; }
+}
+```
+
+Run; fails (`start: not implemented`).
+
+- [ ] **Step 6: Implement `cmd_start`**
+
+Replace the stub `cmd_start()` in `scripts/agent-worktree.sh` with:
+
+```bash
+cmd_start() {
+  local issue=""
+  local dry_run=0
+  local verbose=0
+  while (($#)); do
+    case "$1" in
+      --issue) issue="$2"; shift 2 ;;
+      --issue=*) issue="${1#--issue=}"; shift ;;
+      --dry-run) dry_run=1; shift ;;
+      --verbose|-v) verbose=1; shift ;;
+      *) echo "start: unexpected arg: $1" >&2 ; return 1 ;;
+    esac
+  done
+  if [[ -z "$issue" ]]; then
+    echo "start: --issue <N> required" >&2 ; return 1
+  fi
+
+  # Preconditions
+  if ! "$GH_BIN" auth status >/dev/null 2>&1; then
+    echo "start: gh not authenticated. Run: gh auth login" >&2 ; return 2
+  fi
+  if ! "$GIT_BIN" diff-index --quiet HEAD --; then
+    echo "start: working tree is dirty. Commit or stash first." >&2 ; return 3
+  fi
+
+  # Refuse if we are already inside the worktree root
+  local cwd ; cwd=$(pwd)
+  if [[ "$cwd" == "$WORKTREE_ROOT/"* ]]; then
+    echo "start: already inside a worktree under $WORKTREE_ROOT" >&2 ; return 3
+  fi
+
+  local json
+  if ! json=$("$GH_BIN" issue view "$issue" --json title,labels 2>/dev/null); then
+    echo "start: issue #$issue not found" >&2 ; return 2
+  fi
+
+  local branch dir slug
+  branch=$(branch_from_issue "$issue" "$json")
+  slug="${branch#*/}"   # strip prefix dir
+  slug="${slug#*-}"     # strip the issue number prefix
+  dir="$WORKTREE_ROOT/${issue}-${slug}"
+
+  if [[ -e "$dir" ]]; then
+    echo "start: worktree path already exists: $dir" >&2 ; return 3
+  fi
+  if "$GIT_BIN" show-ref --verify --quiet "refs/heads/$branch"; then
+    echo "start: branch already exists: $branch" >&2 ; return 3
+  fi
+
+  if (( dry_run )); then
+    echo "dry-run: would create branch=$branch dir=$dir"
+    return 0
+  fi
+
+  mkdir -p "$WORKTREE_ROOT"
+  "$GIT_BIN" fetch -q origin master 2>/dev/null || true
+  "$GIT_BIN" worktree add -b "$branch" "$dir" origin/master >/dev/null
+
+  # Copy local Claude settings, if present
+  if [[ -f .claude/settings.local.json ]]; then
+    mkdir -p "$dir/.claude"
+    cp .claude/settings.local.json "$dir/.claude/settings.local.json"
+  fi
+
+  "$GH_BIN" issue comment "$issue" \
+    --body "Worktree created at \`$dir\`, branch \`$branch\`." >/dev/null
+
+  echo "branch:   $branch"
+  echo "worktree: $dir"
+  echo "next:     cd $dir"
+}
+```
+
+- [ ] **Step 7: Re-run; happy path passes**
+
+```bash
+bash scripts/tests/test-agent-worktree.sh
+```
+
+If the harness reports "branch fix/42-hello-world missing", confirm that the sandbox `make_sandbox_repo` indeed sets `origin/master` (Step 1) and that `cmd_start` uses `origin/master` as the start-point.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/agent-worktree.sh scripts/lib/agent-worktree-lib.sh scripts/tests/test-agent-worktree.sh
+git commit -m "$(cat <<'EOF'
+feat(scripts): implement agent-worktree start sub-command (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `start` edge cases
+
+**Files:**
+- Modify: `scripts/tests/test-agent-worktree.sh`
+
+- [ ] **Step 1: Add edge-case tests, expect them to pass against current implementation**
+
+Append before the discovery loop:
+
+```bash
+test_start_missing_issue_flag() {
+  export GH_BIN="$GH_MOCK"
+  local out rc
+  out=$(bash "$SCRIPT" start 2>&1) ; rc=$?
+  if [[ $rc -ne 1 ]]; then echo "rc=$rc out=$out" >&2; return 1; fi
+  assert_contains "$out" "--issue"
+}
+
+test_start_unknown_issue_exits_2() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_999_EXIT=2
+  export WORKTREE_ROOT="$wt"
+  local rc
+  (cd "$repo" && bash "$SCRIPT" start --issue 999) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 2 ]]; then echo "expected rc=2 got $rc" >&2; return 1; fi
+}
+
+test_start_dirty_repo_exits_3() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  (cd "$repo" && echo dirty > newfile && git add newfile)
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_1_TITLE="t"; export GH_MOCK_ISSUE_1_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  local rc
+  (cd "$repo" && bash "$SCRIPT" start --issue 1) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 3 ]]; then echo "expected rc=3 got $rc" >&2; return 1; fi
+}
+
+test_start_twice_same_issue_refuses() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_7_TITLE="Same"; export GH_MOCK_ISSUE_7_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 7) >/dev/null
+  local rc
+  (cd "$repo" && bash "$SCRIPT" start --issue 7) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 3 ]]; then echo "expected rc=3 got $rc" >&2; return 1; fi
+}
+
+test_start_dry_run_no_side_effects() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_5_TITLE="Dry"; export GH_MOCK_ISSUE_5_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 5 --dry-run) >/dev/null
+  # No branch should exist
+  (cd "$repo" && git show-ref --verify --quiet refs/heads/feature/5-dry) \
+    && { echo "branch leaked in dry-run" >&2; return 1; }
+  test -d "$wt/5-dry" && { echo "worktree leaked in dry-run" >&2; return 1; }
+  return 0
+}
+```
+
+- [ ] **Step 2: Run; verify all five new tests pass**
+
+```bash
+bash scripts/tests/test-agent-worktree.sh
+```
+
+If a test fails, fix the corresponding logic in `cmd_start` (most likely cause: an exit code mismatch). Re-run until all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/tests/test-agent-worktree.sh
+git commit -m "$(cat <<'EOF'
+test(scripts): cover agent-worktree start edge cases (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `list` sub-command
+
+**Files:**
+- Modify: `scripts/agent-worktree.sh`
+- Modify: `scripts/tests/test-agent-worktree.sh`
+
+`list` calls `git worktree list --porcelain`, prints one line per worktree under `WORKTREE_ROOT`: `<branch>  <path>  ahead:<N> behind:<N> <clean|dirty>`. Worktrees outside `WORKTREE_ROOT` (e.g. the primary checkout) are listed too but tagged `[primary]`.
+
+- [ ] **Step 1: Failing test**
+
+```bash
+test_list_shows_worktree() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_3_TITLE="L"; export GH_MOCK_ISSUE_3_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 3) >/dev/null
+  local out
+  out=$(cd "$repo" && bash "$SCRIPT" list)
+  assert_contains "$out" "feature/3-l"
+  assert_contains "$out" "$wt/3-l"
+}
+```
+
+- [ ] **Step 2: Implement `cmd_list`**
+
+Replace the stub:
+
+```bash
+cmd_list() {
+  local porcelain
+  porcelain=$("$GIT_BIN" worktree list --porcelain)
+  local path="" branch=""
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *) path="${line#worktree }" ;;
+      branch\ refs/heads/*)
+        branch="${line#branch refs/heads/}"
+        _list_emit_row "$path" "$branch"
+        path=""; branch="" ;;
+      "") path=""; branch="" ;;
+    esac
+  done <<< "$porcelain"
+}
+
+_list_emit_row() {
+  local path="$1" branch="$2"
+  local tag=""
+  if [[ "$path" != "$WORKTREE_ROOT"* ]]; then tag="[primary] "; fi
+  local ahead=0 behind=0
+  if "$GIT_BIN" -C "$path" rev-parse --verify -q origin/master >/dev/null 2>&1; then
+    read -r behind ahead < <(
+      "$GIT_BIN" -C "$path" rev-list --left-right --count "origin/master...$branch" 2>/dev/null \
+        | awk '{print $1, $2}'
+    )
+  fi
+  local state="clean"
+  if ! "$GIT_BIN" -C "$path" diff --quiet HEAD -- 2>/dev/null; then state="dirty"; fi
+  printf '%s%s  %s  ahead:%s behind:%s %s\n' "$tag" "$branch" "$path" "${ahead:-0}" "${behind:-0}" "$state"
+}
+```
+
+- [ ] **Step 3: Run; new test passes, no regressions**
+
+```bash
+bash scripts/tests/test-agent-worktree.sh
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/agent-worktree.sh scripts/tests/test-agent-worktree.sh
+git commit -m "$(cat <<'EOF'
+feat(scripts): implement agent-worktree list sub-command (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `sync` sub-command
+
+**Files:**
+- Modify: `scripts/agent-worktree.sh`
+- Modify: `scripts/tests/test-agent-worktree.sh`
+
+`sync` rebases the current branch on `origin/master`. Optional positional `<N>` resolves the worktree by issue number and `git -C` operates on it. On rebase conflict, abort and exit 3.
+
+- [ ] **Step 1: Failing tests**
+
+```bash
+test_sync_clean_rebase() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_9_TITLE="Sync"; export GH_MOCK_ISSUE_9_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 9) >/dev/null
+  # Advance origin/master by one commit
+  (cd "$repo" && echo more >> README.md && git commit -aq -m "more" && \
+     git update-ref refs/remotes/origin/master HEAD~0)
+  # Move HEAD back so origin/master is "ahead" of the worktree branch
+  (cd "$repo" && git update-ref refs/remotes/origin/master HEAD)
+  local rc
+  (cd "$wt/9-sync" && bash "$SCRIPT" sync) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 0 ]]; then echo "expected rc=0 got $rc" >&2; return 1; fi
+}
+```
+
+- [ ] **Step 2: Implement `cmd_sync`**
+
+```bash
+cmd_sync() {
+  local target_issue=""
+  if (($#)); then target_issue="$1"; fi
+
+  local wt_path
+  if [[ -n "$target_issue" ]]; then
+    wt_path=$(_resolve_worktree_path_by_issue "$target_issue") \
+      || { echo "sync: no worktree for issue #$target_issue" >&2; return 2; }
+  else
+    wt_path=$("$GIT_BIN" rev-parse --show-toplevel)
+  fi
+
+  ( cd "$wt_path"
+    "$GIT_BIN" fetch -q origin master
+    if ! "$GIT_BIN" rebase origin/master; then
+      "$GIT_BIN" rebase --abort 2>/dev/null || true
+      echo "sync: rebase conflict; aborted. Resolve manually." >&2
+      return 3
+    fi
+  )
+}
+
+_resolve_worktree_path_by_issue() {
+  local n="$1"
+  local d
+  for d in "$WORKTREE_ROOT"/"$n"-*; do
+    if [[ -d "$d" ]]; then printf '%s' "$d"; return 0; fi
+  done
+  return 1
+}
+```
+
+- [ ] **Step 3: Run; verify**
+
+```bash
+bash scripts/tests/test-agent-worktree.sh
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/agent-worktree.sh scripts/tests/test-agent-worktree.sh
+git commit -m "$(cat <<'EOF'
+feat(scripts): implement agent-worktree sync sub-command (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: `finish` sub-command
+
+**Files:**
+- Modify: `scripts/agent-worktree.sh`
+- Modify: `scripts/tests/test-agent-worktree.sh`
+
+`finish` must be run inside a worktree. Refuses if dirty or zero commits ahead of `origin/master`. Otherwise pushes (`git push -u`) and creates the PR with `Closes #<N>` in the body, where `<N>` is parsed from the branch name `<prefix>/<N>-<slug>`. Worktree is NOT removed.
+
+- [ ] **Step 1: Failing tests**
+
+```bash
+test_finish_refuses_zero_commits() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_4_TITLE="F"; export GH_MOCK_ISSUE_4_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 4) >/dev/null
+  local rc
+  (cd "$wt/4-f" && bash "$SCRIPT" finish) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 3 ]]; then echo "expected rc=3 got $rc" >&2; return 1; fi
+}
+
+test_finish_dirty_refuses() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_6_TITLE="F"; export GH_MOCK_ISSUE_6_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 6) >/dev/null
+  (cd "$wt/6-f" && echo dirty > new && git add new)
+  local rc
+  (cd "$wt/6-f" && bash "$SCRIPT" finish) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 3 ]]; then echo "expected rc=3 got $rc" >&2; return 1; fi
+}
+```
+
+- [ ] **Step 2: Implement `cmd_finish`**
+
+```bash
+cmd_finish() {
+  local dry_run=0
+  while (($#)); do
+    case "$1" in
+      --dry-run) dry_run=1; shift ;;
+      *) echo "finish: unexpected arg: $1" >&2; return 1 ;;
+    esac
+  done
+
+  if ! "$GIT_BIN" diff-index --quiet HEAD --; then
+    echo "finish: working tree dirty; commit or stash first" >&2; return 3
+  fi
+
+  local branch ; branch=$("$GIT_BIN" rev-parse --abbrev-ref HEAD)
+  case "$branch" in
+    feature/*|fix/*|docs/*|chore/*) : ;;
+    *) echo "finish: not on an agent branch ($branch)" >&2; return 1 ;;
+  esac
+
+  local ahead
+  ahead=$("$GIT_BIN" rev-list --count origin/master.."$branch" 2>/dev/null || echo 0)
+  if [[ "$ahead" -eq 0 ]]; then
+    echo "finish: branch has no commits ahead of origin/master" >&2; return 3
+  fi
+
+  local issue
+  issue=$(printf '%s' "$branch" | sed -E 's|^[^/]+/([0-9]+)-.*|\1|')
+  if [[ -z "$issue" || "$issue" == "$branch" ]]; then
+    echo "finish: cannot parse issue number from branch '$branch'" >&2; return 1
+  fi
+
+  if (( dry_run )); then
+    echo "dry-run: would push $branch and open PR closing #$issue"
+    return 0
+  fi
+
+  "$GIT_BIN" push -u origin "$branch" >/dev/null
+  "$GH_BIN" pr create --base master --head "$branch" \
+    --title "$branch" --body "Closes #$issue" \
+    || return 4
+}
+```
+
+- [ ] **Step 3: Run; both tests pass**
+
+```bash
+bash scripts/tests/test-agent-worktree.sh
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/agent-worktree.sh scripts/tests/test-agent-worktree.sh
+git commit -m "$(cat <<'EOF'
+feat(scripts): implement agent-worktree finish sub-command (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: `clean` sub-command
+
+**Files:**
+- Modify: `scripts/agent-worktree.sh`
+- Modify: `scripts/tests/test-agent-worktree.sh`
+
+`clean <N>` resolves the worktree by issue, refuses if dirty, checks PR state (via mock), removes worktree, deletes the branch.
+
+- [ ] **Step 1: Failing tests**
+
+```bash
+test_clean_refuses_open_pr() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_11_TITLE="C"; export GH_MOCK_ISSUE_11_LABELS=""
+  export GH_MOCK_PR_feature_11-c_STATE="OPEN"
+  export GH_MOCK_PR_feature_11-c_MERGED=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 11) >/dev/null
+  local rc
+  (cd "$repo" && bash "$SCRIPT" clean 11) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 3 ]]; then echo "expected rc=3 got $rc" >&2; return 1; fi
+}
+
+test_clean_merged_pr_removes() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_12_TITLE="C"; export GH_MOCK_ISSUE_12_LABELS=""
+  export GH_MOCK_PR_feature_12-c_STATE="MERGED"
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 12) >/dev/null
+  # Make a real commit on the branch then fold into master so branch is "merged"
+  (cd "$wt/12-c" && echo x > x && git add x && git commit -q -m "x")
+  (cd "$repo" && git merge --no-ff -q feature/12-c)
+  (cd "$repo" && bash "$SCRIPT" clean 12) >/dev/null
+  test -d "$wt/12-c" && { echo "worktree still present" >&2; return 1; }
+  (cd "$repo" && git show-ref --verify --quiet refs/heads/feature/12-c) \
+    && { echo "branch still present" >&2; return 1; }
+  return 0
+}
+```
+
+(Note: the mock env-var name dot/slash mangling — `feature/11-c` becomes `feature_11-c`. Match exactly.)
+
+- [ ] **Step 2: Implement `cmd_clean`**
+
+```bash
+cmd_clean() {
+  local force=0
+  local issue=""
+  while (($#)); do
+    case "$1" in
+      --force) force=1; shift ;;
+      -*) echo "clean: unknown flag $1" >&2; return 1 ;;
+      *) issue="$1"; shift ;;
+    esac
+  done
+  if [[ -z "$issue" ]]; then
+    echo "clean: usage: clean <issue#>" >&2; return 1
+  fi
+
+  local wt_path
+  wt_path=$(_resolve_worktree_path_by_issue "$issue") \
+    || { echo "clean: no worktree for issue #$issue" >&2; return 2; }
+
+  if ! "$GIT_BIN" -C "$wt_path" diff-index --quiet HEAD --; then
+    echo "clean: worktree dirty: $wt_path" >&2; return 3
+  fi
+
+  local branch
+  branch=$("$GIT_BIN" -C "$wt_path" rev-parse --abbrev-ref HEAD)
+
+  if (( ! force )); then
+    local pr_json state
+    pr_json=$("$GH_BIN" pr view --head "$branch" --json state,mergedAt 2>/dev/null || true)
+    state=$(printf '%s' "$pr_json" | sed -E 's/.*"state":"([^"]+)".*/\1/')
+    if [[ "$state" != "MERGED" ]]; then
+      echo "clean: PR for $branch is '$state', refusing (use --force)" >&2; return 3
+    fi
+  fi
+
+  "$GIT_BIN" worktree remove "$wt_path"
+  "$GIT_BIN" branch -d "$branch" 2>/dev/null \
+    || "$GIT_BIN" branch -D "$branch"
+  echo "removed: $wt_path branch=$branch"
+}
+```
+
+- [ ] **Step 3: Run; verify**
+
+```bash
+bash scripts/tests/test-agent-worktree.sh
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/agent-worktree.sh scripts/tests/test-agent-worktree.sh
+git commit -m "$(cat <<'EOF'
+feat(scripts): implement agent-worktree clean sub-command (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: CLAUDE.md doctrine section
+
+**Files:**
+- Modify: `CLAUDE.md` (insert new section after `## 🔑 Règles impératives`)
+
+- [ ] **Step 1: Locate the insertion point**
+
+```bash
+grep -n "🔑 Règles impératives" CLAUDE.md
+```
+
+Expected: one line number. The new section is inserted immediately *after* that section and *before* the next `## ` heading.
+
+- [ ] **Step 2: Insert the section**
+
+Use `Edit` on `CLAUDE.md`. Identify the unique line that ends the existing "Règles impératives" block (the next `## ` heading line — e.g. `## 🔒 Security Policies — Héritées …`). Insert the following block immediately before that next heading:
+
+```markdown
+---
+
+## 🌿 Multi-Agent Worktree Workflow — Obligatoire
+
+Chaque travail non-trivial doit s'exécuter dans un worktree dédié, créé via
+`scripts/agent-worktree.sh start --issue <#>`. Le checkout principal
+(`~/CyberMindStudio/secubox-deb/secubox-deb/`) est réservé au `master`
+housekeeping et au travail humain — pas aux agents.
+
+### Quand créer un worktree
+
+- Toute issue GitHub avec label `bug`, `enhancement`, `documentation`,
+  `eye-remote`, ou tout label métier (migration, hardware, api, frontend,
+  security, infra)
+- Toute tâche estimée > 30 min ou touchant ≥ 3 fichiers
+- Toute feature/fix qui finira en PR
+
+### Quand NE PAS en créer
+
+- Édition triviale d'un seul fichier de suivi (`HISTORY.md`, `WIP.md`,
+  `TODO.md`)
+- Exploration read-only, réponse à une question
+- Commits administratifs sur master (tags, bumps de version)
+
+### Cycle obligatoire
+
+```
+gh issue create
+  → scripts/agent-worktree.sh start --issue <#>
+  → cd ~/CyberMindStudio/secubox-deb-worktrees/<#>-<slug>
+  → code + commits (chaque message: "(ref #<#>)")
+  → scripts/agent-worktree.sh finish     # push + PR avec "Closes #<#>"
+  → [user valide et merge la PR]
+  → scripts/agent-worktree.sh clean <#>  # supprime worktree + branche
+```
+
+### Parallélisme
+
+`start` refuse de créer un second worktree pour la même issue. Deux sessions
+Claude (deux terminaux) peuvent travailler simultanément sur deux issues
+distinctes sans collision.
+
+### Source de vérité opérationnelle
+
+`scripts/agent-worktree.sh --help`
+
+---
+```
+
+- [ ] **Step 3: Verify the file still parses as Markdown (smoke check)**
+
+```bash
+grep -c "^## " CLAUDE.md
+```
+
+Compare to the value before the edit: expect exactly +1.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs: add multi-agent worktree workflow doctrine to CLAUDE.md (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: scripts/README.md update
+
+**Files:**
+- Modify: `scripts/README.md`
+
+- [ ] **Step 1: Add a new section after "Package Scaffolding"**
+
+Use `Edit` on `scripts/README.md`. Locate the section header `## Package Scaffolding` and the next `## ` heading after it. Insert this block before that next heading:
+
+```markdown
+---
+
+## Multi-Agent Worktrees
+
+| Script | Description |
+|--------|-------------|
+| `agent-worktree.sh` | Lifecycle helper for one-branch-per-issue work in isolated git worktrees |
+
+### Usage
+
+```bash
+# Create a worktree bound to GitHub issue #83
+bash scripts/agent-worktree.sh start --issue 83
+cd ~/CyberMindStudio/secubox-deb-worktrees/83-multi-agent-worktree-workflow
+
+# List active worktrees + ahead/behind/dirty status
+bash scripts/agent-worktree.sh list
+
+# Rebase the current worktree on origin/master
+bash scripts/agent-worktree.sh sync
+
+# Push and open the PR (`Closes #83` in body)
+bash scripts/agent-worktree.sh finish
+
+# After merge, remove the worktree and local branch
+bash scripts/agent-worktree.sh clean 83
+```
+
+See `scripts/agent-worktree.sh --help` for the full reference and
+`docs/superpowers/specs/2026-05-12-multi-agent-worktree-workflow-design.md`
+for the design rationale.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/README.md
+git commit -m "$(cat <<'EOF'
+docs(scripts): document agent-worktree in scripts/README (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: HISTORY.md entry + final test run
+
+**Files:**
+- Modify: `.claude/HISTORY.md`
+
+- [ ] **Step 1: Run the full test suite one last time**
+
+```bash
+bash scripts/tests/test-agent-worktree.sh
+```
+
+Expected: all tests OK, `passed: <N>  failed: 0`.
+
+- [ ] **Step 2: Prepend an entry to `.claude/HISTORY.md`**
+
+Open `.claude/HISTORY.md` with `Edit`. Find the most recent date heading (`## 2026-05-12` or whatever is at the top), and insert a new `### Session N+1` block above the previous session under that date — or under a new date heading if today differs.
+
+```markdown
+### Session 152 — Multi-Agent Worktree Workflow
+
+**Goal:** Enable parallel multi-agent work via one-branch-per-issue isolated worktrees.
+
+**Delivered:**
+
+- `scripts/agent-worktree.sh` with sub-commands `start`, `list`, `sync`, `finish`, `clean`
+- `scripts/lib/agent-worktree-lib.sh` (slug + label→prefix helpers)
+- Test suite `scripts/tests/test-agent-worktree.sh` (~15 cases, no bats dep)
+- `gh` CLI mock at `scripts/tests/fixtures/gh-mock.sh`
+- New section in `CLAUDE.md`: `## 🌿 Multi-Agent Worktree Workflow — Obligatoire`
+- `scripts/README.md` updated with usage
+
+**Issue:** #83. **Spec:** `docs/superpowers/specs/2026-05-12-multi-agent-worktree-workflow-design.md`. **Plan:** `docs/superpowers/plans/2026-05-12-multi-agent-worktree-workflow.md`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/HISTORY.md
+git commit -m "$(cat <<'EOF'
+docs: add HISTORY.md entry for multi-agent worktree workflow (ref #83)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4: Push the branch and open the PR via the new script (dogfood)**
+
+```bash
+bash scripts/agent-worktree.sh finish
+```
+
+Expected output: PR URL printed. The PR body will contain `Closes #83`.
+
+If `finish` complains about being run outside the worktree root (because we implemented the feature *inside* the primary checkout — the chicken-and-egg case), fall back to:
+
+```bash
+git push -u origin feature/83-multi-agent-worktree-workflow
+gh pr create --base master --title "Multi-agent worktree workflow" --body "Closes #83"
+```
+
+- [ ] **Step 5: Comment on the issue summarizing completion**
+
+```bash
+gh issue comment 83 --body "Implementation complete on branch \`feature/83-multi-agent-worktree-workflow\`, PR opened. Pending user validation."
+```
+
+---
+
+## Final Self-Review (run by author of the plan, not by an executor)
+
+- **Spec coverage:** every section of the spec maps to a task — script (Tasks 4–10), slug/prefix (Tasks 2–3), CLAUDE.md doctrine (Task 11), tests (interleaved), README update (Task 12), HISTORY entry (Task 13). ✓
+- **Type/name consistency:** `branch_from_issue` is defined Task 5 Step 3 and reused as-is in `cmd_start`. `_resolve_worktree_path_by_issue` defined Task 8 Step 2, reused Task 10. ✓
+- **No placeholders:** all steps contain literal commands or code blocks. Where the plan tells the executor to insert a section into an existing file, the exact Markdown to insert is shown verbatim. ✓
+- **Chicken-and-egg note:** Task 13 Step 4 explicitly handles the case where the script cannot dogfood itself because development happened in the primary checkout. ✓

--- a/docs/superpowers/specs/2026-05-12-multi-agent-worktree-workflow-design.md
+++ b/docs/superpowers/specs/2026-05-12-multi-agent-worktree-workflow-design.md
@@ -1,0 +1,225 @@
+# Multi-Agent Worktree Workflow — Design
+
+**Date:** 2026-05-12
+**Status:** Approved (brainstorming complete)
+**Author:** Gérald Kerma (Gandalf) + Claude
+**Topic:** Enable parallel multi-agent work via git worktrees, one branch per task
+
+---
+
+## 1. Context & Motivation
+
+The SecuBox-DEB repo hosts multiple long-running feature branches (`feature/eye-remote-auto-mode`, `feature/license-headers`, etc.) and a strict GitHub Issues workflow defined in `CLAUDE.md`. Today, all agent work happens in the single primary checkout at `~/CyberMindStudio/secubox-deb/secubox-deb/`. This prevents two Claude sessions (or any two agents) from working in parallel without stepping on each other's working tree, and makes context-switching slow (stash/checkout/stash).
+
+**Goal:** allow each task to live in its own branch *and* its own working directory (git worktree), with a single helper script enforcing a consistent lifecycle bound to GitHub issues.
+
+## 2. Scope
+
+**In scope**
+- One bash helper script (`scripts/agent-worktree.sh`) with sub-commands `start`, `list`, `sync`, `finish`, `clean`.
+- External worktree root at `~/CyberMindStudio/secubox-deb-worktrees/`.
+- Mandatory GitHub Issue before any branch is created.
+- New section in `CLAUDE.md` (`## 🌿 Multi-Agent Worktree Workflow — Obligatoire`) documenting the doctrine.
+- Test suite covering happy path and edge cases (~12 tests).
+
+**Out of scope (YAGNI)**
+- No Claude Code session-start hook enforcing worktree usage.
+- No CI guard rejecting PRs without a linked issue.
+- No multi-user support (the path is per-developer).
+- No auto-merge, no auto-close of issues.
+- No deep integration with `superpowers:using-git-worktrees` (that skill remains usable independently).
+
+## 3. Architecture
+
+### 3.1 File layout
+
+```
+secubox-deb/
+├── scripts/
+│   ├── agent-worktree.sh          ← new, executable
+│   └── tests/
+│       └── test-agent-worktree.bats   ← new (or .sh fallback)
+├── CLAUDE.md                      ← new section added
+└── docs/superpowers/specs/
+    └── 2026-05-12-multi-agent-worktree-workflow-design.md  ← this file
+```
+
+### 3.2 Worktree layout on disk
+
+```
+~/CyberMindStudio/
+├── secubox-deb/secubox-deb/              ← primary checkout (master / human work)
+└── secubox-deb-worktrees/                ← created on first `start`
+    ├── 80-apt-tier-manifest-helper/      ← worktree for issue #80
+    ├── 77-hyperpixel-init/
+    └── 78-eye-agent-imports/
+```
+
+Each subfolder is a real git worktree (`git worktree add`), pointing to the same `.git/` as the primary checkout.
+
+### 3.3 Branch naming
+
+`<prefix>/<issue#>-<slug>` — derived from issue labels:
+
+| GitHub label                         | Prefix     |
+|--------------------------------------|------------|
+| `bug`, `fix`                         | `fix/`     |
+| `documentation`                      | `docs/`    |
+| `infra`, `chore`                     | `chore/`   |
+| anything else (default)              | `feature/` |
+
+`<slug>` is the issue title, lowercased, ASCII-folded, non-alphanumerics → `-`, collapsed dashes, trimmed, **max 40 chars**. Empty slug → fallback `issue`. Collision with existing branch → suffix `-2`, `-3`, …
+
+Examples:
+- Issue #80 "Add tier-manifest helper for APT staging" + label `infra` → `chore/80-add-tier-manifest-helper-for-apt`
+- Issue #77 "Hyperpixel init fails on cold boot" + label `bug` → `fix/77-hyperpixel-init-fails-on-cold-boot`
+
+## 4. Script Interface (`scripts/agent-worktree.sh`)
+
+### 4.1 `start --issue <N>`
+
+1. Validate preconditions:
+   - `gh` is on `PATH` and authenticated (`gh auth status`)
+   - Current repo working tree is clean (no uncommitted changes)
+   - We are NOT already inside a worktree under `~/CyberMindStudio/secubox-deb-worktrees/`
+2. Fetch issue metadata: `gh issue view <N> --json title,labels`
+3. Compute prefix (from labels) and slug (from title), assemble `<branch>`.
+4. `git fetch origin master`
+5. `git worktree add ~/CyberMindStudio/secubox-deb-worktrees/<#>-<slug> -b <branch> origin/master`
+6. Copy `.claude/settings.local.json` from primary into the new worktree (so per-tool permissions carry over).
+7. `gh issue comment <N> --body "Worktree created at \`<path>\`, branch \`<branch>\`"`
+8. Print `cd <path>` for the user / agent to execute.
+
+### 4.2 `list`
+
+Run `git worktree list --porcelain`, decorate each entry with:
+- branch name
+- ahead/behind master count (`git rev-list --left-right --count origin/master...<branch>`)
+- dirty marker (any modified or untracked files)
+- `[orphan]` if the branch is gone from remote and never merged
+
+### 4.3 `sync [<N>]`
+
+Inside the worktree (or by issue number → resolve path):
+- `git fetch origin master`
+- `git rebase origin/master`
+- On conflict: `git rebase --abort`, print message, exit code 3.
+
+### 4.4 `finish`
+
+Must run inside a worktree.
+1. Refuse if working tree dirty or zero commits ahead of master.
+2. `git push -u origin <branch>` (idempotent).
+3. `gh pr create --base master --head <branch> --title "<title-from-issue>" --body "Closes #<N>\n\n<auto-body>"`
+4. Print PR URL.
+5. **Do NOT remove the worktree** — leaves room for review feedback fixes.
+
+### 4.5 `clean <N>`
+
+1. Resolve worktree path from issue number.
+2. Refuse if worktree dirty (list modified files).
+3. Refuse if `gh pr view <branch> --json state,mergedAt` shows non-merged.
+4. `git worktree remove <path>`
+5. `git branch -d <branch>` (safe delete, refuses unmerged).
+
+### 4.6 Common flags
+
+- `--verbose` / `-v` — extra debug output
+- `--dry-run` — print intended actions, perform none
+- `--help` / `-h` — usage
+
+### 4.7 Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Success |
+| `1`  | Generic error / usage |
+| `2`  | Precondition failure (missing issue, gh not authed, etc.) |
+| `3`  | Bad state (dirty tree, conflict, non-merged PR) |
+| `4`  | Network / remote error (gh API, git push) |
+
+## 5. CLAUDE.md Doctrine Section
+
+A new section is inserted in `CLAUDE.md` after `## 🔑 Règles impératives` (or in an analogous location), titled `## 🌿 Multi-Agent Worktree Workflow — Obligatoire`. Its content:
+
+1. **Base rule** — Any non-trivial work MUST happen in a dedicated worktree created via `scripts/agent-worktree.sh start --issue <#>`. The primary checkout is reserved for `master` housekeeping and human work.
+2. **When to create a worktree:**
+   - Any GitHub issue labeled `migration`, `hardware`, `api`, `frontend`, `security`, `infra`
+   - Any task estimated > 30 min or touching ≥ 3 files
+   - Any feature / fix that will end in a PR
+3. **When NOT to create a worktree:**
+   - Trivial single-file edits to tracking docs (`HISTORY.md`, `WIP.md`, `TODO.md`)
+   - Read-only exploration, answering questions
+   - Administrative commits on master (tags, version bumps)
+4. **Mandatory cycle:**
+   `gh issue create → agent-worktree.sh start → code+commits → agent-worktree.sh finish → user validates and merges → agent-worktree.sh clean`
+5. **Parallel safety** — `start` refuses if another worktree already targets the same issue. Two Claude sessions in two terminals can safely work on two different issues at the same time.
+6. **Commit messages** must include `(ref #<issue>)`. Co-authorship line stays as defined elsewhere in `CLAUDE.md`.
+7. **Tracking files** — `WIP.md` is updated inside the worktree; `HISTORY.md` is updated on master after PR merge.
+8. **Source of truth** for operational details: `scripts/agent-worktree.sh --help`.
+
+## 6. Error Handling & Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| Issue does not exist (`gh issue view` fails) | Exit 2, clear message, no branch created |
+| Issue already has an active worktree | Refuse, print existing path, suggest `cd` |
+| Repo dirty at `start` time | Refuse, suggest commit/stash in current worktree |
+| `gh` not authenticated | Detect early, point to `gh auth login` |
+| Title is fully non-ASCII (empty slug) | Fallback `<prefix>/<#>-issue` |
+| Slug collides with existing branch | Append `-2`, `-3`, … |
+| `finish` with zero commits | Refuse |
+| `finish` with branch not pushed | Auto `git push -u origin <branch>` |
+| `clean` on dirty worktree | Refuse, list modified files |
+| `clean` on open / unmerged PR | Refuse, print PR status |
+| Rebase conflict during `sync` | `git rebase --abort`, exit 3, leave resolution to user |
+| Orphan worktree (branch deleted upstream) | `list` marks `[orphan]`, `clean` detects and offers `--force` removal |
+| `--dry-run` on any sub-command | Print planned commands, run none |
+
+All error messages are in English (matches existing scripts under `scripts/`).
+
+## 7. Testing
+
+**Framework:** prefer `bats-core` if already present in `scripts/tests/`; otherwise a flat shell test script using `set -e` and trap-based assertions.
+
+**Mocking:** Inject `GH_BIN` and `GIT_BIN` environment variables (or function shims) so tests run without hitting the real GitHub API and without polluting the actual repo. Use a temporary scratch repo per test via `git init` in `mktemp -d`.
+
+**Test cases (target 12+):**
+
+1. `start` happy path — valid issue → branch + worktree created, issue commented
+2. `start` invalid issue (`gh` returns non-zero) → exit 2, no side effects
+3. `start` with dirty repo → exit 3
+4. `start` twice on same issue → second invocation refuses
+5. Slug derivation: accented French title (`"Migration vérification à valider"`) → ASCII slug
+6. Slug collision: pre-existing branch with same slug → suffix `-2`
+7. `list` shows worktrees with ahead/behind and dirty markers
+8. `sync` clean → rebase succeeds
+9. `sync` with conflict → aborts, exit 3
+10. `finish` zero commits → refuse
+11. `clean` on open PR → refuse
+12. `clean` on merged PR → removes worktree and local branch
+13. `--dry-run start` → prints commands, leaves no branch / worktree
+14. `--help` on each sub-command → non-zero only for unknown sub-commands
+
+## 8. Implementation Order
+
+1. Write `scripts/agent-worktree.sh` skeleton with sub-command dispatch and `--help`.
+2. Implement `start` (slug derivation, label→prefix mapping, worktree add, issue comment).
+3. Implement `list`.
+4. Implement `sync`.
+5. Implement `finish`.
+6. Implement `clean`.
+7. Write tests; iterate until all pass.
+8. Add the new section to `CLAUDE.md`.
+9. Update `scripts/README.md` with a "Multi-agent worktrees" section pointing at the script.
+10. Create a tracking entry in `.claude/HISTORY.md` (date + summary).
+
+## 9. Open Questions
+
+None at design time. Any new question raised during implementation should be logged as a comment on the implementing GitHub issue and resolved before merging the corresponding PR.
+
+## 10. References
+
+- Existing `CLAUDE.md` section `## Synchronisation GitHub Issues — Workflow Obligatoire` — this design extends it with a worktree dimension.
+- `superpowers:using-git-worktrees` skill — usable as a manual fallback, not invoked by this script.
+- `git-worktree(1)` man page.

--- a/repo/install.sh
+++ b/repo/install.sh
@@ -48,7 +48,7 @@ apt-get install -y -qq curl gnupg ca-certificates >/dev/null
 
 # Download and install GPG key
 log "Adding GPG key..."
-curl -fsSL "${REPO_URL}/secubox-keyring.gpg" | tee "${KEYRING_PATH}" >/dev/null
+curl -fsSL "${REPO_URL}/secubox-keyring.gpg" | gpg --dearmor | tee "${KEYRING_PATH}" >/dev/null
 chmod 644 "${KEYRING_PATH}"
 ok "GPG key installed"
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -69,6 +69,38 @@ bash port-frontend.sh crowdsec-dashboard
 
 ---
 
+## Multi-Agent Worktrees
+
+| Script | Description |
+|--------|-------------|
+| `agent-worktree.sh` | Lifecycle helper for one-branch-per-issue work in isolated git worktrees |
+
+### Usage
+
+```bash
+# Create a worktree bound to GitHub issue #83
+bash scripts/agent-worktree.sh start --issue 83
+cd ~/CyberMindStudio/secubox-deb-worktrees/83-multi-agent-worktree-workflow
+
+# List active worktrees + ahead/behind/dirty status
+bash scripts/agent-worktree.sh list
+
+# Rebase the current worktree on origin/master
+bash scripts/agent-worktree.sh sync
+
+# Push and open the PR (`Closes #83` in body)
+bash scripts/agent-worktree.sh finish
+
+# After merge, remove the worktree and local branch
+bash scripts/agent-worktree.sh clean 83
+```
+
+See `scripts/agent-worktree.sh --help` for the full reference and
+`docs/superpowers/specs/2026-05-12-multi-agent-worktree-workflow-design.md`
+for the design rationale.
+
+---
+
 ## Local Cache Setup
 
 | Script | Description |

--- a/scripts/agent-worktree.sh
+++ b/scripts/agent-worktree.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# scripts/agent-worktree.sh
+# Multi-agent worktree workflow helper.
+# See docs/superpowers/specs/2026-05-12-multi-agent-worktree-workflow-design.md
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/agent-worktree-lib.sh
+source "$SCRIPT_DIR/lib/agent-worktree-lib.sh"
+
+WORKTREE_ROOT="${WORKTREE_ROOT:-$HOME/CyberMindStudio/secubox-deb-worktrees}"
+GH_BIN="${GH_BIN:-gh}"
+GIT_BIN="${GIT_BIN:-git}"
+
+usage() {
+  cat <<'USAGE'
+agent-worktree.sh — multi-agent worktree workflow helper
+
+Usage:
+  agent-worktree.sh start  --issue <N> [--dry-run] [--verbose]
+  agent-worktree.sh list   [--verbose]
+  agent-worktree.sh sync   [<N>]
+  agent-worktree.sh finish [--dry-run]
+  agent-worktree.sh clean  <N> [--force]
+  agent-worktree.sh --help
+
+Environment:
+  WORKTREE_ROOT   override worktree root (default: ~/CyberMindStudio/secubox-deb-worktrees)
+  GH_BIN, GIT_BIN override CLI binaries (used by tests)
+
+Exit codes:
+  0 success
+  1 generic / usage
+  2 precondition (issue missing, gh not authed, etc.)
+  3 bad state (dirty tree, conflict, non-merged PR)
+  4 network / remote error
+USAGE
+}
+
+cmd_start()  { echo "start: not implemented" >&2 ; return 1; }
+cmd_list()   { echo "list: not implemented"  >&2 ; return 1; }
+cmd_sync()   { echo "sync: not implemented"  >&2 ; return 1; }
+cmd_finish() { echo "finish: not implemented" >&2; return 1; }
+cmd_clean()  { echo "clean: not implemented" >&2 ; return 1; }
+
+main() {
+  local sub="${1:-}"
+  shift || true
+  case "$sub" in
+    -h|--help|help|"") usage ; return 0 ;;
+    start)  cmd_start  "$@" ;;
+    list)   cmd_list   "$@" ;;
+    sync)   cmd_sync   "$@" ;;
+    finish) cmd_finish "$@" ;;
+    clean)  cmd_clean  "$@" ;;
+    *) echo "unknown sub-command: $sub" >&2 ; usage >&2 ; return 1 ;;
+  esac
+}
+
+main "$@"

--- a/scripts/agent-worktree.sh
+++ b/scripts/agent-worktree.sh
@@ -37,7 +37,77 @@ Exit codes:
 USAGE
 }
 
-cmd_start()  { echo "start: not implemented" >&2 ; return 1; }
+cmd_start() {
+  local issue=""
+  local dry_run=0
+  local verbose=0
+  while (($#)); do
+    case "$1" in
+      --issue) issue="$2"; shift 2 ;;
+      --issue=*) issue="${1#--issue=}"; shift ;;
+      --dry-run) dry_run=1; shift ;;
+      --verbose|-v) verbose=1; shift ;;
+      *) echo "start: unexpected arg: $1" >&2 ; return 1 ;;
+    esac
+  done
+  if [[ -z "$issue" ]]; then
+    echo "start: --issue <N> required" >&2 ; return 1
+  fi
+
+  # Preconditions
+  if ! "$GH_BIN" auth status >/dev/null 2>&1; then
+    echo "start: gh not authenticated. Run: gh auth login" >&2 ; return 2
+  fi
+  if ! "$GIT_BIN" diff-index --quiet HEAD --; then
+    echo "start: working tree is dirty. Commit or stash first." >&2 ; return 3
+  fi
+
+  # Refuse if we are already inside the worktree root
+  local cwd ; cwd=$(pwd)
+  if [[ "$cwd" == "$WORKTREE_ROOT/"* ]]; then
+    echo "start: already inside a worktree under $WORKTREE_ROOT" >&2 ; return 3
+  fi
+
+  local json
+  if ! json=$("$GH_BIN" issue view "$issue" --json title,labels 2>/dev/null); then
+    echo "start: issue #$issue not found" >&2 ; return 2
+  fi
+
+  local branch dir slug
+  branch=$(branch_from_issue "$issue" "$json")
+  slug="${branch#*/}"   # strip prefix dir
+  slug="${slug#*-}"     # strip the issue number prefix
+  dir="$WORKTREE_ROOT/${issue}-${slug}"
+
+  if [[ -e "$dir" ]]; then
+    echo "start: worktree path already exists: $dir" >&2 ; return 3
+  fi
+  if "$GIT_BIN" show-ref --verify --quiet "refs/heads/$branch"; then
+    echo "start: branch already exists: $branch" >&2 ; return 3
+  fi
+
+  if (( dry_run )); then
+    echo "dry-run: would create branch=$branch dir=$dir"
+    return 0
+  fi
+
+  mkdir -p "$WORKTREE_ROOT"
+  "$GIT_BIN" fetch -q origin master 2>/dev/null || true
+  "$GIT_BIN" worktree add -b "$branch" "$dir" origin/master >/dev/null
+
+  # Copy local Claude settings, if present
+  if [[ -f .claude/settings.local.json ]]; then
+    mkdir -p "$dir/.claude"
+    cp .claude/settings.local.json "$dir/.claude/settings.local.json"
+  fi
+
+  "$GH_BIN" issue comment "$issue" \
+    --body "Worktree created at \`$dir\`, branch \`$branch\`." >/dev/null
+
+  echo "branch:   $branch"
+  echo "worktree: $dir"
+  echo "next:     cd $dir"
+}
 cmd_list()   { echo "list: not implemented"  >&2 ; return 1; }
 cmd_sync()   { echo "sync: not implemented"  >&2 ; return 1; }
 cmd_finish() { echo "finish: not implemented" >&2; return 1; }

--- a/scripts/agent-worktree.sh
+++ b/scripts/agent-worktree.sh
@@ -108,7 +108,37 @@ cmd_start() {
   echo "worktree: $dir"
   echo "next:     cd $dir"
 }
-cmd_list()   { echo "list: not implemented"  >&2 ; return 1; }
+cmd_list() {
+  local porcelain
+  porcelain=$("$GIT_BIN" worktree list --porcelain)
+  local path="" branch=""
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *) path="${line#worktree }" ;;
+      branch\ refs/heads/*)
+        branch="${line#branch refs/heads/}"
+        _list_emit_row "$path" "$branch"
+        path=""; branch="" ;;
+      "") path=""; branch="" ;;
+    esac
+  done <<< "$porcelain"
+}
+
+_list_emit_row() {
+  local path="$1" branch="$2"
+  local tag=""
+  if [[ "$path" != "$WORKTREE_ROOT"* ]]; then tag="[primary] "; fi
+  local ahead=0 behind=0
+  if "$GIT_BIN" -C "$path" rev-parse --verify -q origin/master >/dev/null 2>&1; then
+    read -r behind ahead < <(
+      "$GIT_BIN" -C "$path" rev-list --left-right --count "origin/master...$branch" 2>/dev/null \
+        | awk '{print $1, $2}'
+    )
+  fi
+  local state="clean"
+  if ! "$GIT_BIN" -C "$path" diff --quiet HEAD -- 2>/dev/null; then state="dirty"; fi
+  printf '%s%s  %s  ahead:%s behind:%s %s\n' "$tag" "$branch" "$path" "${ahead:-0}" "${behind:-0}" "$state"
+}
 cmd_sync()   { echo "sync: not implemented"  >&2 ; return 1; }
 cmd_finish() { echo "finish: not implemented" >&2; return 1; }
 cmd_clean()  { echo "clean: not implemented" >&2 ; return 1; }

--- a/scripts/agent-worktree.sh
+++ b/scripts/agent-worktree.sh
@@ -169,7 +169,47 @@ _resolve_worktree_path_by_issue() {
   done
   return 1
 }
-cmd_finish() { echo "finish: not implemented" >&2; return 1; }
+cmd_finish() {
+  local dry_run=0
+  while (($#)); do
+    case "$1" in
+      --dry-run) dry_run=1; shift ;;
+      *) echo "finish: unexpected arg: $1" >&2; return 1 ;;
+    esac
+  done
+
+  if ! "$GIT_BIN" diff-index --quiet HEAD --; then
+    echo "finish: working tree dirty; commit or stash first" >&2; return 3
+  fi
+
+  local branch ; branch=$("$GIT_BIN" rev-parse --abbrev-ref HEAD)
+  case "$branch" in
+    feature/*|fix/*|docs/*|chore/*) : ;;
+    *) echo "finish: not on an agent branch ($branch)" >&2; return 1 ;;
+  esac
+
+  local ahead
+  ahead=$("$GIT_BIN" rev-list --count origin/master.."$branch" 2>/dev/null || echo 0)
+  if [[ "$ahead" -eq 0 ]]; then
+    echo "finish: branch has no commits ahead of origin/master" >&2; return 3
+  fi
+
+  local issue
+  issue=$(printf '%s' "$branch" | sed -E 's|^[^/]+/([0-9]+)-.*|\1|')
+  if [[ -z "$issue" || "$issue" == "$branch" ]]; then
+    echo "finish: cannot parse issue number from branch '$branch'" >&2; return 1
+  fi
+
+  if (( dry_run )); then
+    echo "dry-run: would push $branch and open PR closing #$issue"
+    return 0
+  fi
+
+  "$GIT_BIN" push -u origin "$branch" >/dev/null
+  "$GH_BIN" pr create --base master --head "$branch" \
+    --title "$branch" --body "Closes #$issue" \
+    || return 4
+}
 cmd_clean()  { echo "clean: not implemented" >&2 ; return 1; }
 
 main() {

--- a/scripts/agent-worktree.sh
+++ b/scripts/agent-worktree.sh
@@ -200,14 +200,23 @@ cmd_finish() {
     echo "finish: cannot parse issue number from branch '$branch'" >&2; return 1
   fi
 
+  local issue_title
+  issue_title=$("$GH_BIN" issue view "$issue" --json title 2>/dev/null \
+    | sed -E 's/.*"title":"((\\.|[^"\\])*)".*/\1/')
+  if [[ -z "$issue_title" || "$issue_title" == *'"title"'* ]]; then
+    issue_title="$branch"
+  fi
+
   if (( dry_run )); then
-    echo "dry-run: would push $branch and open PR closing #$issue"
+    echo "dry-run: would push $branch and open PR closing #$issue with title '$issue_title'"
     return 0
   fi
 
-  "$GIT_BIN" push -u origin "$branch" >/dev/null
+  if ! "$GIT_BIN" push -u origin "$branch" >/dev/null; then
+    echo "finish: git push failed" >&2; return 4
+  fi
   "$GH_BIN" pr create --base master --head "$branch" \
-    --title "$branch" --body "Closes #$issue" \
+    --title "$issue_title" --body "Closes #$issue" \
     || return 4
 }
 cmd_clean() {

--- a/scripts/agent-worktree.sh
+++ b/scripts/agent-worktree.sh
@@ -210,7 +210,45 @@ cmd_finish() {
     --title "$branch" --body "Closes #$issue" \
     || return 4
 }
-cmd_clean()  { echo "clean: not implemented" >&2 ; return 1; }
+cmd_clean() {
+  local force=0
+  local issue=""
+  while (($#)); do
+    case "$1" in
+      --force) force=1; shift ;;
+      -*) echo "clean: unknown flag $1" >&2; return 1 ;;
+      *) issue="$1"; shift ;;
+    esac
+  done
+  if [[ -z "$issue" ]]; then
+    echo "clean: usage: clean <issue#>" >&2; return 1
+  fi
+
+  local wt_path
+  wt_path=$(_resolve_worktree_path_by_issue "$issue") \
+    || { echo "clean: no worktree for issue #$issue" >&2; return 2; }
+
+  if ! "$GIT_BIN" -C "$wt_path" diff-index --quiet HEAD --; then
+    echo "clean: worktree dirty: $wt_path" >&2; return 3
+  fi
+
+  local branch
+  branch=$("$GIT_BIN" -C "$wt_path" rev-parse --abbrev-ref HEAD)
+
+  if (( ! force )); then
+    local pr_json state
+    pr_json=$("$GH_BIN" pr view --head "$branch" --json state,mergedAt 2>/dev/null || true)
+    state=$(printf '%s' "$pr_json" | sed -E 's/.*"state":"([^"]+)".*/\1/')
+    if [[ "$state" != "MERGED" ]]; then
+      echo "clean: PR for $branch is '$state', refusing (use --force)" >&2; return 3
+    fi
+  fi
+
+  "$GIT_BIN" worktree remove "$wt_path"
+  "$GIT_BIN" branch -d "$branch" 2>/dev/null \
+    || "$GIT_BIN" branch -D "$branch"
+  echo "removed: $wt_path branch=$branch"
+}
 
 main() {
   local sub="${1:-}"

--- a/scripts/agent-worktree.sh
+++ b/scripts/agent-worktree.sh
@@ -139,7 +139,36 @@ _list_emit_row() {
   if ! "$GIT_BIN" -C "$path" diff --quiet HEAD -- 2>/dev/null; then state="dirty"; fi
   printf '%s%s  %s  ahead:%s behind:%s %s\n' "$tag" "$branch" "$path" "${ahead:-0}" "${behind:-0}" "$state"
 }
-cmd_sync()   { echo "sync: not implemented"  >&2 ; return 1; }
+cmd_sync() {
+  local target_issue=""
+  if (($#)); then target_issue="$1"; fi
+
+  local wt_path
+  if [[ -n "$target_issue" ]]; then
+    wt_path=$(_resolve_worktree_path_by_issue "$target_issue") \
+      || { echo "sync: no worktree for issue #$target_issue" >&2; return 2; }
+  else
+    wt_path=$("$GIT_BIN" rev-parse --show-toplevel)
+  fi
+
+  ( cd "$wt_path"
+    "$GIT_BIN" fetch -q origin master 2>/dev/null || true
+    if ! "$GIT_BIN" rebase origin/master; then
+      "$GIT_BIN" rebase --abort 2>/dev/null || true
+      echo "sync: rebase conflict; aborted. Resolve manually." >&2
+      return 3
+    fi
+  )
+}
+
+_resolve_worktree_path_by_issue() {
+  local n="$1"
+  local d
+  for d in "$WORKTREE_ROOT"/"$n"-*; do
+    if [[ -d "$d" ]]; then printf '%s' "$d"; return 0; fi
+  done
+  return 1
+}
 cmd_finish() { echo "finish: not implemented" >&2; return 1; }
 cmd_clean()  { echo "clean: not implemented" >&2 ; return 1; }
 

--- a/scripts/lib/agent-worktree-lib.sh
+++ b/scripts/lib/agent-worktree-lib.sh
@@ -20,3 +20,20 @@ derive_slug() {
   if [[ -z "$s" ]]; then s="issue"; fi
   printf '%s' "$s"
 }
+
+# Map a comma-separated label list to a branch prefix.
+# Mapping: bug|fix -> fix/, documentation -> docs/, infra|chore -> chore/,
+# everything else (including empty) -> feature/. First matching label wins.
+prefix_from_labels() {
+  local labels="${1:-}"
+  local IFS=','
+  local label
+  for label in $labels; do
+    case "$label" in
+      bug|fix)             printf 'fix/';     return 0 ;;
+      documentation)       printf 'docs/';    return 0 ;;
+      infra|chore)         printf 'chore/';   return 0 ;;
+    esac
+  done
+  printf 'feature/'
+}

--- a/scripts/lib/agent-worktree-lib.sh
+++ b/scripts/lib/agent-worktree-lib.sh
@@ -1,0 +1,22 @@
+# shellcheck shell=bash
+# scripts/lib/agent-worktree-lib.sh
+# Helpers for scripts/agent-worktree.sh. Sourced, never executed.
+
+set -uo pipefail
+
+# Slugify a free-text title into a branch-safe slug.
+# Rules: lowercase, ASCII-fold via iconv, non-[a-z0-9] -> '-', collapse runs,
+# trim leading/trailing '-', max 40 chars, fallback 'issue' when empty.
+derive_slug() {
+  local raw="${1:-}"
+  local s
+  s=$(printf '%s' "$raw" | iconv -f UTF-8 -t ASCII//TRANSLIT 2>/dev/null || printf '%s' "$raw")
+  s=$(printf '%s' "$s" | tr '[:upper:]' '[:lower:]')
+  s=$(printf '%s' "$s" | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')
+  if [[ ${#s} -gt 40 ]]; then
+    s="${s:0:40}"
+    s="${s%-}"
+  fi
+  if [[ -z "$s" ]]; then s="issue"; fi
+  printf '%s' "$s"
+}

--- a/scripts/lib/agent-worktree-lib.sh
+++ b/scripts/lib/agent-worktree-lib.sh
@@ -37,3 +37,28 @@ prefix_from_labels() {
   done
   printf 'feature/'
 }
+
+# Extract title and label list from gh JSON (no jq required — minimal parse).
+# Expects the exact shape produced by `gh issue view --json title,labels`.
+_extract_title() {
+  # Match `"title":"..."` allowing escaped quotes inside.
+  printf '%s' "$1" | sed -E 's/.*"title":"((\\.|[^"\\])*)".*/\1/'
+}
+
+_extract_labels() {
+  # Print comma-separated label names from `[{"name":"a"},{"name":"b"}]`.
+  printf '%s' "$1" \
+    | grep -oE '"name":"[^"]+"' \
+    | sed -E 's/"name":"([^"]+)"/\1/' \
+    | paste -sd, -
+}
+
+branch_from_issue() {
+  local num="$1" json="$2"
+  local title labels prefix slug
+  title=$(_extract_title "$json")
+  labels=$(_extract_labels "$json")
+  prefix=$(prefix_from_labels "$labels")
+  slug=$(derive_slug "$title")
+  printf '%s%s-%s' "$prefix" "$num" "$slug"
+}

--- a/scripts/sync-all-routes.sh
+++ b/scripts/sync-all-routes.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# SecuBox Routes Auto-Sync - All Services
+# Syncs routes from streamlit, metablogizer, and other services to mitmproxy
+
+set -euo pipefail
+
+ROUTES_FILE="/srv/mitmproxy/haproxy-routes.json"
+LOG_TAG="routes-sync"
+
+log() { logger -t "$LOG_TAG" "$1"; echo "[$(date +%H:%M:%S)] $1"; }
+
+log "Starting full routes sync..."
+
+# Ensure mitmproxy container is running
+if ! lxc-info -n mitmproxy 2>/dev/null | grep -q "RUNNING"; then
+    log "Starting mitmproxy container..."
+    lxc-start -n mitmproxy 2>/dev/null || true
+    sleep 3
+fi
+
+# Get container IPs
+STREAMLIT_IP=$(lxc-attach -n streamlit -- ip -4 addr show eth0 2>/dev/null | grep -oP "inet \K[\d.]+" || echo "10.100.0.50")
+GITEA_IP=$(lxc-attach -n gitea -- ip -4 addr show eth0 2>/dev/null | grep -oP "inet \K[\d.]+" || echo "10.100.0.40")
+
+python3 << PYEOF
+import json
+import subprocess
+from pathlib import Path
+
+routes_file = "$ROUTES_FILE"
+streamlit_ip = "$STREAMLIT_IP"
+gitea_ip = "$GITEA_IP"
+host_ip = "192.168.1.200"
+
+# Load existing routes
+routes = {}
+if Path(routes_file).exists():
+    routes = json.loads(Path(routes_file).read_text())
+
+updated = 0
+
+# 1. Streamlit instances
+try:
+    import tomllib
+    with open("/etc/secubox/streamlit.toml", "rb") as f:
+        cfg = tomllib.load(f)
+    for name, inst in cfg.get("instances", {}).items():
+        domain = inst.get("domain", f"{name}.gk2.secubox.in")
+        port = inst.get("port")
+        if port:
+            routes[domain] = [streamlit_ip, int(port)]
+            updated += 1
+    print(f"Streamlit: {updated} routes")
+except Exception as e:
+    print(f"Streamlit error: {e}")
+
+# 2. Metablogizer sites (static sites served by nginx on 9080)
+try:
+    result = subprocess.run(
+        ["curl", "-s", "--unix-socket", "/run/secubox/metablogizer.sock", "http://localhost/access"],
+        capture_output=True, text=True, timeout=5
+    )
+    data = json.loads(result.stdout)
+    mb_count = 0
+    for site in data.get("sites", []):
+        domain = site.get("domain")
+        if domain and site.get("published"):
+            routes[domain] = [host_ip, 8900]
+            mb_count += 1
+    print(f"Metablogizer: {mb_count} routes")
+    updated += mb_count
+except Exception as e:
+    print(f"Metablogizer error: {e}")
+
+# 3. Fixed routes
+routes["admin.gk2.secubox.in"] = [host_ip, 9080]
+routes["git.gk2.secubox.in"] = [gitea_ip, 3000]
+
+# Save routes
+Path(routes_file).write_text(json.dumps(routes, indent=2, sort_keys=True))
+print(f"Total: {len(routes)} routes saved")
+PYEOF
+
+# Copy routes to mitmproxy container
+log "Syncing to mitmproxy container..."
+cat "$ROUTES_FILE" | lxc-attach -n mitmproxy -- tee /srv/mitmproxy/haproxy-routes.json > /dev/null
+
+# Reload mitmproxy
+lxc-attach -n mitmproxy -- pkill -HUP mitmdump 2>/dev/null || true
+
+log "Routes sync complete"

--- a/scripts/sync-mitmproxy-routes.sh
+++ b/scripts/sync-mitmproxy-routes.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Re-exec self under flock to prevent concurrent runs (added 2026-05-12)
+LOCK=/run/sync-mitmproxy-routes.lock
+exec 9>"$LOCK"
+flock -n 9 || { echo "[$(date "+%F %T")] another instance running, skipping"; exit 0; }
+
 # SecuBox Route Sync - Ensures HAProxy vhosts are synced to mitmproxy routes
 # Run periodically via cron or systemd timer
 #
@@ -23,7 +29,7 @@ BACKEND_IP="10.100.0.1"
 DEAD_CONTAINER_IPS="10.100.0.10 10.100.0.20 10.100.0.30 10.100.0.40 10.100.0.50"
 
 log() {
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >&2
 }
 
 # Get current routes from container
@@ -71,13 +77,14 @@ fix_dead_container_routes() {
         for domain in $domains; do
             [[ -z "$domain" ]] && continue
             log "Fixing dead route: $domain ($dead_ip -> $BACKEND_IP:$WEBUI_PORT)"
-            routes_json=$(echo "$routes_json" | jq --arg d "$domain" --arg ip "$BACKEND_IP" --argjson p "$WEBUI_PORT" '.[$d] = [$ip, $p]')
+            new_rj=$(echo "$routes_json" | jq --arg d "$domain" --arg ip "$BACKEND_IP" --argjson p "$WEBUI_PORT" '.[$d] = [$ip, $p]' 2>/dev/null || true)
+            if [[ -n "$new_rj" ]]; then routes_json="$new_rj"; fi
             fixed=$((fixed + 1))
         done
     done
 
     echo "$routes_json"
-    return $fixed
+    return 0
 }
 
 # Main sync
@@ -101,11 +108,12 @@ main() {
         port=$(get_port_for_domain "$domain")
 
         # Check if route exists with correct port
-        existing=$(echo "$routes_json" | jq -r --arg d "$domain" '.[$d] // empty')
+        existing=$(echo "$routes_json" | jq -r --arg d "$domain" '.[$d] // empty' 2>/dev/null || true)
 
         if [[ -z "$existing" ]] || ! echo "$existing" | jq -e ".[1] == $port" >/dev/null 2>&1; then
             log "Updating route: $domain -> $BACKEND_IP:$port"
-            routes_json=$(echo "$routes_json" | jq --arg d "$domain" --arg ip "$BACKEND_IP" --argjson p "$port" '.[$d] = [$ip, $p]')
+            new_rj=$(echo "$routes_json" | jq --arg d "$domain" --arg ip "$BACKEND_IP" --argjson p "$port" '.[$d] = [$ip, $p]' 2>/dev/null || true)
+            if [[ -n "$new_rj" ]]; then routes_json="$new_rj"; fi
             updated=$((updated + 1))
         fi
     done < <(get_haproxy_domains)
@@ -114,11 +122,12 @@ main() {
     while IFS= read -r domain; do
         [[ -z "$domain" ]] && continue
 
-        existing=$(echo "$routes_json" | jq -r --arg d "$domain" '.[$d] // empty')
+        existing=$(echo "$routes_json" | jq -r --arg d "$domain" '.[$d] // empty' 2>/dev/null || true)
 
         if [[ -z "$existing" ]] || ! echo "$existing" | jq -e ".[1] == $METABLOG_PORT" >/dev/null 2>&1; then
             log "Updating metablog route: $domain -> $BACKEND_IP:$METABLOG_PORT"
-            routes_json=$(echo "$routes_json" | jq --arg d "$domain" --arg ip "$BACKEND_IP" --argjson p "$METABLOG_PORT" '.[$d] = [$ip, $p]')
+            new_rj=$(echo "$routes_json" | jq --arg d "$domain" --arg ip "$BACKEND_IP" --argjson p "$METABLOG_PORT" '.[$d] = [$ip, $p]' 2>/dev/null || true)
+            if [[ -n "$new_rj" ]]; then routes_json="$new_rj"; fi
             updated=$((updated + 1))
         fi
     done < <(get_metablog_domains)

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -1,0 +1,1 @@
+# test fixtures for agent-worktree.sh

--- a/scripts/tests/fixtures/gh-mock.sh
+++ b/scripts/tests/fixtures/gh-mock.sh
@@ -49,12 +49,17 @@ case "$cmd" in
       view|list)
         # Look up by --head or by branch arg
         branch=""
+        _prev=""
         for arg in "$@"; do
+          if [[ "$_prev" == "--head" ]]; then branch="$arg"; fi
           case "$arg" in --head=*) branch="${arg#--head=}";; esac
+          _prev="$arg"
         done
         if [[ -z "$branch" ]]; then branch="${1:-}"; fi
-        var_state="GH_MOCK_PR_${branch//\//_}_STATE"
-        var_merged="GH_MOCK_PR_${branch//\//_}_MERGED"
+        sanitized="${branch//\//_}"
+        sanitized="${sanitized//-/_}"
+        var_state="GH_MOCK_PR_${sanitized}_STATE"
+        var_merged="GH_MOCK_PR_${sanitized}_MERGED"
         state="${!var_state:-MERGED}"
         merged="${!var_merged:-2026-05-12T10:00:00Z}"
         printf '{"state":"%s","mergedAt":"%s"}\n' "$state" "$merged"

--- a/scripts/tests/fixtures/gh-mock.sh
+++ b/scripts/tests/fixtures/gh-mock.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Minimal `gh` stand-in for agent-worktree tests.
+# Implements just the verbs the script invokes.
+set -u
+
+cmd="${1:-}"; shift || true
+
+case "$cmd" in
+  auth)
+    sub="${1:-}"
+    if [[ "$sub" == "status" ]]; then
+      if [[ "${GH_MOCK_AUTH:-ok}" == "ok" ]]; then exit 0; else exit 1; fi
+    fi
+    ;;
+  issue)
+    sub="${1:-}"; shift || true
+    case "$sub" in
+      view)
+        num="${1:-}"; shift || true
+        var_exit="GH_MOCK_ISSUE_${num}_EXIT"
+        if [[ -n "${!var_exit:-}" ]]; then exit "${!var_exit}"; fi
+        var_title="GH_MOCK_ISSUE_${num}_TITLE"
+        var_labels="GH_MOCK_ISSUE_${num}_LABELS"
+        title="${!var_title:-Missing title}"
+        labels="${!var_labels:-}"
+        labels_json=""
+        if [[ -n "$labels" ]]; then
+          IFS=',' read -r -a arr <<< "$labels"
+          for l in "${arr[@]}"; do
+            labels_json+="{\"name\":\"$l\"},"
+          done
+          labels_json="${labels_json%,}"
+        fi
+        printf '{"title":%s,"labels":[%s]}\n' "$(printf '"%s"' "$title")" "$labels_json"
+        exit 0
+        ;;
+      comment)
+        # always succeed; record the body in a side file if requested
+        if [[ -n "${GH_MOCK_RECORD:-}" ]]; then
+          echo "comment $*" >> "$GH_MOCK_RECORD"
+        fi
+        exit 0
+        ;;
+    esac
+    ;;
+  pr)
+    sub="${1:-}"; shift || true
+    case "$sub" in
+      view|list)
+        # Look up by --head or by branch arg
+        branch=""
+        for arg in "$@"; do
+          case "$arg" in --head=*) branch="${arg#--head=}";; esac
+        done
+        if [[ -z "$branch" ]]; then branch="${1:-}"; fi
+        var_state="GH_MOCK_PR_${branch//\//_}_STATE"
+        var_merged="GH_MOCK_PR_${branch//\//_}_MERGED"
+        state="${!var_state:-MERGED}"
+        merged="${!var_merged:-2026-05-12T10:00:00Z}"
+        printf '{"state":"%s","mergedAt":"%s"}\n' "$state" "$merged"
+        exit 0
+        ;;
+      create)
+        if [[ -n "${GH_MOCK_RECORD:-}" ]]; then
+          echo "pr create $*" >> "$GH_MOCK_RECORD"
+        fi
+        echo "https://github.com/test/repo/pull/999"
+        exit 0
+        ;;
+    esac
+    ;;
+esac
+echo "gh-mock: unhandled invocation: $cmd $*" >&2
+exit 2

--- a/scripts/tests/test-agent-worktree.sh
+++ b/scripts/tests/test-agent-worktree.sh
@@ -266,6 +266,33 @@ test_sync_clean_rebase() {
   if [[ $rc -ne 0 ]]; then echo "expected rc=0 got $rc" >&2; return 1; fi
 }
 
+test_finish_refuses_zero_commits() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_4_TITLE="F"; export GH_MOCK_ISSUE_4_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 4) >/dev/null
+  local rc
+  (cd "$wt/4-f" && bash "$SCRIPT" finish) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 3 ]]; then echo "expected rc=3 got $rc" >&2; return 1; fi
+}
+
+test_finish_dirty_refuses() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_6_TITLE="F"; export GH_MOCK_ISSUE_6_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 6) >/dev/null
+  (cd "$wt/6-f" && echo dirty > new && git add new)
+  local rc
+  (cd "$wt/6-f" && bash "$SCRIPT" finish) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 3 ]]; then echo "expected rc=3 got $rc" >&2; return 1; fi
+}
+
 # Auto-discover and run
 mapfile -t tests < <(declare -F | awk '{print $3}' | grep '^test_')
 for t in "${tests[@]}"; do run_test "$t"; done

--- a/scripts/tests/test-agent-worktree.sh
+++ b/scripts/tests/test-agent-worktree.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Test harness for scripts/agent-worktree.sh
+# Each `test_*` function is auto-discovered and run in a subshell.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+LIB="$REPO_ROOT/scripts/lib/agent-worktree-lib.sh"
+SCRIPT="$REPO_ROOT/scripts/agent-worktree.sh"
+GH_MOCK="$REPO_ROOT/scripts/tests/fixtures/gh-mock.sh"
+
+pass=0
+fail=0
+failed_names=()
+
+run_test() {
+  local name="$1"
+  local out
+  if out=$(set -e; "$name" 2>&1); then
+    echo "OK   $name"
+    pass=$((pass+1))
+  else
+    echo "FAIL $name"
+    echo "$out" | sed 's/^/     /'
+    fail=$((fail+1))
+    failed_names+=("$name")
+  fi
+}
+
+assert_eq() {
+  local expected="$1" actual="$2" label="${3:-value}"
+  if [[ "$expected" != "$actual" ]]; then
+    echo "$label mismatch: expected '$expected' got '$actual'" >&2
+    return 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "expected to contain '$needle' in: $haystack" >&2
+    return 1
+  fi
+}
+
+# Tests below
+
+test_derive_slug_basic() {
+  source "$LIB"
+  assert_eq "add-tier-manifest-helper-for-apt-staging" "$(derive_slug 'Add tier-manifest helper for APT staging')" "basic slug"
+}
+
+test_derive_slug_accents() {
+  source "$LIB"
+  assert_eq "migration-verification-a-valider" "$(derive_slug 'Migration vérification à valider')" "accents"
+}
+
+test_derive_slug_truncate_40() {
+  source "$LIB"
+  local out
+  out=$(derive_slug 'this title is intentionally far too long to fit in forty characters')
+  assert_eq "40" "${#out}" "length"
+  assert_eq "this-title-is-intentionally-far-too-long" "$out" "truncated value"
+}
+
+test_derive_slug_empty_falls_back() {
+  source "$LIB"
+  assert_eq "issue" "$(derive_slug '')" "empty input"
+  assert_eq "issue" "$(derive_slug '日本語のみ')" "all non-ASCII"
+}
+
+# Auto-discover and run
+mapfile -t tests < <(declare -F | awk '{print $3}' | grep '^test_')
+for t in "${tests[@]}"; do run_test "$t"; done
+
+echo "---"
+echo "passed: $pass  failed: $fail"
+exit $((fail > 0))

--- a/scripts/tests/test-agent-worktree.sh
+++ b/scripts/tests/test-agent-worktree.sh
@@ -101,6 +101,25 @@ test_prefix_first_match_wins() {
   assert_eq "fix/" "$(prefix_from_labels 'bug,documentation')" "first match"
 }
 
+test_script_help_exits_zero() {
+  local out
+  out=$(bash "$SCRIPT" --help 2>&1)
+  assert_eq "0" "$?" "help exit"
+  assert_contains "$out" "agent-worktree.sh"
+  assert_contains "$out" "start"
+  assert_contains "$out" "list"
+  assert_contains "$out" "sync"
+  assert_contains "$out" "finish"
+  assert_contains "$out" "clean"
+}
+
+test_script_unknown_subcommand_exits_1() {
+  local out rc
+  out=$(bash "$SCRIPT" wibble 2>&1) ; rc=$?
+  if [[ $rc -ne 1 ]]; then echo "expected rc=1, got $rc; out=$out" >&2; return 1; fi
+  assert_contains "$out" "unknown"
+}
+
 # Auto-discover and run
 mapfile -t tests < <(declare -F | awk '{print $3}' | grep '^test_')
 for t in "${tests[@]}"; do run_test "$t"; done

--- a/scripts/tests/test-agent-worktree.sh
+++ b/scripts/tests/test-agent-worktree.sh
@@ -248,6 +248,24 @@ test_list_shows_worktree() {
   assert_contains "$out" "$wt/3-l"
 }
 
+test_sync_clean_rebase() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_9_TITLE="Sync"; export GH_MOCK_ISSUE_9_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 9) >/dev/null
+  # Advance origin/master by one commit
+  (cd "$repo" && echo more >> README.md && git commit -aq -m "more" && \
+     git update-ref refs/remotes/origin/master HEAD~0)
+  # Move HEAD back so origin/master is "ahead" of the worktree branch
+  (cd "$repo" && git update-ref refs/remotes/origin/master HEAD)
+  local rc
+  (cd "$wt/9-sync" && bash "$SCRIPT" sync) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 0 ]]; then echo "expected rc=0 got $rc" >&2; return 1; fi
+}
+
 # Auto-discover and run
 mapfile -t tests < <(declare -F | awk '{print $3}' | grep '^test_')
 for t in "${tests[@]}"; do run_test "$t"; done

--- a/scripts/tests/test-agent-worktree.sh
+++ b/scripts/tests/test-agent-worktree.sh
@@ -68,6 +68,39 @@ test_derive_slug_empty_falls_back() {
   assert_eq "issue" "$(derive_slug '日本語のみ')" "all non-ASCII"
 }
 
+test_prefix_default_when_no_labels() {
+  source "$LIB"
+  assert_eq "feature/" "$(prefix_from_labels '')" "no labels"
+}
+
+test_prefix_bug_label() {
+  source "$LIB"
+  assert_eq "fix/" "$(prefix_from_labels 'bug')" "bug label"
+  assert_eq "fix/" "$(prefix_from_labels 'fix')" "fix label"
+}
+
+test_prefix_documentation_label() {
+  source "$LIB"
+  assert_eq "docs/" "$(prefix_from_labels 'documentation')" "documentation label"
+}
+
+test_prefix_infra_chore_label() {
+  source "$LIB"
+  assert_eq "chore/" "$(prefix_from_labels 'infra')" "infra label"
+  assert_eq "chore/" "$(prefix_from_labels 'chore')" "chore label"
+}
+
+test_prefix_unknown_label_defaults_feature() {
+  source "$LIB"
+  assert_eq "feature/" "$(prefix_from_labels 'enhancement,question')" "unknown labels"
+}
+
+test_prefix_first_match_wins() {
+  source "$LIB"
+  # bug appears first → fix/, even if documentation also present
+  assert_eq "fix/" "$(prefix_from_labels 'bug,documentation')" "first match"
+}
+
 # Auto-discover and run
 mapfile -t tests < <(declare -F | awk '{print $3}' | grep '^test_')
 for t in "${tests[@]}"; do run_test "$t"; done

--- a/scripts/tests/test-agent-worktree.sh
+++ b/scripts/tests/test-agent-worktree.sh
@@ -7,6 +7,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 LIB="$REPO_ROOT/scripts/lib/agent-worktree-lib.sh"
 SCRIPT="$REPO_ROOT/scripts/agent-worktree.sh"
 GH_MOCK="$REPO_ROOT/scripts/tests/fixtures/gh-mock.sh"
+GIT_BIN="${GIT_BIN:-git}"
 
 pass=0
 fail=0
@@ -40,6 +41,23 @@ assert_contains() {
     echo "expected to contain '$needle' in: $haystack" >&2
     return 1
   fi
+}
+
+# Make a throwaway repo with one commit on master; returns its path on stdout.
+make_sandbox_repo() {
+  local dir
+  dir=$(mktemp -d)
+  (
+    cd "$dir"
+    "$GIT_BIN" init -q -b master
+    git config user.email "t@t" ; git config user.name "t"
+    echo "hello" > README.md
+    git add README.md
+    git commit -q -m "init"
+    # Simulate an origin/master so worktree-add can use it
+    git update-ref refs/remotes/origin/master HEAD
+  )
+  printf '%s' "$dir"
 }
 
 # Tests below
@@ -118,6 +136,41 @@ test_script_unknown_subcommand_exits_1() {
   out=$(bash "$SCRIPT" wibble 2>&1) ; rc=$?
   if [[ $rc -ne 1 ]]; then echo "expected rc=1, got $rc; out=$out" >&2; return 1; fi
   assert_contains "$out" "unknown"
+}
+
+test_branch_from_issue_chore() {
+  source "$LIB"
+  local json='{"title":"Add tier-manifest helper for APT staging","labels":[{"name":"infra"}]}'
+  assert_eq "chore/80-add-tier-manifest-helper-for-apt-staging" "$(branch_from_issue 80 "$json")" "infra issue"
+}
+
+test_branch_from_issue_default_feature() {
+  source "$LIB"
+  local json='{"title":"Multi-agent worktree workflow","labels":[{"name":"enhancement"}]}'
+  assert_eq "feature/83-multi-agent-worktree-workflow" "$(branch_from_issue 83 "$json")" "default feature"
+}
+
+test_start_happy_path() {
+  local repo wt_root
+  repo=$(make_sandbox_repo)
+  wt_root="$(mktemp -d)"
+  trap "rm -rf $repo $wt_root" RETURN
+
+  export GH_BIN="$GH_MOCK"
+  export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_42_TITLE="Hello world"
+  export GH_MOCK_ISSUE_42_LABELS="bug"
+  export WORKTREE_ROOT="$wt_root"
+
+  (cd "$repo" && bash "$SCRIPT" start --issue 42) >/dev/null
+
+  # Branch exists locally
+  (cd "$repo" && git rev-parse --verify "fix/42-hello-world") >/dev/null \
+    || { echo "branch fix/42-hello-world missing" >&2; return 1; }
+
+  # Worktree dir exists
+  test -d "$wt_root/42-hello-world" \
+    || { echo "worktree dir missing" >&2; return 1; }
 }
 
 # Auto-discover and run

--- a/scripts/tests/test-agent-worktree.sh
+++ b/scripts/tests/test-agent-worktree.sh
@@ -234,6 +234,20 @@ test_start_dry_run_no_side_effects() {
   return 0
 }
 
+test_list_shows_worktree() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_3_TITLE="L"; export GH_MOCK_ISSUE_3_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 3) >/dev/null
+  local out
+  out=$(cd "$repo" && bash "$SCRIPT" list)
+  assert_contains "$out" "feature/3-l"
+  assert_contains "$out" "$wt/3-l"
+}
+
 # Auto-discover and run
 mapfile -t tests < <(declare -F | awk '{print $3}' | grep '^test_')
 for t in "${tests[@]}"; do run_test "$t"; done

--- a/scripts/tests/test-agent-worktree.sh
+++ b/scripts/tests/test-agent-worktree.sh
@@ -293,6 +293,40 @@ test_finish_dirty_refuses() {
   if [[ $rc -ne 3 ]]; then echo "expected rc=3 got $rc" >&2; return 1; fi
 }
 
+test_clean_refuses_open_pr() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_11_TITLE="C"; export GH_MOCK_ISSUE_11_LABELS=""
+  export GH_MOCK_PR_feature_11_c_STATE="OPEN"
+  export GH_MOCK_PR_feature_11_c_MERGED=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 11) >/dev/null
+  local rc
+  (cd "$repo" && bash "$SCRIPT" clean 11) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 3 ]]; then echo "expected rc=3 got $rc" >&2; return 1; fi
+}
+
+test_clean_merged_pr_removes() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_12_TITLE="C"; export GH_MOCK_ISSUE_12_LABELS=""
+  export GH_MOCK_PR_feature_12_c_STATE="MERGED"
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 12) >/dev/null
+  # Make a real commit on the branch then fold into master so branch is "merged"
+  (cd "$wt/12-c" && echo x > x && git add x && git commit -q -m "x")
+  (cd "$repo" && git merge --no-ff -q feature/12-c)
+  (cd "$repo" && bash "$SCRIPT" clean 12) >/dev/null
+  test -d "$wt/12-c" && { echo "worktree still present" >&2; return 1; }
+  (cd "$repo" && git show-ref --verify --quiet refs/heads/feature/12-c) \
+    && { echo "branch still present" >&2; return 1; }
+  return 0
+}
+
 # Auto-discover and run
 mapfile -t tests < <(declare -F | awk '{print $3}' | grep '^test_')
 for t in "${tests[@]}"; do run_test "$t"; done

--- a/scripts/tests/test-agent-worktree.sh
+++ b/scripts/tests/test-agent-worktree.sh
@@ -173,6 +173,67 @@ test_start_happy_path() {
     || { echo "worktree dir missing" >&2; return 1; }
 }
 
+test_start_missing_issue_flag() {
+  export GH_BIN="$GH_MOCK"
+  local out rc
+  out=$(bash "$SCRIPT" start 2>&1) ; rc=$?
+  if [[ $rc -ne 1 ]]; then echo "rc=$rc out=$out" >&2; return 1; fi
+  assert_contains "$out" "--issue"
+}
+
+test_start_unknown_issue_exits_2() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_999_EXIT=2
+  export WORKTREE_ROOT="$wt"
+  local rc
+  (cd "$repo" && bash "$SCRIPT" start --issue 999) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 2 ]]; then echo "expected rc=2 got $rc" >&2; return 1; fi
+}
+
+test_start_dirty_repo_exits_3() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  (cd "$repo" && echo dirty > newfile && git add newfile)
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_1_TITLE="t"; export GH_MOCK_ISSUE_1_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  local rc
+  (cd "$repo" && bash "$SCRIPT" start --issue 1) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 3 ]]; then echo "expected rc=3 got $rc" >&2; return 1; fi
+}
+
+test_start_twice_same_issue_refuses() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_7_TITLE="Same"; export GH_MOCK_ISSUE_7_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 7) >/dev/null
+  local rc
+  (cd "$repo" && bash "$SCRIPT" start --issue 7) >/dev/null 2>&1 ; rc=$?
+  if [[ $rc -ne 3 ]]; then echo "expected rc=3 got $rc" >&2; return 1; fi
+}
+
+test_start_dry_run_no_side_effects() {
+  local repo wt
+  repo=$(make_sandbox_repo); wt=$(mktemp -d)
+  trap "rm -rf $repo $wt" RETURN
+  export GH_BIN="$GH_MOCK"; export GH_MOCK_AUTH=ok
+  export GH_MOCK_ISSUE_5_TITLE="Dry"; export GH_MOCK_ISSUE_5_LABELS=""
+  export WORKTREE_ROOT="$wt"
+  (cd "$repo" && bash "$SCRIPT" start --issue 5 --dry-run) >/dev/null
+  # No branch should exist
+  (cd "$repo" && git show-ref --verify --quiet refs/heads/feature/5-dry) \
+    && { echo "branch leaked in dry-run" >&2; return 1; }
+  test -d "$wt/5-dry" && { echo "worktree leaked in dry-run" >&2; return 1; }
+  return 0
+}
+
 # Auto-discover and run
 mapfile -t tests < <(declare -F | awk '{print $3}' | grep '^test_')
 for t in "${tests[@]}"; do run_test "$t"; done

--- a/scripts/validate-staged-repo.sh
+++ b/scripts/validate-staged-repo.sh
@@ -52,13 +52,14 @@ if [[ -z "${SKIP_CHROOT:-}" ]]; then
         | sudo tee "$CHROOT/etc/apt/sources.list.d/secubox.list" >/dev/null
       sudo mkdir -p "$CHROOT$OUT"
       sudo mount --bind "$OUT" "$CHROOT$OUT"
-      local_ok=1
-      if ! sudo chroot "$CHROOT" apt-get update 2>&1 | tee "$REPO/output/chroot-update.log" \
-            | grep -qE "Get.*$SUITE|file:.*$SUITE"; then
-        local_ok=0
-      fi
+      # Capture log first; check separately so pipefail on apt-get's exit
+      # status (it may warn about file:// or unsigned packages) doesn't mask
+      # a successful repo-discovery check.
+      sudo chroot "$CHROOT" apt-get update 2>&1 | tee "$REPO/output/chroot-update.log" >/dev/null || true
       sudo umount "$CHROOT$OUT"
-      [[ $local_ok -eq 1 ]] || fail "chroot apt-get update did not see SecuBox repo (see output/chroot-update.log)"
+      if ! grep -qE "Get.*$SUITE|file:.*$SUITE" "$REPO/output/chroot-update.log"; then
+        fail "chroot apt-get update did not see SecuBox repo (see output/chroot-update.log)"
+      fi
       log "  chroot apt-get update OK"
     fi
   fi


### PR DESCRIPTION
## Summary

- Add `scripts/agent-worktree.sh` with sub-commands `start`, `list`, `sync`, `finish`, `clean` to enable parallel multi-agent work via one-branch-per-issue isolated git worktrees
- Add `scripts/lib/agent-worktree-lib.sh` (slug + label→prefix helpers)
- Add test suite `scripts/tests/test-agent-worktree.sh` (26 cases, no bats dependency) with `gh` CLI mock at `scripts/tests/fixtures/gh-mock.sh`
- Update `CLAUDE.md` with `## 🌿 Multi-Agent Worktree Workflow — Obligatoire` section
- Update `scripts/README.md` with usage documentation

## Test plan

- [ ] Run `bash scripts/tests/test-agent-worktree.sh` — expected: `passed: 26  failed: 0`
- [ ] Test `bash scripts/agent-worktree.sh start --issue 84` on a real issue (creates worktree in `../worktrees/`)
- [ ] Test `bash scripts/agent-worktree.sh list`
- [ ] Test `bash scripts/agent-worktree.sh sync` from inside a worktree
- [ ] Test `bash scripts/agent-worktree.sh finish` from inside a worktree (clean tree required)
- [ ] Test `bash scripts/agent-worktree.sh clean` after PR is merged

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)