### PR TITLE
Round image: drop dead ifupdown config, give secubox sudo, fix misleading OTG comment (closes #139)

### DIFF
--- a/remote-ui/common/shell/secubox-otg-gadget.sh
+++ b/remote-ui/common/shell/secubox-otg-gadget.sh
@@ -284,9 +284,14 @@ gadget_start() {
     log "Activation sur UDC: ${udc}"
     echo "$udc" > UDC
 
-    # Attendre que l'interface usb1 (ECM) apparaisse
-    # Note: Le gadget composite crée usb0 (RNDIS/Windows) et usb1 (ECM/Linux-Mac)
-    # On configure usb1 car les hôtes Linux utilisent le driver cdc_ether (ECM)
+    # Attendre que la deuxième interface réseau du gadget composé
+    # apparaisse côté kernel. Le composé crée rndis.usb0 puis ecm.usb0
+    # (dans cet ordre, cf. liens configfs ci-dessus) — le kernel les
+    # enregistre comme /sys/class/net/usb0 et /sys/class/net/usb1.
+    # Côté hôte, RNDIS et ECM partagent le même host_addr donc l'ARP
+    # remonte sur n'importe laquelle des deux interfaces UP du host;
+    # binder /usb1 ici suffit pour rendre 10.55.0.2 joignable depuis
+    # 10.55.0.1, peu importe le canal physique sélectionné par l'hôte.
     local retry=0
     while [[ ! -d /sys/class/net/usb1 ]] && [[ $retry -lt 10 ]]; do
         sleep 0.5
@@ -294,9 +299,9 @@ gadget_start() {
     done
 
     if [[ -d /sys/class/net/usb1 ]]; then
-        log "Interface usb1 (ECM) créée"
+        log "Interface usb1 (deuxième fonction réseau du gadget) créée"
 
-        # Configurer l'IP sur usb1 uniquement (évite le routage asymétrique)
+        # Configurer l'IP sur usb1 uniquement (évite le routage asymétrique).
         ip addr flush dev usb1 2>/dev/null || true
         ip addr add "${OTG_NETWORK_DEV}/30" dev usb1
         ip link set usb1 up

--- a/remote-ui/round/build-eye-remote-image.sh
+++ b/remote-ui/round/build-eye-remote-image.sh
@@ -787,8 +787,9 @@ if ! id secubox &>/dev/null; then
     echo "secubox:secubox2026" | chpasswd
 fi
 
-# Add to groups
-usermod -aG video,input,gpio,i2c,spi,audio secubox 2>/dev/null || true
+# Add to groups. `sudo` lets the kiosk user manually recover networking
+# from the ACM serial console (e.g. when /dev/ttyACM0 is the only path in).
+usermod -aG sudo,video,input,gpio,i2c,spi,audio secubox 2>/dev/null || true
 
 # Enable lightdm and nginx
 systemctl enable lightdm 2>/dev/null || true

--- a/remote-ui/round/build-eye-remote-image.sh
+++ b/remote-ui/round/build-eye-remote-image.sh
@@ -704,15 +704,12 @@ ln -sf /etc/systemd/system/secubox-serial-console.service \
 # NOTE: fb-dashboard is DEPRECATED - use fallback-display instead
 # The old dashboard is kept for reference but NOT enabled by default
 
-# Network config for usb0
-mkdir -p "$ROOT_MNT/etc/network/interfaces.d"
-cat > "$ROOT_MNT/etc/network/interfaces.d/usb0" << 'EOF'
-allow-hotplug usb0
-iface usb0 inet static
-    address 10.55.0.2
-    netmask 255.255.255.252
-    gateway 10.55.0.1
-EOF
+# IP binding for the gadget's usb1 interface is handled by
+# /usr/local/sbin/secubox-otg-gadget.sh (the same script that composes
+# the configfs gadget). The legacy /etc/network/interfaces.d/usb0
+# stanza was removed (closes #139) — it required `ifupdown` which the
+# image never installed, so it never did anything except confuse
+# diagnostics.
 
 # USB network script (handles both usb0 and usb1 - ECM may create either)
 mkdir -p "$ROOT_MNT/usr/local/bin"

--- a/remote-ui/round/files/etc/network/interfaces.d/usb0
+++ b/remote-ui/round/files/etc/network/interfaces.d/usb0
@@ -1,5 +1,0 @@
-allow-hotplug usb0
-iface usb0 inet static
-    address 10.55.0.2
-    netmask 255.255.255.252
-    gateway 10.55.0.1


### PR DESCRIPTION
## Summary

Three small cleanups against the round image, all surfaced by the
follow-up OTG bench on PR #137:

1. **Drop `remote-ui/round/files/etc/network/interfaces.d/usb0`** —
   dead `ifupdown` config. `ifupdown` isn't in the apt list,
   `networking.service` is inactive, and the actual `usb1` binding is
   done programmatically by `secubox-otg-gadget.sh`. The file misleads
   diagnostics; deleting it.

2. **Add `sudo` to the `secubox` user's group list** in
   `build-eye-remote-image.sh`. Without it, recovery from the ACM
   serial console (`/dev/ttyACM0`) is impossible — the user can log
   in but can't run privileged commands. Now the only-path-in still
   has a path-to-fix.

3. **Rewrite the misleading `usb1 = ECM` comment** in
   `secubox-otg-gadget.sh`. RNDIS and ECM share the same `host_addr`
   so the host can reach 10.55.0.2 via either function, regardless
   of which kernel-driver binds first. The comment now documents the
   actual invariant: bind on `usb1` (second-registered network
   function), independent of transport.

## What's not in this PR

- `ifupdown` installation or `systemd-networkd` migration — there's
  nothing to bring up, since `secubox-otg-gadget.sh` already does the
  job. Adding either would be dead weight.
- `fallback_manager.py` migration to the converged painter — separate
  scope (deferred follow-up under #138).

## Test plan

- [ ] Rebuild the round image, flash to Pi Zero W 1st gen.
- [ ] Verify boot still reaches OFFLINE-mode radar on the HyperPixel.
- [ ] `id secubox` shows `sudo` in groups.
- [ ] `ls /etc/network/interfaces.d/usb0` returns "no such file".
- [ ] `systemctl is-active secubox-otg-gadget` returns `active`.
- [ ] Host ping 10.55.0.2 succeeds (regression check — the comment
      rewrite is documentation-only, must not change behaviour).

Closes #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)