### PR TITLE
feat(secubox-mitmproxy): cookie-audit hardening — AppArmor + logrotate (#170)

### DIFF
--- a/packages/secubox-mitmproxy/debian/changelog
+++ b/packages/secubox-mitmproxy/debian/changelog
@@ -1,3 +1,16 @@
+secubox-mitmproxy (1.0.1-1~bookworm1) bookworm; urgency=medium
+
+  * Add cookie audit AppArmor abstraction at
+    /etc/apparmor.d/abstractions/secubox-cookie-audit — operators with
+    an enforced mitmdump profile include this to grant rw on
+    /var/log/secubox/cookie-audit/** and /var/lib/secubox/cookie-audit/**.
+  * Add /etc/logrotate.d/secubox-cookie-audit — daily rotation of the
+    JSONL ledger, 14 days kept, 50M maxsize, copytruncate so the running
+    addon keeps the same fd open.
+  * Closes: #170 (ref #156)
+
+ -- Gerald KERMA <devel@cybermind.fr>  Sun, 17 May 2026 08:37:01 +0200
+
 secubox-mitmproxy (1.0.0-1~bookworm1) bookworm; urgency=medium
 
   * Initial release

--- a/packages/secubox-mitmproxy/debian/cookie-audit.apparmor
+++ b/packages/secubox-mitmproxy/debian/cookie-audit.apparmor
@@ -1,0 +1,18 @@
+# AppArmor abstraction for the cookie_audit addon (issue #156).
+# Include this from any /etc/apparmor.d/usr.bin.mitmdump profile that
+# enforces mitmproxy with the SecuBox cookie audit addon loaded.
+#
+# Usage in a profile:
+#   #include <abstractions/secubox-cookie-audit>
+#
+# Or paste these lines directly inside the profile body.
+
+  # JSONL ledger written by the addon — append + rotate
+  /var/log/secubox/cookie-audit/ rw,
+  /var/log/secubox/cookie-audit/server.jsonl rwk,
+  /var/log/secubox/cookie-audit/server.jsonl.* rwk,
+
+  # Optional ingest store mirror inside the LXC (kept for future
+  # cross-LXC aggregation; aggregator side actually lives on host)
+  /var/lib/secubox/cookie-audit/ rw,
+  /var/lib/secubox/cookie-audit/** rwk,

--- a/packages/secubox-mitmproxy/debian/cookie-audit.logrotate
+++ b/packages/secubox-mitmproxy/debian/cookie-audit.logrotate
@@ -1,0 +1,13 @@
+# Rotate the cookie_audit JSONL ledger (issue #156).
+# Install path inside the mitmproxy LXC: /etc/logrotate.d/secubox-cookie-audit
+/var/log/secubox/cookie-audit/server.jsonl {
+    daily
+    rotate 14
+    maxsize 50M
+    missingok
+    notifempty
+    compress
+    delaycompress
+    copytruncate
+    create 0644 mitmproxy mitmproxy
+}

--- a/packages/secubox-mitmproxy/debian/rules
+++ b/packages/secubox-mitmproxy/debian/rules
@@ -21,3 +21,10 @@ override_dh_auto_install:
 	install -m 644 debian/secubox-mitmproxy.service $(CURDIR)/debian/secubox-mitmproxy/usr/lib/systemd/system/
 	install -d $(CURDIR)/debian/secubox-mitmproxy/etc/nginx/secubox.d
 	install -m 644 nginx/mitmproxy.conf $(CURDIR)/debian/secubox-mitmproxy/etc/nginx/secubox.d/
+	# Cookie audit (issue #156) hardening — AppArmor abstraction + logrotate (issue #170)
+	install -d $(CURDIR)/debian/secubox-mitmproxy/etc/apparmor.d/abstractions
+	install -m 644 debian/cookie-audit.apparmor \
+	  $(CURDIR)/debian/secubox-mitmproxy/etc/apparmor.d/abstractions/secubox-cookie-audit
+	install -d $(CURDIR)/debian/secubox-mitmproxy/etc/logrotate.d
+	install -m 644 debian/cookie-audit.logrotate \
+	  $(CURDIR)/debian/secubox-mitmproxy/etc/logrotate.d/secubox-cookie-audit


### PR DESCRIPTION
## Summary

Two post-deploy hardening artifacts for the #156 cookie-audit pipeline:

* `/etc/apparmor.d/abstractions/secubox-cookie-audit` — includable abstraction granting rw on the ledger + ingest paths. No-op when no profile enforces.
* `/etc/logrotate.d/secubox-cookie-audit` — daily rotation, 14 days, 50M maxsize, copytruncate.

Closes #170 (ref #156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)