### PR TITLE
fix(eye-remote): live-deploy regressions on 192.168.1.200 (ref #158)

### DIFF
--- a/packages/secubox-eye-remote/debian/postinst
+++ b/packages/secubox-eye-remote/debian/postinst
@@ -12,9 +12,21 @@ case "$1" in
         mkdir -p /run/secubox
         chown secubox:secubox /run/secubox 2>/dev/null || true
 
-        # Ensure config dirs exist with correct ownership
-        install -d -m 0750 -o root -g root /etc/secubox/eye-remote
+        # Ensure config dirs exist with correct ownership.
+        # 0755 on eye-remote/ so the dnsmasq daemon (running as dnsmasq:nogroup
+        # after --user/--group privilege drop) can read reservations.conf.
+        # The .conf file itself stays 0644, owner root:root.
+        install -d -m 0755 -o root -g root /etc/secubox/eye-remote
         install -d -m 0755 -o root -g root /var/log/secubox
+
+        # /etc/secubox/ may already exist owned secubox:secubox mode 0750
+        # (created by another package). dnsmasq:nogroup needs to traverse it
+        # to reach eye-remote/. 0751 keeps the listing private but allows
+        # traversal — the eye-remote subdir is the only thing the daemon
+        # actually opens.
+        if [ -d /etc/secubox ]; then
+            chmod 0751 /etc/secubox 2>/dev/null || true
+        fi
 
         # Prevent Debian's system-wide dnsmasq from grabbing port 53
         # (we ship our own scoped instance instead).

--- a/packages/secubox-eye-remote/dnsmasq.d/eye-remote.conf
+++ b/packages/secubox-eye-remote/dnsmasq.d/eye-remote.conf
@@ -33,4 +33,4 @@ dhcp-script=/usr/lib/secubox/eye-remote-leasewatch.sh
 conf-file=/etc/secubox/eye-remote/reservations.conf
 
 log-dhcp
-log-facility=/var/log/secubox/eye-remote-dhcp.log
+# log-facility intentionally unset — dnsmasq logs to syslog via systemd

--- a/packages/secubox-eye-remote/systemd/secubox-eye-remote-dhcp.service
+++ b/packages/secubox-eye-remote/systemd/secubox-eye-remote-dhcp.service
@@ -2,8 +2,8 @@
 [Unit]
 Description=SecuBox Eye Remote — DHCP server on eye-br0
 Documentation=https://github.com/CyberMind-FR/secubox-deb/issues/158
-Requires=sys-subsystem-net-devices-eye_br0.device
-After=sys-subsystem-net-devices-eye_br0.device systemd-networkd.service
+Requires=sys-subsystem-net-devices-eye\x2dbr0.device
+After=sys-subsystem-net-devices-eye\x2dbr0.device systemd-networkd.service
 ConditionPathExists=/sys/class/net/eye-br0
 
 [Service]


### PR DESCRIPTION
## Summary

Three fixes caught during the live install of PR #161 on the test board, captured in commit \`c93d4ac3\`:

1. **systemd unit dash escape** — \`sys-subsystem-net-devices-eye_br0.device\` → \`sys-subsystem-net-devices-eye\\x2dbr0.device\`. Without the proper \`\\x2d\` escape for the dash in \`eye-br0\`, the device unit never resolves and the DHCP service hangs on dependency timeout.
2. **dnsmasq log destination** — drop \`log-facility=/var/log/secubox/...\` and use syslog default. The daemon (privilege-dropped to \`dnsmasq:nogroup\`) couldn't write to the root-owned log dir. Journal output via systemd is the right path.
3. **Directory traversal** — postinst now creates \`/etc/secubox/eye-remote\` as \`0755\` (not \`0750\`) and additionally chmods \`/etc/secubox\` to \`0751\` so the daemon can traverse the parent (which other packages create as \`0750 secubox:secubox\`).

## Verified live on 192.168.1.200

- \`secubox-eye-remote-dhcp.service\` active, \`dnsmasq\` listening on \`0.0.0.0:67\` bound exclusively to \`eye-br0\`
- nftables \`inet secubox_eye_remote\` table loaded with the two allow rules
- \`/api/v1/eye-remote/leases\` returns \`401\` (JWT auth working as designed)
- Bridge has its 3 expected slaves (\`enx02fb...\` for the two Pi gadgets + the stale \`eye-remote\` from before #157)

## Remaining acceptance gates (manual, hardware-dependent)

- Reflash a Pi with the Round image built from current master (includes Tasks 14+15: \`usb0→eye0\` rename, DHCP client)
- Plug in, watch DHCP DISCOVER → ACK in \`journalctl -u secubox-eye-remote-dhcp\`
- Confirm \`reservations.conf\` auto-appends a stable lease via the leasewatch hook
- Plug in a second Pi; confirm distinct \`.12\` lease

Ref #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)