### PR TITLE
fix(secubox-soc-web): remove duplicate /soc/ location from nginx snippet (#163)

### DIFF
--- a/packages/secubox-soc-web/debian/changelog
+++ b/packages/secubox-soc-web/debian/changelog
@@ -1,3 +1,18 @@
+secubox-soc-web (1.1.1-1) bookworm; urgency=medium
+
+  * nginx snippet: remove duplicate `location /soc/` block (already defined
+    inline in secubox-hub's sites-enabled/webui.conf). The snippet now only
+    declares routes UNIQUE to soc-web (the /api/v1/soc-gateway/ proxy).
+  * Fixes "duplicate location /soc/" nginx test failure that silently
+    blocked every "systemctl reload nginx" on boards where webui.conf
+    inline + secubox.d/soc.conf + secubox.d/soc-web.conf overlapped.
+  * Operator note: if an orphan /etc/nginx/secubox.d/soc.conf still exists
+    on the board from a previous (now-removed) package, it must be cleaned
+    manually (no package owns it).
+  * Closes: #163
+
+ -- Gerald KERMA <devel@cybermind.fr>  Sun, 17 May 2026 07:26:00 +0200
+
 secubox-soc-web (1.1.0-1) bookworm; urgency=medium
 
   * Phase 5: Hierarchical Mode UI

--- a/packages/secubox-soc-web/debian/secubox-soc-web.nginx.conf
+++ b/packages/secubox-soc-web/debian/secubox-soc-web.nginx.conf
@@ -1,16 +1,13 @@
 # SecuBox SOC Web Dashboard - Nginx Configuration
-# Include this in your main nginx config or sites-enabled
-
-location /soc/ {
-    alias /usr/share/secubox/www/soc/;
-    try_files $uri $uri/ /soc/index.html;
-
-    # Cache static assets
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-    }
-}
+# Include this in your main nginx config or sites-enabled.
+#
+# NOTE (issue #163): the `location /soc/` static-serving block was REMOVED
+# from this file. It is already defined inline in secubox-hub's
+# sites-enabled/webui.conf (the canonical location), and was historically
+# also present in an orphan /etc/nginx/secubox.d/soc.conf — yielding a
+# triple definition in the same server block which made every "nginx -t"
+# fail with `duplicate location "/soc/"`. This snippet now only declares
+# routes UNIQUE to secubox-soc-web (the SOC Gateway proxy below).
 
 # API proxy to SOC Gateway
 location /api/v1/soc-gateway/ {


### PR DESCRIPTION
## Summary

* The snippet at `debian/secubox-soc-web.nginx.conf` (installed to `/etc/nginx/secubox.d/soc-web.conf`) declared `location /soc/` — already defined inline in `secubox-hub`'s `sites-enabled/webui.conf`. Combined with a third orphan file `/etc/nginx/secubox.d/soc.conf` (no source in the repo), this triple-defined `/soc/` in a single server block.
* Every `nginx -t` failed with `duplicate location "/soc/"`, silently no-op'ing `systemctl reload nginx` calls for days until a full restart finally surfaced it during the #156 deploy (cascade with #162).
* This PR removes the `/soc/` static-serving block from the soc-web snippet — the inline block in webui.conf is canonical. The unique `/api/v1/soc-gateway/` proxy is preserved.

## Operator note

Existing boards may still carry an orphan `/etc/nginx/secubox.d/soc.conf` from a previously-removed package — no current package owns it, so it must be cleaned manually.

## Test plan

- [x] Nginx syntax conceptually: only the duplicate is removed, the unique proxy is unchanged.
- [ ] Upgrade test on a board: install 1.1.1 over 1.1.0 → `nginx -t` passes (assuming no orphan `soc.conf`).
- [ ] `curl https://admin/soc/` still serves the dashboard (via `webui.conf` inline alias).

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)