### PR TITLE
fix(metablog-webhook): pass safe.directory to git on every call (closes #117)

### DIFF
--- a/packages/secubox-metablogizer/api/tests/test_webhook.py
+++ b/packages/secubox-metablogizer/api/tests/test_webhook.py
@@ -127,9 +127,16 @@ def test_git_pull_returns_old_and_new_sha(tmp_path, monkeypatch):
     old, new = webhook.git_pull(site, "main")
     assert old == "aaa1111"
     assert new == "bbb2222"
-    # ensure the 4 expected git commands happened in order
-    op_names = [c[3] for c in calls]
+    # ensure the 4 expected git commands happened in order. The git arg
+    # layout is now [git, -c, safe.directory=..., -C, <site>, <op>, ...]
+    # so the op verb is at index 5.
+    op_names = [c[5] for c in calls]
     assert op_names == ["rev-parse", "fetch", "reset", "rev-parse"]
+    # every call must carry the safe.directory override (fixes dubious-ownership
+    # under the secubox service user on root-owned site dirs).
+    for c in calls:
+        assert c[1] == "-c"
+        assert c[2] == f"safe.directory={site}"
 
 
 def test_git_pull_timeout_propagates(tmp_path, monkeypatch):

--- a/packages/secubox-metablogizer/api/webhook.py
+++ b/packages/secubox-metablogizer/api/webhook.py
@@ -58,9 +58,14 @@ def git_pull(site_dir: Path, branch: str) -> tuple[str, str]:
 
     Raises subprocess.TimeoutExpired or CalledProcessError on git failure.
     """
+    # Per-invocation safe.directory: site dirs are owned by root (from sub-B
+    # ingest) but the service runs as secubox; without this, git 2.35+
+    # refuses with "fatal: detected dubious ownership".
+    safe_dir = f"safe.directory={site_dir}"
+
     def _git(*args: str, timeout: int = GIT_OP_TIMEOUT) -> str:
         result = subprocess.run(
-            ["git", "-C", str(site_dir), *args],
+            ["git", "-c", safe_dir, "-C", str(site_dir), *args],
             capture_output=True, text=True, timeout=timeout, check=True,
         )
         return result.stdout.strip()


### PR DESCRIPTION
Closes #117. Unblocks live deploys.

Webhook-triggered deploys were 500-ing on every site because site dirs are root-owned and the service runs as secubox. Git 2.35+ refuses with `fatal: detected dubious ownership`.

Fix: per-invocation `-c safe.directory=<site_dir>` on every git call inside `git_pull`. Scoped, no global config change.

Existing git_pull test updated for the new arg layout + new assertion that the override is on every call. 36/36 pytest cases green.