### PR TITLE
fix(metablog-ui): defensive api() helper (closes #105)

### DIFF
--- a/packages/secubox-metablogizer/www/metablogizer/index.html
+++ b/packages/secubox-metablogizer/www/metablogizer/index.html
@@ -438,8 +438,13 @@
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
                 if (res.status === 401) { window.location = '/login.html'; return {}; }
-                return res.json();
-            } catch { return {}; }
+                const ct = res.headers.get('content-type') || '';
+                if (!res.ok || !ct.includes('application/json')) {
+                    console.warn('api()', path, 'status=' + res.status, 'content-type=' + ct);
+                    return {};
+                }
+                return await res.json();
+            } catch (e) { console.warn('api()', path, 'threw', e); return {}; }
         }
 
         function showTab(name) {

--- a/packages/secubox-metablogizer/www/metablogizer/site.html
+++ b/packages/secubox-metablogizer/www/metablogizer/site.html
@@ -139,9 +139,13 @@
             try {
                 const res = await fetch(API + path, { headers: headers() });
                 if (res.status === 401) { window.location = '/login.html'; return null; }
-                if (!res.ok) return null;
-                return res.json();
-            } catch { return null; }
+                const ct = res.headers.get('content-type') || '';
+                if (!res.ok || !ct.includes('application/json')) {
+                    console.warn('api()', path, 'status=' + res.status, 'content-type=' + ct);
+                    return null;
+                }
+                return await res.json();
+            } catch (e) { console.warn('api()', path, 'threw', e); return null; }
         }
 
         function relativeTime(iso) {


### PR DESCRIPTION
Closes #105.

## What changes

In both `index.html` and the new `site.html`:

```diff
-return res.json();
+const ct = res.headers.get('content-type') || '';
+if (!res.ok || !ct.includes('application/json')) {
+    console.warn('api()', path, 'status=' + res.status, 'content-type=' + ct);
+    return {};  // or null in site.html
+}
+return await res.json();
```

Plus a symmetric catch that logs the thrown error with path context.

## Why

The previous `return res.json()` returned the parse promise without awaiting it. The try/catch wrapped the async function body — but since the unawaited promise was returned, its rejection became the async function's rejection and propagated as **Uncaught (in promise) SyntaxError** in the browser console whenever a non-401 response had a non-JSON body (e.g., a 500 with an HTML error page from upstream, or an empty body).

Pre-existing but more visible after PR #104 (60s polling exercises the helper more often).

## Investigation hook

The new `console.warn(path, status, content-type)` line surfaces the offending endpoint right in the browser console — so the next time the SyntaxError surfaces, we can identify the failing request without digging through server logs.

## Test

`tests/scripts/test-metablogizer-ui.sh` still passes (4/4 gates green, live page reachable at HTTP 200).