### PR TITLE
feat(eye-remote): /api/v1/health alias for round dashboard probe (closes #197)

### DIFF
--- a/packages/secubox-eye-remote/api/main.py
+++ b/packages/secubox-eye-remote/api/main.py
@@ -354,8 +354,15 @@ async def get_paired_devices():
 
 
 @app.get("/health")
+@app.get("/api/v1/health")
 async def health():
-    """Health check endpoint."""
+    """Health check endpoint.
+
+    Exposed at both /health (root) and /api/v1/health (versioned) — the
+    Round UI dashboard probes the versioned path on OTG connect and uses
+    a 200 reply as the "API reachable" signal that flips the badge from
+    offline / SIM → ● OTG (ref #197).
+    """
     return {"status": "ok", "service": "secubox-eye-remote"}
 
 

--- a/packages/secubox-eye-remote/tests/integration/test_health_endpoints.py
+++ b/packages/secubox-eye-remote/tests/integration/test_health_endpoints.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+"""SecuBox-Deb :: /health + /api/v1/health smoke tests (issue #197).
+
+The Round UI dashboard (remote-ui/round/index.html) probes the host API
+on first OTG connect:
+
+    fetch http://10.55.0.1:8000/api/v1/health  timeout=2s
+
+A 200 here is the signal that flips the badge from offline / SIM → OTG.
+"""
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+def test_health_root_returns_200():
+    client = TestClient(app)
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["service"] == "secubox-eye-remote"
+
+
+def test_health_v1_returns_200():
+    """Round dashboard probe path — must succeed for OTG online state."""
+    client = TestClient(app)
+    r = client.get("/api/v1/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+
+
+def test_health_root_and_v1_return_same_payload():
+    """The two routes must alias to the same handler so any client that
+    reads the response body sees identical fields."""
+    client = TestClient(app)
+    a = client.get("/health").json()
+    b = client.get("/api/v1/health").json()
+    assert a == b


### PR DESCRIPTION
## Summary

The Round UI dashboard probes \`http://10.55.0.1:8000/api/v1/health\` on OTG connect to decide between offline / OTG / WiFi / SIM transport modes. The MOCHAbin's eye-remote API only exposed \`/health\` at the root path, so the probe returned 404 and the dashboard stayed offline even with a working USB gadget link.

Three-line change: stack \`/api/v1/health\` on the existing \`health()\` handler so both routes return the same payload.

## Test plan

- [x] \`pytest tests/integration/test_health_endpoints.py\` — 3/3 passing (root 200, v1 200, identical payloads)
- [ ] Deploy on 192.168.1.200: \`bash scripts/deploy.sh secubox-eye-remote root@192.168.1.200\`
- [ ] \`curl http://10.55.0.1:8000/api/v1/health\` → 200
- [ ] Round dashboard transitions ● OTG (was stuck offline)

Closes #197.