### PR TITLE
fix(eye-remote): own the OTG bridge so multiple Pi gadgets coexist (ref #155)

### DIFF
--- a/.claude/HISTORY.md
+++ b/.claude/HISTORY.md
@@ -2,6 +2,32 @@
 *Tracking completed milestones with dates*
 
 ---
+## 2026-05-16
+
+### eye-remote: fix link-rename collision when multiple Pi gadgets plug into MOCHAbin USB (Issue [#155](https://github.com/CyberMind-FR/secubox-deb/issues/155))
+
+**Context:** Test board `192.168.1.200` had both a Pi Zero W (`rpiz`, MAC `02:fb:00:00:11:03`) and a Pi 4B (MAC `02:fb:00:00:d2:7f`) plugged into its USB hub. Both enumerated cleanly as `Linux Foundation Multifunction Composite Gadget` (1d6b:0104) but every `usb*` net iface stayed in `state DOWN` — `secubox-eye-remote.service` was running but uvicorn's `10.55.0.1:8000` had no interface to bind to.
+
+**Root cause:** Hand-installed `/etc/systemd/network/10-eye-remote.link` (not dpkg-owned) tried to rename every `02:fb:00:00:* + rndis_host` interface to the fixed name `eye-remote`. With two matching gadgets the rename collided and systemd-networkd silently left them as `usb0/usb1/usb2`. The companion `50-eye-remote.network` (and netplan's `eye-remote` ethernet stanza in `00-secubox.yaml`) then never matched anything live, so `10.55.0.1/30` was never applied. The `/etc/network/interfaces.d/usb0` ifupdown stanza was also dead (networkd is the active manager).
+
+**Fix (host-side, no Pi-side changes):**
+- New canonical `eye-br0` bridge owned by the package: [`packages/secubox-eye-remote/networkd/05-eye-br0.netdev`](../packages/secubox-eye-remote/networkd/05-eye-br0.netdev), [`packages/secubox-eye-remote/networkd/10-eye-br0.network`](../packages/secubox-eye-remote/networkd/10-eye-br0.network) (`10.55.0.1/24`, `ConfigureWithoutCarrier=yes`, `STP=off`).
+- udev rule rewritten in [`packages/secubox-system/etc/udev/rules.d/90-secubox-eye-remote.rules`](../packages/secubox-system/etc/udev/rules.d/90-secubox-eye-remote.rules): no per-iface IP, just call `eye-remote-connected.sh` which enslaves the netdev (`ip link set %k master eye-br0`). Mirror in [`packages/secubox-eye-remote/udev/90-secubox-eye-remote.rules`](../packages/secubox-eye-remote/udev/90-secubox-eye-remote.rules) kept identical.
+- Connect handler [`eye-remote-connected.sh`](../packages/secubox-system/usr/lib/secubox/eye-remote-connected.sh) rewritten to enslave into the bridge instead of assigning `10.55.0.1/30` on the gadget iface; falls back to point-to-point if bridge is missing.
+- Idempotent host hotfix [`remote-ui/round/host-cleanup-dead-config.sh`](../remote-ui/round/host-cleanup-dead-config.sh): rewrites netplan to drop the `eye-remote:` ethernet stanza (stateful YAML editor — regex approach was too greedy and over-matched), removes the dead `.link/.network/interfaces.d/usb0` files, installs the canonical bridge files, syncs udev rules, runs `netplan generate` + `systemctl restart systemd-networkd` + `udevadm trigger`.
+- Multi-gadget L3 limitation documented in [`remote-ui/round/MULTI-GADGET.md`](../remote-ui/round/MULTI-GADGET.md): every Round image currently statically claims `10.55.0.2/30` as its peer, so two Pis simultaneously plugged in race for the same L3 address even though the bridge keeps L2 clean. Proper fix needs a Round-image change (MAC-derived peer or DHCP client) — out of scope for #155.
+
+**Verification on `192.168.1.200`:**
+- `eye-br0` is UP with `10.55.0.1/24`
+- Three L2 slaves: `enx02fb00001103` (rpiz), `enx02fb0000d27f` (Pi 4B), plus a stale `eye-remote` (the rpiz's pre-fix rename; harmless leftover, will disappear on next hot-unplug)
+- `secubox-eye-remote.service` active, uvicorn listening on `10.55.0.1:8000`, `curl http://10.55.0.1:8000/health` → HTTP 200
+- udev journal shows the bridge enslavement firing on the `udevadm trigger` retrigger; `journalctl -t secubox-eye-remote` clean
+
+**Followups:**
+- Branch pushed to `origin/fix/155-eye-remote-link-rename-collision-when-mu`; PR opening deferred per user preference.
+- Round-image change for per-Pi peer IP (DHCP or MAC-derived static) — file as a separate issue when the Round image work resumes.
+
+---
 ## 2026-05-14
 
 ### remote-ui Phases 1 + 3 merged to master (Issue #127, PRs #130 + #132)

--- a/.claude/WIP.md
+++ b/.claude/WIP.md
@@ -1,5 +1,27 @@
 # WIP — Work In Progress
-*Mis à jour : 2026-05-15*
+*Mis à jour : 2026-05-16*
+
+---
+
+## ✅ 2026-05-16: eye-remote — link-rename collision fix for multi-gadget MOCHAbin USB (Issue [#155](https://github.com/CyberMind-FR/secubox-deb/issues/155))
+
+### Status (worktree `155-eye-remote-link-rename-collision-when-mu`, branch `fix/155-eye-remote-link-rename-collision-when-mu`)
+
+- New canonical `eye-br0` bridge `.netdev` + `.network` shipped in `packages/secubox-eye-remote/networkd/`
+- `secubox-eye-remote.install` updated to deploy them to `/etc/systemd/network/`
+- udev rule + connect/disconnect handlers rewritten across `packages/secubox-system/` (and mirror in `packages/secubox-eye-remote/udev/`) — no per-iface IP assignment, just enslave into bridge
+- Idempotent `remote-ui/round/host-cleanup-dead-config.sh` runs locally on a host to:
+  - Drop the deployed netplan `eye-remote` ethernet stanza
+  - Remove the hand-installed `10-eye-remote.link` / `50-eye-remote.network` / `interfaces.d/usb0`
+  - Install the packaged bridge files, sync udev + handlers
+  - Reload networkd + udev
+- Multi-gadget L3 limitation documented in `remote-ui/round/MULTI-GADGET.md` (both Pis claim `10.55.0.2/30` — needs a Round-image change, not host-side)
+- **Hotfix applied live on `192.168.1.200`** — `eye-br0` UP with `10.55.0.1/24`, three rndis_host slaves attached, uvicorn binding succeeds, `curl http://10.55.0.1:8000/health` → HTTP 200
+- Branch pushed; PR open deferred per user preference
+
+### Followup (separate issue)
+
+- Round image: derive peer IP from MAC (or run DHCP client) so two gadgets can coexist at L3 — beyond #155 scope
 
 ---
 

--- a/packages/secubox-eye-remote/debian/secubox-eye-remote.install
+++ b/packages/secubox-eye-remote/debian/secubox-eye-remote.install
@@ -5,3 +5,5 @@ menu.d usr/share/secubox/
 www usr/share/secubox/
 nginx/eye-remote.conf etc/nginx/secubox.d/
 debian/secubox-eye-remote.service etc/systemd/system/
+networkd/05-eye-br0.netdev etc/systemd/network/
+networkd/10-eye-br0.network etc/systemd/network/

--- a/packages/secubox-eye-remote/networkd/05-eye-br0.netdev
+++ b/packages/secubox-eye-remote/networkd/05-eye-br0.netdev
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+#
+# SecuBox Eye Remote — bridge for USB OTG gadgets
+#
+# All matching Pi RNDIS gadgets (MAC prefix 02:fb:00:00:*) are enslaved into
+# this bridge by udev (90-secubox-eye-remote.rules), so multiple gadgets can
+# coexist on a single broadcast domain without host-side IP collisions.
+#
+# The IP 10.55.0.1/24 lives on the bridge itself (see 10-eye-br0.network).
+
+[NetDev]
+Name=eye-br0
+Kind=bridge
+Description=SecuBox Eye Remote OTG bridge
+MACAddress=02:fb:00:00:00:01
+
+[Bridge]
+STP=no
+ForwardDelaySec=0

--- a/packages/secubox-eye-remote/networkd/10-eye-br0.network
+++ b/packages/secubox-eye-remote/networkd/10-eye-br0.network
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+#
+# SecuBox Eye Remote — host gateway address on the OTG bridge.
+#
+# The /24 fits the existing Pi-side firmware that statically configures
+# 10.55.0.2 as its peer; ConfigureWithoutCarrier=yes keeps the address
+# live even when no gadget is currently attached, so uvicorn (bound to
+# 10.55.0.1:8000) survives device hot-plug.
+
+[Match]
+Name=eye-br0
+
+[Network]
+Description=SecuBox Eye Remote host gateway
+Address=10.55.0.1/24
+DHCP=no
+ConfigureWithoutCarrier=yes
+IPv6AcceptRA=no
+LinkLocalAddressing=no
+
+[Link]
+RequiredForOnline=no

--- a/packages/secubox-eye-remote/udev/90-secubox-eye-remote.rules
+++ b/packages/secubox-eye-remote/udev/90-secubox-eye-remote.rules
@@ -1,46 +1,28 @@
 # ==============================================================================
 # SecuBox Eye Remote - USB OTG Gadget Detection
-# Detects Pi Zero W composite gadget (RNDIS + CDC-ECM + ACM + Mass Storage)
+# (Mirror of packages/secubox-system/etc/udev/rules.d/90-secubox-eye-remote.rules
+#  — kept in sync deliberately; secubox-system ships the canonical /etc copy.)
+#
+# IP addressing is managed by systemd-networkd via the eye-br0 bridge
+# (packages/secubox-eye-remote/networkd/{05-eye-br0.netdev,10-eye-br0.network}).
+# This rule only enslaves the gadget netdev into the bridge so multiple
+# gadgets can coexist as L2 ports.
+#
 # CyberMind - https://cybermind.fr
 # ==============================================================================
 
-# Pi Zero W Composite Gadget: Linux Foundation Multifunction (1d6b:0104)
-# Creates both RNDIS (usb0) and CDC-ECM (usb1) interfaces
-# We only want IP on RNDIS (usb0), disable CDC-ECM (usb1) to prevent conflicts
-
-# RNDIS interface (usb0) - Primary network connection
-# Configure IP and bring up
+# RNDIS interface — enslave into eye-br0 (which owns 10.55.0.1/24)
 ACTION=="add", SUBSYSTEM=="net", DRIVERS=="rndis_host", ATTR{address}=="02:fb:*", \
-    RUN+="/sbin/ip link set %k up", \
-    RUN+="/sbin/ip addr add 10.55.0.1/24 dev %k 2>/dev/null || true", \
     RUN+="/usr/lib/secubox/eye-remote-connected.sh %k"
 
-# CDC-ECM interface (usb1) - Disable to prevent duplicate IP route
-# Pi Zero creates both RNDIS and ECM; we only use RNDIS
+# CDC-ECM duplicate interface — keep down so it cannot fight for ARP
 ACTION=="add", SUBSYSTEM=="net", DRIVERS=="cdc_ether", ATTR{address}=="02:fb:*", \
     RUN+="/sbin/ip link set %k down"
 
-# Legacy: Pi Zero W CDC-ECM only gadget (NetChip signature)
-ACTION=="add", SUBSYSTEM=="net", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", \
-    NAME="eye-remote", \
-    RUN+="/sbin/ip link set %k up", \
-    RUN+="/sbin/ip addr add 10.55.0.1/24 dev %k 2>/dev/null || true", \
-    RUN+="/usr/lib/secubox/eye-remote-connected.sh %k"
-
-# Legacy: Alternative Raspberry Pi USB gadget signature
-ACTION=="add", SUBSYSTEM=="net", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a1", \
-    NAME="eye-remote", \
-    RUN+="/sbin/ip link set %k up", \
-    RUN+="/sbin/ip addr add 10.55.0.1/24 dev %k 2>/dev/null || true", \
-    RUN+="/usr/lib/secubox/eye-remote-connected.sh %k"
-
-# Serial console symlink (ACM interface)
+# Serial console symlink for the ACM function of the composite gadget
 ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="1d6b", ATTRS{idProduct}=="0104", \
-    SYMLINK+="eye-remote-console", MODE="0666"
+    SYMLINK+="eye-console", MODE="0660", GROUP="dialout"
 
 # Disconnect handler
 ACTION=="remove", SUBSYSTEM=="net", DRIVERS=="rndis_host", ATTR{address}=="02:fb:*", \
-    RUN+="/usr/lib/secubox/eye-remote-disconnected.sh"
-
-ACTION=="remove", SUBSYSTEM=="net", ENV{INTERFACE}=="eye-remote", \
     RUN+="/usr/lib/secubox/eye-remote-disconnected.sh"

--- a/packages/secubox-system/etc/udev/rules.d/90-secubox-eye-remote.rules
+++ b/packages/secubox-system/etc/udev/rules.d/90-secubox-eye-remote.rules
@@ -1,46 +1,27 @@
 # ==============================================================================
 # SecuBox Eye Remote - USB OTG Gadget Detection
-# Detects Pi Zero W composite gadget (RNDIS + CDC-ECM + ACM + Mass Storage)
+# Detects Pi RNDIS+CDC-ECM+ACM composite gadget (Linux Foundation 1d6b:0104)
+#
+# IP addressing is managed by systemd-networkd via the eye-br0 bridge
+# (see packages/secubox-eye-remote/networkd/{05-eye-br0.netdev,
+# 10-eye-br0.network}). This rule only enslaves the gadget netdev into
+# the bridge — multiple gadgets can coexist as L2 ports.
+#
 # CyberMind - https://cybermind.fr
 # ==============================================================================
 
-# Pi Zero W Composite Gadget: Linux Foundation Multifunction (1d6b:0104)
-# Creates both RNDIS (usb0) and CDC-ECM (usb1) interfaces
-# We only want IP on RNDIS (usb0), disable CDC-ECM (usb1) to prevent conflicts
-
-# RNDIS interface (usb0) - Primary network connection
-# Configure IP and bring up
+# RNDIS interface — enslave into eye-br0 (which owns 10.55.0.1/24)
 ACTION=="add", SUBSYSTEM=="net", DRIVERS=="rndis_host", ATTR{address}=="02:fb:*", \
-    RUN+="/sbin/ip link set %k up", \
-    RUN+="/sbin/ip addr add 10.55.0.1/24 dev %k 2>/dev/null || true", \
     RUN+="/usr/lib/secubox/eye-remote-connected.sh %k"
 
-# CDC-ECM interface (usb1) - Disable to prevent duplicate IP route
-# Pi Zero creates both RNDIS and ECM; we only use RNDIS
+# CDC-ECM duplicate interface — keep down so it cannot fight for ARP
 ACTION=="add", SUBSYSTEM=="net", DRIVERS=="cdc_ether", ATTR{address}=="02:fb:*", \
     RUN+="/sbin/ip link set %k down"
 
-# Legacy: Pi Zero W CDC-ECM only gadget (NetChip signature)
-ACTION=="add", SUBSYSTEM=="net", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", \
-    NAME="eye-remote", \
-    RUN+="/sbin/ip link set %k up", \
-    RUN+="/sbin/ip addr add 10.55.0.1/24 dev %k 2>/dev/null || true", \
-    RUN+="/usr/lib/secubox/eye-remote-connected.sh %k"
-
-# Legacy: Alternative Raspberry Pi USB gadget signature
-ACTION=="add", SUBSYSTEM=="net", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a1", \
-    NAME="eye-remote", \
-    RUN+="/sbin/ip link set %k up", \
-    RUN+="/sbin/ip addr add 10.55.0.1/24 dev %k 2>/dev/null || true", \
-    RUN+="/usr/lib/secubox/eye-remote-connected.sh %k"
-
-# Serial console symlink (ACM interface)
+# Serial console symlink for the ACM function of the composite gadget
 ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="1d6b", ATTRS{idProduct}=="0104", \
-    SYMLINK+="eye-remote-console", MODE="0666"
+    SYMLINK+="eye-console", MODE="0660", GROUP="dialout"
 
 # Disconnect handler
 ACTION=="remove", SUBSYSTEM=="net", DRIVERS=="rndis_host", ATTR{address}=="02:fb:*", \
-    RUN+="/usr/lib/secubox/eye-remote-disconnected.sh"
-
-ACTION=="remove", SUBSYSTEM=="net", ENV{INTERFACE}=="eye-remote", \
     RUN+="/usr/lib/secubox/eye-remote-disconnected.sh"

--- a/packages/secubox-system/usr/lib/secubox/eye-remote-connected.sh
+++ b/packages/secubox-system/usr/lib/secubox/eye-remote-connected.sh
@@ -1,49 +1,68 @@
 #!/usr/bin/env bash
-# SecuBox Eye Remote Connected Handler
-# Called by udev when Pi Zero W Eye Remote is connected via USB OTG
-# CyberMind - https://cybermind.fr
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+#
+# SecuBox Eye Remote — USB OTG connect handler.
+# Called by udev when a Pi RNDIS gadget (MAC 02:fb:00:00:*) is plugged in.
+# Enslaves the kernel-named interface (usb0/usb1/…) into the eye-br0 bridge
+# managed by systemd-networkd (05-eye-br0.netdev + 10-eye-br0.network).
+#
+# The bridge owns the host IP 10.55.0.1/24, so multiple gadgets can coexist
+# without duplicate-address races. Per-Pi L3 addressing is the Round image's
+# responsibility — see remote-ui/round/MULTI-GADGET.md.
+
 set -euo pipefail
 
-IFACE="${INTERFACE:-eye-remote}"
-HOST_IP="10.55.0.1"
+IFACE="${INTERFACE:-${1:-}}"
+BRIDGE="eye-br0"
 PEER_IP="10.55.0.2"
-NETMASK="30"
 
-log() {
-    logger -t "secubox-eye-remote" "$*"
-    echo "[eye-remote] $*"
-}
+log() { logger -t "secubox-eye-remote" "$*"; }
 
-log "Eye Remote connected: $IFACE"
-
-# Wait for interface to be ready
-sleep 1
-
-# Configure host side of OTG link
-if ip link show "$IFACE" &>/dev/null; then
-    # Set IP address (host side)
-    ip addr flush dev "$IFACE" 2>/dev/null || true
-    ip addr add "${HOST_IP}/${NETMASK}" dev "$IFACE"
-    ip link set "$IFACE" up
-
-    log "Interface $IFACE configured: ${HOST_IP}/${NETMASK}"
-
-    # Add route to Eye Remote
-    ip route add "${PEER_IP}/32" dev "$IFACE" 2>/dev/null || true
-
-    # Enable forwarding for this interface
-    echo 1 > /proc/sys/net/ipv4/conf/"$IFACE"/forwarding 2>/dev/null || true
-
-    # Notify SecuBox API that Eye Remote is connected
-    if command -v curl &>/dev/null; then
-        curl -s -X POST "http://127.0.0.1:8000/api/v1/system/eye-remote/connected" \
-            -H "Content-Type: application/json" \
-            -d "{\"interface\": \"$IFACE\", \"peer_ip\": \"$PEER_IP\"}" \
-            2>/dev/null || true
-    fi
-
-    log "Eye Remote ready at ${PEER_IP}"
-else
-    log "ERROR: Interface $IFACE not found"
+if [[ -z "$IFACE" ]]; then
+    log "ERROR: no interface name (\$INTERFACE / \$1)"
     exit 1
 fi
+
+log "Eye Remote connect: $IFACE"
+
+# Wait for the kernel netdev to settle (rndis_host probing can take ~1s)
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [[ -e "/sys/class/net/$IFACE" ]] && break
+    sleep 0.2
+done
+
+if [[ ! -e "/sys/class/net/$IFACE" ]]; then
+    log "ERROR: interface $IFACE not found"
+    exit 1
+fi
+
+# Wait for the bridge — networkd may still be bringing it up on cold boot.
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [[ -e "/sys/class/net/$BRIDGE" ]] && break
+    sleep 0.2
+done
+
+if [[ ! -e "/sys/class/net/$BRIDGE" ]]; then
+    log "WARN: bridge $BRIDGE missing — falling back to point-to-point on $IFACE"
+    ip addr flush dev "$IFACE" 2>/dev/null || true
+    ip addr add 10.55.0.1/24 dev "$IFACE" 2>/dev/null || true
+    ip link set "$IFACE" up
+else
+    # Drop any stray IP on the gadget iface — the bridge owns L3.
+    ip addr flush dev "$IFACE" 2>/dev/null || true
+    ip link set "$IFACE" master "$BRIDGE"
+    ip link set "$IFACE" up
+    log "Enslaved $IFACE into $BRIDGE"
+fi
+
+# Notify the API (best-effort; the service may not be running yet on boot)
+if command -v curl >/dev/null 2>&1; then
+    curl --max-time 2 -s -X POST \
+        "http://127.0.0.1:8000/api/v1/system/eye-remote/connected" \
+        -H "Content-Type: application/json" \
+        -d "{\"interface\": \"$IFACE\", \"bridge\": \"$BRIDGE\", \"peer_ip\": \"$PEER_IP\"}" \
+        >/dev/null 2>&1 || true
+fi
+
+log "Eye Remote ready: $IFACE on $BRIDGE (peer $PEER_IP)"

--- a/packages/secubox-system/usr/lib/secubox/eye-remote-disconnected.sh
+++ b/packages/secubox-system/usr/lib/secubox/eye-remote-disconnected.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
-# SecuBox Eye Remote Disconnected Handler
-# Called by udev when Pi Zero W Eye Remote is disconnected
-# CyberMind - https://cybermind.fr
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+#
+# SecuBox Eye Remote — USB OTG disconnect handler.
+# Called by udev when a Pi RNDIS gadget is unplugged. The slave netdev is
+# already gone by the time udev fires the remove event, so this script only
+# notifies the API and logs.
+
 set -euo pipefail
 
-IFACE="${INTERFACE:-eye-remote}"
+IFACE="${INTERFACE:-${1:-}}"
 
-log() {
-    logger -t "secubox-eye-remote" "$*"
-    echo "[eye-remote] $*"
-}
+log() { logger -t "secubox-eye-remote" "$*"; }
 
-log "Eye Remote disconnected: $IFACE"
+log "Eye Remote disconnect: ${IFACE:-<unknown>}"
 
-# Notify SecuBox API
-if command -v curl &>/dev/null; then
-    curl -s -X POST "http://127.0.0.1:8000/api/v1/system/eye-remote/disconnected" \
+if command -v curl >/dev/null 2>&1; then
+    curl --max-time 2 -s -X POST \
+        "http://127.0.0.1:8000/api/v1/system/eye-remote/disconnected" \
         -H "Content-Type: application/json" \
-        -d "{\"interface\": \"$IFACE\"}" \
-        2>/dev/null || true
+        -d "{\"interface\": \"${IFACE:-}\"}" \
+        >/dev/null 2>&1 || true
 fi
-
-log "Eye Remote cleanup complete"

--- a/remote-ui/round/MULTI-GADGET.md
+++ b/remote-ui/round/MULTI-GADGET.md
@@ -1,0 +1,76 @@
+# Eye Remote — Multi-Gadget Limitation
+
+Status: known limitation as of issue #155 fix.
+
+## What works
+
+The host (MOCHAbin / ESPRESSObin SecuBox) accepts an arbitrary number of Pi
+RNDIS USB gadgets simultaneously plugged into its USB hub. Each gadget
+enumerates as a `Linux Foundation Multifunction Composite Gadget`
+(`1d6b:0104`) with kernel-assigned names `usb0`, `usb1`, … and udev
+(`/etc/udev/rules.d/90-secubox-eye-remote.rules`) enslaves each one into
+the `eye-br0` bridge created by systemd-networkd
+(`/etc/systemd/network/05-eye-br0.netdev`, `10-eye-br0.network`).
+
+The bridge owns the host IP **10.55.0.1/24** and survives gadget hot-plug
+thanks to `ConfigureWithoutCarrier=yes`. Each gadget is also exposed as
+its own ACM serial endpoint under `/dev/ttyACM*` (the `eye-console`
+symlink only points at the first ACM by udev order — that is intentional;
+use `udevadm info` to map each ACM device to a specific gadget when
+needed).
+
+## What does *not* work — peer-IP collision at L3
+
+Every Round image currently flashes the same static peer configuration on
+the gadget side: **`10.55.0.2/30`** with host `10.55.0.1`. As a result,
+when two or more Round gadgets are plugged into the same host they all
+claim **the same** L3 address (`10.55.0.2`). The Linux bridge ARPs them
+in order; whichever Pi answers first wins, and traffic to `10.55.0.2`
+from the host is non-deterministically routed to one of them.
+
+The eye-br0 bridge keeps the **L2** topology clean — no host-side
+duplicate IP, no rp_filter drops, no per-port routing ambiguity — but it
+cannot solve a duplicate-address L3 conflict that originates on the Pi
+side.
+
+### Symptoms
+
+- `ping 10.55.0.2` from the host alternates RTT / TTL between gadgets
+- `ssh root@10.55.0.2` may land on either Pi depending on cache state
+- `arp -n` on the host shows a flapping MAC for `10.55.0.2`
+
+### Workaround for "one Pi at a time"
+
+Unplug the gadgets you don't want active. The bridge keeps `10.55.0.1`
+live regardless, so the API at `http://10.55.0.1:8000` stays reachable
+whenever any single gadget is plugged in.
+
+### Proper fix — Round image change (future)
+
+The Round image needs to derive its peer IP from its own MAC address
+(or run a tiny DHCP client requesting a unique lease from
+`secubox-eye-remote`). Sketch:
+
+```bash
+# /etc/systemd/network/10-secubox-eye.network on the Pi
+[Network]
+DHCP=yes
+LinkLocalAddressing=no
+```
+
+…paired with a host-side `dnsmasq` (or `systemd-networkd` DHCP server
+section) on `eye-br0` handing out leases from `10.55.0.10/24` upward,
+keyed by MAC for stable addressing.
+
+This is **out of scope for issue #155** — that fix is purely host-side.
+Track the follow-up in its own issue when the Round image rework starts.
+
+## Verification commands
+
+```bash
+ip -br link show type bridge                # eye-br0 should be UP
+ip -br addr show eye-br0                    # 10.55.0.1/24
+bridge link show                            # usb0/usb1/… should list master eye-br0
+journalctl -t secubox-eye-remote --since -10m
+curl -s http://10.55.0.1:8000/api/v1/eye-remote/health
+```

--- a/remote-ui/round/host-cleanup-dead-config.sh
+++ b/remote-ui/round/host-cleanup-dead-config.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+#
+# SecuBox Eye Remote — host cleanup + bridge installer
+#
+# Idempotent. Run on the SecuBox host (e.g. 192.168.1.200) to:
+#   1. Remove hand-installed networkd / ifupdown leftovers that are NOT
+#      owned by any dpkg package and that fight with the canonical
+#      bridge approach (link rename collision when ≥2 gadgets plug in).
+#   2. Install the canonical eye-br0 bridge .netdev + .network from
+#      packages/secubox-eye-remote/networkd/.
+#   3. Sync the per-gadget connect/disconnect handlers + udev rule from
+#      packages/secubox-system/.
+#   4. Reload systemd-networkd + udev so both Pi gadgets (Zero W + 4B)
+#      come up as L2 ports of eye-br0, with 10.55.0.1/24 living on the
+#      bridge.
+#
+# Safe to re-run: every step checks state before mutating.
+#
+# Usage:
+#     sudo ./host-cleanup-dead-config.sh         # run locally on the host
+#     bash host-cleanup-dead-config.sh --dry-run # show what would change
+#
+# Issue: https://github.com/CyberMind-FR/secubox-deb/issues/155
+
+set -euo pipefail
+
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+    DRY_RUN=1
+fi
+
+# Resolve repo root: this script lives at remote-ui/round/, so the repo
+# root is two levels up. SCRIPT_DIR is robust to symlinks via realpath.
+SCRIPT_DIR=$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+DEAD_FILES=(
+    /etc/systemd/network/10-eye-remote.link
+    /etc/systemd/network/50-eye-remote.network
+    /etc/network/interfaces.d/usb0
+)
+
+NETPLAN_FILE="/etc/netplan/00-secubox.yaml"
+
+CANONICAL_NETWORKD=(
+    "$REPO_ROOT/packages/secubox-eye-remote/networkd/05-eye-br0.netdev:/etc/systemd/network/05-eye-br0.netdev"
+    "$REPO_ROOT/packages/secubox-eye-remote/networkd/10-eye-br0.network:/etc/systemd/network/10-eye-br0.network"
+)
+
+CANONICAL_UDEV=(
+    "$REPO_ROOT/packages/secubox-system/etc/udev/rules.d/90-secubox-eye-remote.rules:/etc/udev/rules.d/90-secubox-eye-remote.rules"
+)
+
+CANONICAL_HOOKS=(
+    "$REPO_ROOT/packages/secubox-system/usr/lib/secubox/eye-remote-connected.sh:/usr/lib/secubox/eye-remote-connected.sh"
+    "$REPO_ROOT/packages/secubox-system/usr/lib/secubox/eye-remote-disconnected.sh:/usr/lib/secubox/eye-remote-disconnected.sh"
+)
+
+say() { printf '[eye-remote-fix] %s\n' "$*"; }
+do_cmd() {
+    if (( DRY_RUN )); then
+        printf '[dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+# ---- 0. netplan: drop the eye-remote ethernet stanza ------------------------
+# The deployed netplan declares `eye-remote` as an ethernet (with 10.55.0.1/30),
+# which only works after a separate .link rename — and that rename collides
+# when ≥2 gadgets are plugged in. Drop the stanza; the packaged .netdev/.network
+# below own the bridge that holds the IP.
+say "Netplan: dropping any eye-remote ethernet stanza in $NETPLAN_FILE"
+if [[ -f "$NETPLAN_FILE" ]] && grep -qE '^[[:space:]]+eye-remote:' "$NETPLAN_FILE"; then
+    if (( DRY_RUN )); then
+        printf '[dry-run] would edit %s to remove eye-remote: stanza\n' "$NETPLAN_FILE"
+    else
+        cp -a "$NETPLAN_FILE" "${NETPLAN_FILE}.bak.155"
+        python3 - "$NETPLAN_FILE" <<'PY'
+import sys, re
+
+path = sys.argv[1]
+lines = open(path).readlines()
+
+def leading_spaces(s):
+    return len(s) - len(s.lstrip(' '))
+
+out = []
+i = 0
+removed = False
+while i < len(lines):
+    ln = lines[i]
+    # Detect "<indent>eye-remote:" (possibly followed by trailing whitespace).
+    m = re.match(r'^([ \t]+)eye-remote:\s*$', ln)
+    if m and not removed:
+        block_indent = leading_spaces(ln)
+        # Skip the key line itself plus every following line whose indent is
+        # strictly greater than block_indent, or which is blank.
+        i += 1
+        while i < len(lines):
+            nxt = lines[i]
+            if nxt.strip() == '':
+                # Blank line: drop it only if it precedes another child of the
+                # same block; otherwise let it survive as a separator.
+                # Peek ahead for the next non-blank line's indent.
+                j = i + 1
+                while j < len(lines) and lines[j].strip() == '':
+                    j += 1
+                if j < len(lines) and leading_spaces(lines[j]) > block_indent:
+                    i += 1
+                    continue
+                break
+            if leading_spaces(nxt) > block_indent:
+                i += 1
+                continue
+            break
+        removed = True
+        continue
+    out.append(ln)
+    i += 1
+
+if not removed:
+    sys.stderr.write("WARN: eye-remote stanza not found, nothing changed\n")
+    sys.exit(0)
+
+open(path, 'w').writelines(out)
+PY
+        say "  ✓ patched (backup at ${NETPLAN_FILE}.bak.155)"
+    fi
+else
+    say "  = no eye-remote stanza present, nothing to do"
+fi
+
+# ---- 1. remove hand-installed dead config (only if not dpkg-owned) -----------
+say "Removing hand-installed dead config (only files not owned by any package):"
+for f in "${DEAD_FILES[@]}"; do
+    if [[ ! -e "$f" ]]; then
+        say "  - $f (already absent)"
+        continue
+    fi
+    if dpkg -S "$f" >/dev/null 2>&1; then
+        say "  ! $f is dpkg-owned — refusing to delete (manual review)"
+        continue
+    fi
+    say "  - rm $f"
+    do_cmd "rm -f \"$f\""
+done
+
+# ---- 2. install canonical bridge networkd files -----------------------------
+say "Installing canonical eye-br0 networkd files:"
+for pair in "${CANONICAL_NETWORKD[@]}"; do
+    src="${pair%%:*}"
+    dst="${pair##*:}"
+    if [[ ! -f "$src" ]]; then
+        say "  ! source missing: $src — abort"
+        exit 1
+    fi
+    if cmp -s "$src" "$dst" 2>/dev/null; then
+        say "  = $dst (already up-to-date)"
+    else
+        say "  + install $dst"
+        do_cmd "install -D -m 0644 \"$src\" \"$dst\""
+    fi
+done
+
+# ---- 3. sync udev rule + handler scripts ------------------------------------
+say "Syncing udev rule + connect/disconnect handlers:"
+for pair in "${CANONICAL_UDEV[@]}"; do
+    src="${pair%%:*}"; dst="${pair##*:}"
+    if cmp -s "$src" "$dst" 2>/dev/null; then
+        say "  = $dst (already up-to-date)"
+    else
+        say "  + install $dst"
+        do_cmd "install -D -m 0644 \"$src\" \"$dst\""
+    fi
+done
+for pair in "${CANONICAL_HOOKS[@]}"; do
+    src="${pair%%:*}"; dst="${pair##*:}"
+    if cmp -s "$src" "$dst" 2>/dev/null; then
+        say "  = $dst (already up-to-date)"
+    else
+        say "  + install $dst"
+        do_cmd "install -D -m 0755 \"$src\" \"$dst\""
+    fi
+done
+
+# ---- 4. reload services -----------------------------------------------------
+say "Regenerating netplan + reloading networkd + udev:"
+if [[ -f "$NETPLAN_FILE" ]]; then
+    do_cmd "netplan generate"
+fi
+do_cmd "systemctl restart systemd-networkd"
+do_cmd "udevadm control --reload"
+do_cmd "udevadm trigger --subsystem-match=net --action=add"
+
+# ---- 5. quick verification --------------------------------------------------
+say "Post-fix state (informational):"
+if (( DRY_RUN )); then
+    say "  (dry-run: skipping verification)"
+    exit 0
+fi
+
+sleep 2
+
+if ip -br addr show eye-br0 2>/dev/null | grep -q '10.55.0.1'; then
+    say "  ✓ eye-br0 carries 10.55.0.1/24"
+else
+    say "  ✗ eye-br0 has no 10.55.0.1 — see: ip -br addr show eye-br0"
+fi
+
+slaves=$(bridge -j link show 2>/dev/null | python3 -c 'import json,sys
+try:
+    data=json.load(sys.stdin)
+except Exception:
+    print(""); sys.exit(0)
+print(" ".join(x["ifname"] for x in data if x.get("master")=="eye-br0"))' 2>/dev/null || true)
+if [[ -n "$slaves" ]]; then
+    say "  ✓ eye-br0 slaves: $slaves"
+else
+    say "  • no gadget enslaved yet — plug a Pi Zero W or check /dev/ttyACM*"
+fi
+
+say "Done. Restart secubox-eye-remote.service if it failed to bind earlier:"
+say "    systemctl restart secubox-eye-remote.service"


### PR DESCRIPTION
## Summary

- Issue [#155](https://github.com/CyberMind-FR/secubox-deb/issues/155): hand-installed `/etc/systemd/network/10-eye-remote.link` renamed every `02:fb:00:00:* + rndis_host` interface to a fixed name `eye-remote`. With two Pi gadgets (Zero W + 4B) plugged into the MOCHAbin USB hub the rename collides; systemd-networkd silently leaves all of them as `usb0/usb1/usb2`, netplan's `eye-remote` ethernet stanza never matches, and `10.55.0.1/30` never gets applied → the API service can't bind, every `usb*` iface stays DOWN.
- Replaces the rename approach with a package-owned `eye-br0` bridge that the host IP lives on; udev enslaves every matching `rndis_host` netdev into the bridge so multiple gadgets coexist as L2 ports without host-side IP collisions.
- Ships an idempotent host hotfix (`remote-ui/round/host-cleanup-dead-config.sh`) that rewrites the deployed netplan, removes the dead `.link`/`.network`/`interfaces.d/usb0` files, and installs the canonical bridge config.
- Documents the remaining L3 limitation (every Round image statically claims `10.55.0.2/30` as its peer, so two Pis racing for the same address needs a separate Round-image change) in [`remote-ui/round/MULTI-GADGET.md`](remote-ui/round/MULTI-GADGET.md).

## Files

- `packages/secubox-eye-remote/networkd/05-eye-br0.netdev` (new) — bridge definition
- `packages/secubox-eye-remote/networkd/10-eye-br0.network` (new) — `10.55.0.1/24`, `ConfigureWithoutCarrier=yes`
- `packages/secubox-eye-remote/debian/secubox-eye-remote.install` — ship the two networkd files to `/etc/systemd/network/`
- `packages/secubox-system/etc/udev/rules.d/90-secubox-eye-remote.rules` — drop per-iface IP, just call the hook
- `packages/secubox-eye-remote/udev/90-secubox-eye-remote.rules` — mirror kept in sync
- `packages/secubox-system/usr/lib/secubox/eye-remote-connected.sh` — enslave into `eye-br0` (with point-to-point fallback if the bridge is missing)
- `packages/secubox-system/usr/lib/secubox/eye-remote-disconnected.sh` — slimmed; the slave netdev is gone by the time udev fires `remove`
- `remote-ui/round/host-cleanup-dead-config.sh` (new) — idempotent hotfix runner
- `remote-ui/round/MULTI-GADGET.md` (new) — L3 limitation + verification commands
- `.claude/HISTORY.md`, `.claude/WIP.md` — log + status

## Test plan

- [x] Dry-run of `host-cleanup-dead-config.sh` on the test board shows the expected diff
- [x] Stateful YAML editor on a copy produces valid netplan (no duplicate `addresses:` keys); `netplan generate --root-dir /tmp/np-check` accepts it
- [x] Live apply on `192.168.1.200`: `eye-br0` UP with `10.55.0.1/24`, three rndis_host slaves enslaved
- [x] `secubox-eye-remote.service` active; `ss -tlnp` shows uvicorn bound on `10.55.0.1:8000`
- [x] `curl --max-time 3 http://10.55.0.1:8000/health` → HTTP 200
- [x] `journalctl -t secubox-eye-remote` clean on udev re-trigger
- [ ] **User validation** of multi-gadget behavior with hot-plug/unplug cycles
- [ ] **User validation** of reboot persistence (netplan + networkd + udev all firing in order)

Ref #155 — keep open after merge until the user explicitly validates and closes per `Jamais de fermeture automatique`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)