### PR TITLE
fix(metablog-api): DELETE /site/<name> survives locked .git subtrees (closes #106)

### DIFF
--- a/packages/secubox-metablogizer/api/main.py
+++ b/packages/secubox-metablogizer/api/main.py
@@ -36,6 +36,7 @@ NGINX_BACKEND_IP = "192.168.1.200"
 
 import logging
 from site_schema import enrich as _schema_enrich, validate as _schema_validate
+from rmtree import force_remove as _rmtree_force
 
 logger = logging.getLogger("metablogizer")
 
@@ -562,8 +563,11 @@ async def delete_site(name: str):
     (NGINX_ENABLED_DIR / f"{name}.conf").unlink(missing_ok=True)
     (NGINX_VHOST_DIR / f"{name}.conf").unlink(missing_ok=True)
 
-    # Delete directory
-    shutil.rmtree(site_dir)
+    # Sites cloned from Gitea (sub-B of #49) carry a .git subtree whose pack
+    # files are 0444 and whose directories may be 0500 — shutil.rmtree then
+    # trips on os.open(..., O_RDONLY, dir_fd=topfd). _rmtree_force chmods
+    # restricted entries to 0700 and retries.
+    _rmtree_force(site_dir)
 
     return {"success": True, "name": name}
 

--- a/packages/secubox-metablogizer/api/rmtree.py
+++ b/packages/secubox-metablogizer/api/rmtree.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+"""
+SecuBox-Deb :: metablogizer :: rmtree helper
+CyberMind — https://cybermind.fr
+
+Sites cloned from Gitea (sub-B of #49) carry a .git subtree whose pack files
+are 0444 and whose directories may be 0500. Vanilla `shutil.rmtree` then
+trips on `os.open(..., O_RDONLY, dir_fd=topfd)`. `force_remove` chmods the
+offending entry to 0700 and retries the failing op.
+"""
+import os
+import shutil
+from pathlib import Path
+
+
+def force_remove(path: Path) -> None:
+    """shutil.rmtree, but chmods read-only entries before retry.
+
+    For unlink/rmdir failures the parent directory's mode is the real
+    blocker; for opendir failures the entry itself is. Chmod both.
+    """
+    def _onerror(func, entry, _exc):
+        parent = os.path.dirname(entry)
+        for target in (parent, entry):
+            try:
+                os.chmod(target, 0o700)
+            except OSError:
+                pass
+        func(entry)
+    shutil.rmtree(path, onerror=_onerror)

--- a/packages/secubox-metablogizer/api/tests/test_rmtree_force.py
+++ b/packages/secubox-metablogizer/api/tests/test_rmtree_force.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+"""Tests for _rmtree_force — must clear Gitea-style read-only .git subtrees."""
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from rmtree import force_remove as _rmtree_force
+
+
+def _make_locked_git_tree(root: Path) -> Path:
+    """Build a fake site dir that mimics a Gitea-cloned layout (0500 .git, 0444 packs)."""
+    site = root / "fakesite"
+    site.mkdir()
+    (site / "site.json").write_text("{}")
+    git = site / ".git"
+    git.mkdir()
+    objects = git / "objects" / "pack"
+    objects.mkdir(parents=True)
+    pack = objects / "pack-abcd.pack"
+    pack.write_bytes(b"\x00" * 32)
+    # Lock down: pack file read-only, objects dir read-execute only, .git read-execute only.
+    os.chmod(pack, 0o444)
+    os.chmod(objects, 0o500)
+    os.chmod(git / "objects", 0o500)
+    os.chmod(git, 0o500)
+    return site
+
+
+def test_rmtree_force_clears_locked_git_subtree(tmp_path):
+    site = _make_locked_git_tree(tmp_path)
+    # Sanity check: vanilla rmtree fails on this tree.
+    with pytest.raises(PermissionError):
+        shutil.rmtree(site)
+    # Rebuild (the failed rmtree may have partially mutated state).
+    if site.exists():
+        # Best-effort cleanup so the test can re-create cleanly.
+        for p in site.rglob("*"):
+            try:
+                os.chmod(p, 0o700)
+            except OSError:
+                pass
+        shutil.rmtree(site)
+    site = _make_locked_git_tree(tmp_path)
+    _rmtree_force(site)
+    assert not site.exists()
+
+
+def test_rmtree_force_clears_plain_directory(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "a.txt").write_text("a")
+    (plain / "sub").mkdir()
+    (plain / "sub" / "b.txt").write_text("b")
+    _rmtree_force(plain)
+    assert not plain.exists()


### PR DESCRIPTION
Closes #106.

## Symptom

Clicking Delete on any Gitea-ingested site (166 of them after sub-B) returned 500 with:

```
PermissionError: [Errno 13] Permission denied: '.git'
  File "/usr/lib/secubox/metablogizer/api/main.py", line 540, in delete_site
    shutil.rmtree(site_dir)
```

## Root cause

Gitea clones write a `.git` subtree where:

- pack files are mode `0444` (read-only)
- the containing `pack/`, `objects/`, `refs/` directories are mode `0500` (read+execute, no write)
- the `.git` root itself is `0500`

`shutil.rmtree` then fails in two distinct places:

1. `os.open(name, O_RDONLY, dir_fd=topfd)` — can't descend into a `0500` dir
2. `os.unlink(file)` — can't remove a file whose parent dir is non-writable

Chmod'ing only the failing entry fixes (1) but not (2): unlink's EACCES is about the **parent** dir, not the file.

## Fix

Extract a `force_remove` helper into `api/rmtree.py`:

```python
def force_remove(path: Path) -> None:
    def _onerror(func, entry, _exc):
        parent = os.path.dirname(entry)
        for target in (parent, entry):
            try: os.chmod(target, 0o700)
            except OSError: pass
        func(entry)
    shutil.rmtree(path, onerror=_onerror)
```

Chmod **both** the parent dir and the entry, then retry the failing op. Handles both classes of EACCES.

`main.py:delete_site` now calls `_rmtree_force(site_dir)`.

## Tests

`api/tests/test_rmtree_force.py` (2 cases):
- builds a Gitea-style locked tree (0500 dirs + 0444 packs), asserts vanilla `shutil.rmtree` raises, then asserts `force_remove` clears it
- plain directory still cleared (regression check)

All 10 metablogizer api tests green.

## Why `onerror` and not `onexc`

`onexc` is Python 3.12+. Debian Bookworm ships 3.11 — `onerror` is the correct API.