### PR TITLE
fix(secubox-core): preserve operator-tuned nginx site config on upgrade (#162)

### DIFF
--- a/packages/secubox-core/debian/changelog
+++ b/packages/secubox-core/debian/changelog
@@ -1,3 +1,17 @@
+secubox-core (1.1.2-1~bookworm1) bookworm; urgency=medium
+
+  * postinst: gate /etc/nginx/sites-available/secubox install on first install
+    only — preserve operator-tuned variants on upgrade.
+  * postinst: skip nginx reload when "nginx -t" fails (don't crash a running
+    nginx worker pool on a stale-but-working config).
+  * Fixes the regression where dpkg -i secubox-core on HAProxy-fronted
+    boards silently overwrote the working sites-available/secubox config
+    with the standalone-nginx variant (listen 80/443), then the next
+    systemctl restart nginx crashed with bind() EADDRINUSE.
+  * Closes: #162
+
+ -- Gerald KERMA <devel@cybermind.fr>  Sun, 17 May 2026 07:24:20 +0200
+
 secubox-core (1.1.1-1~bookworm1) bookworm; urgency=medium
 
   * Add get_cookie_audit_config() helper with built-in RGPD/CNIL classifier

--- a/packages/secubox-core/debian/postinst
+++ b/packages/secubox-core/debian/postinst
@@ -26,21 +26,37 @@ case "$1" in
     fi
 
     # ── Nginx ──
+    # The /etc/nginx/sites-available/secubox file ships with three server
+    # blocks bound to 80/443 — fine for standalone-nginx topologies, fatal
+    # on HAProxy-fronted boards where HAProxy already owns 80/443.
+    # Only install it on first install (when the file doesn't exist).
+    # Subsequent installs/upgrades keep the operator-tuned variant intact.
+    # See issue #162.
     if [ -d /etc/nginx/sites-available ]; then
-      install -m 644 /usr/share/secubox-core/nginx/secubox.conf \
-        /etc/nginx/sites-available/secubox
+      if [ ! -f /etc/nginx/sites-available/secubox ]; then
+        install -m 644 /usr/share/secubox-core/nginx/secubox.conf \
+          /etc/nginx/sites-available/secubox
+      fi
       install -m 644 /usr/share/secubox-core/nginx/secubox-proxy.conf \
         /etc/nginx/snippets/secubox-proxy.conf
 
-      # Activer le site
+      # Symlink only on first install — never overwrite an existing one
+      # (which may point at an HAProxy-aware variant like secubox-local).
       if [ ! -e /etc/nginx/sites-enabled/secubox ]; then
         ln -s /etc/nginx/sites-available/secubox \
               /etc/nginx/sites-enabled/secubox
       fi
       rm -f /etc/nginx/sites-enabled/default
 
-      nginx -t && install -d -m 755 /etc/nginx/secubox.d
-    systemctl reload nginx 2>/dev/null || true
+      install -d -m 755 /etc/nginx/secubox.d
+      # Only reload nginx if the resulting config is valid. On HAProxy
+      # boards the operator-tuned file is preserved, so this passes; on
+      # standalone boards the freshly-installed file is also valid.
+      if nginx -t 2>/dev/null; then
+        systemctl reload nginx 2>/dev/null || true
+      else
+        echo "secubox-core: nginx -t failed, skipping reload (preserving running config)" >&2
+      fi
     fi
 
     systemctl daemon-reload


### PR DESCRIPTION
## Summary

* postinst now only installs `/etc/nginx/sites-available/secubox` when the file is absent (first install). Subsequent upgrades preserve the operator-tuned variant — same idempotent pattern already used for `/etc/secubox/secubox.conf`.
* nginx reload at the end of postinst now only fires when `nginx -t` passes — avoids waking up a stale-but-working worker pool with a broken merged config.
* Fixes the regression that caused a 4-min prod outage on the gk2 board during the #156 cookie-audit deploy: `dpkg -i secubox-core_1.1.1` silently overwrote the HAProxy-aware `secubox-local`-derived config with the standalone `listen 80/443` variant, then the next `systemctl restart nginx` crashed with `bind() failed (98: Address already in use)`.

## Test plan

- [x] `bash -n debian/postinst` — syntax OK
- [ ] Upgrade test on a board: install 1.1.2 over an existing tuned `/etc/nginx/sites-available/secubox` → file is preserved, symlink untouched, nginx reload skipped if test would fail.
- [ ] Fresh install on a board with no prior file: standalone variant installed as before, symlink created.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)