### PR TITLE
fix(secubox-metrics): VisitorOrigin CAP_NET_ADMIN + DB-IP fallback (#194)

### DIFF
--- a/packages/secubox-metrics/bin/secubox-geoipupdate-fetch
+++ b/packages/secubox-metrics/bin/secubox-geoipupdate-fetch
@@ -1,0 +1,49 @@
+#!/bin/bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+#
+# secubox-geoipupdate-fetch — refresh /var/lib/GeoIP/GeoLite2-ASN.mmdb
+#
+# Two paths (#194):
+#   1. If /etc/secubox/secrets/maxmind.conf exists AND `geoipupdate` is
+#      installed, use the MaxMind GeoLite2 download (operator has a key).
+#   2. Otherwise fall back to DB-IP free ASN lite, no signup required.
+#      Format is MaxMind-compatible — the visitor_origin aggregator reads
+#      it with `maxminddb.open_database` transparently.
+#
+# Invoked by secubox-geoipupdate.service (weekly timer).
+set -euo pipefail
+
+MMDB_DEST="/var/lib/GeoIP/GeoLite2-ASN.mmdb"
+MAXMIND_CONF="/etc/secubox/secrets/maxmind.conf"
+DBIP_URL_BASE="https://download.db-ip.com/free"
+
+log() { echo "[geoipupdate-fetch] $*"; }
+err() { echo "[geoipupdate-fetch] ERROR: $*" >&2; }
+
+install -d -m 755 /var/lib/GeoIP
+
+if [ -f "$MAXMIND_CONF" ] && command -v geoipupdate >/dev/null 2>&1; then
+    log "MaxMind license + geoipupdate present — using MaxMind path"
+    exec geoipupdate -f "$MAXMIND_CONF" -d /var/lib/GeoIP
+fi
+
+log "no MaxMind license (or geoipupdate missing) — falling back to DB-IP free"
+MONTH=$(date +%Y-%m)
+URL="${DBIP_URL_BASE}/dbip-asn-lite-${MONTH}.mmdb.gz"
+TMP=$(mktemp)
+TMP_GZ="${TMP}.gz"
+trap 'rm -f "$TMP" "$TMP_GZ"' EXIT
+
+log "GET $URL"
+if ! curl -fsSL -o "$TMP_GZ" "$URL"; then
+    err "DB-IP download failed; trying previous month as fallback"
+    LAST_MONTH=$(date -d "${MONTH}-01 -1 day" +%Y-%m 2>/dev/null || date -v-1m +%Y-%m)
+    URL="${DBIP_URL_BASE}/dbip-asn-lite-${LAST_MONTH}.mmdb.gz"
+    log "GET $URL"
+    curl -fsSL -o "$TMP_GZ" "$URL"
+fi
+
+gunzip -f "$TMP_GZ"   # writes $TMP
+install -m 644 -o secubox -g secubox "$TMP" "$MMDB_DEST"
+log "installed $MMDB_DEST ($(stat -c %s "$MMDB_DEST") bytes)"

--- a/packages/secubox-metrics/debian/changelog
+++ b/packages/secubox-metrics/debian/changelog
@@ -1,3 +1,24 @@
+secubox-metrics (1.0.3-1~bookworm1) bookworm; urgency=medium
+
+  * VisitorOrigin: add AmbientCapabilities=CAP_NET_ADMIN to the systemd
+    unit (#194, latent since #92). Without this the aggregator runs as
+    secubox user, `nft -j list set inet secubox_metrics seen_src` returns
+    EPERM, _read_nft_set silently returns [] and entries stays empty
+    forever. Caps coexist with NoNewPrivileges=true.
+
+  * secubox-geoipupdate: drop the ConditionPathExists=/etc/secubox/
+    secrets/maxmind.conf gate. New helper `secubox-geoipupdate-fetch`
+    tries MaxMind first if a license is present, else falls back to
+    DB-IP free ASN lite (https://download.db-ip.com/free/dbip-asn-lite-
+    YYYY-MM.mmdb.gz). DB-IP releases mmdb in MaxMind-compatible format
+    so the visitor_origin aggregator reads it transparently.
+
+  * Operators get VisitorOrigin out of the box now (no MaxMind account
+    required); those with a license keep using MaxMind via the same
+    helper.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Mon, 18 May 2026 06:16:28 +0200
+
 secubox-metrics (1.0.2-1~bookworm1) bookworm; urgency=medium
 
   * Add Cookie Audit (RGPD / ePrivacy) endpoints: POST /api/v1/cookie-audit/ingest,

--- a/packages/secubox-metrics/debian/rules
+++ b/packages/secubox-metrics/debian/rules
@@ -39,3 +39,7 @@ override_dh_install:
 	    debian/secubox-metrics/lib/systemd/system/secubox-geoipupdate.service
 	install -D -m 0644 systemd/secubox-geoipupdate.timer \
 	    debian/secubox-metrics/lib/systemd/system/secubox-geoipupdate.timer
+	# Helper fetcher (#194): tries MaxMind first if license present,
+	# else falls back to DB-IP free ASN lite (no signup required).
+	install -D -m 0755 bin/secubox-geoipupdate-fetch \
+	    debian/secubox-metrics/usr/bin/secubox-geoipupdate-fetch

--- a/packages/secubox-metrics/debian/secubox-metrics.service
+++ b/packages/secubox-metrics/debian/secubox-metrics.service
@@ -27,6 +27,13 @@ RestartSec=5
 # ProtectSystem=full
 NoNewPrivileges=true
 ReadWritePaths=/run/secubox /var/cache/secubox
+# VisitorOrigin reads the nft `seen_src` set via `nft -j list set ...` which
+# requires CAP_NET_ADMIN. Without it, _read_nft_set silently returns [] and
+# the aggregator emits empty entries forever (#194 fix, latent since #92).
+# Coexists with NoNewPrivileges=true because systemd sets the ambient set
+# before the User= drop.
+AmbientCapabilities=CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_ADMIN
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/secubox-metrics/systemd/secubox-geoipupdate.service
+++ b/packages/secubox-metrics/systemd/secubox-geoipupdate.service
@@ -1,14 +1,15 @@
 [Unit]
-Description=SecuBox — refresh GeoLite2 ASN database
-ConditionPathExists=/etc/secubox/secrets/maxmind.conf
+Description=SecuBox — refresh GeoLite2-ASN database (MaxMind or DB-IP fallback)
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=oneshot
-User=secubox
-Group=secubox
-ExecStart=/usr/bin/geoipupdate -f /etc/secubox/secrets/maxmind.conf -d /var/lib/GeoIP
-NoNewPrivileges=true
+# Fetcher must run as root because /var/lib/GeoIP is owned by root and the
+# DB-IP fallback path uses `install -o secubox` to land the mmdb under the
+# correct ownership. The helper does not exec anything as root that takes
+# untrusted input.
+User=root
+ExecStart=/usr/bin/secubox-geoipupdate-fetch
 ProtectSystem=full
 ReadWritePaths=/var/lib/GeoIP


### PR DESCRIPTION
Closes #194. Two latent bugs since #92 that together made VisitorOrigin emit empty entries forever. Live-tested on gk2 — surfaces real ASN traffic post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)