### PR TITLE
feat(droplet): static-publisher CLI dropletctl — port from OpenWrt (closes #196)

### DIFF
--- a/docs/superpowers/plans/2026-05-18-dropletctl.md
+++ b/docs/superpowers/plans/2026-05-18-dropletctl.md
@@ -1,0 +1,1230 @@
+# dropletctl CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `/usr/sbin/dropletctl` in the `secubox-droplet` Debian package — port the OpenWrt CLI to Debian conventions so the existing FastAPI consumer can finally publish, remove, rename, and list droplet sites.
+
+**Architecture:** A ~180-line bash orchestrator at `packages/secubox-droplet/sbin/dropletctl`. It validates input, sanitizes names, stages content (HTML / `.zip` / `.tar.gz` / `.tgz`), writes a `[sites.<name>]` block to `/etc/secubox/droplet.toml`, then delegates all nginx + HAProxy + mitmproxy work to `metablogizerctl site publish <name>`. Tests are bats unit cases with PATH-shimmed delegate stubs in `tests/fixtures/bin/`. Packaging updates: install line in `debian/rules`, `Depends:` bump in `debian/control`, changelog bump `1.0.1 → 1.1.0`.
+
+**Tech Stack:** bash 5 (strict mode), bats-core for tests, python3 stdlib (`tomllib` read + manual TOML emission for write), `rsync`, `unzip`, `tar`, `logger`, GNU `find`. Reference: OpenWrt source `/home/reepost/CyberMindStudio/secubox-openwrt/package/secubox/secubox-app-droplet/files/usr/sbin/dropletctl`. Spec: `docs/superpowers/specs/2026-05-18-dropletctl-design.md` (commit `5e6e1d83`).
+
+---
+
+## File structure
+
+```
+packages/secubox-droplet/
+├── sbin/
+│   └── dropletctl                            ← NEW: ~180-line bash CLI
+├── tests/
+│   ├── test_dropletctl.bats                  ← NEW: 10 bats cases
+│   ├── helpers.bash                          ← NEW: setup_suite, stub bin dir, fixture gen
+│   └── fixtures/
+│       └── bin/
+│           ├── metablogizerctl               ← NEW: stub (logs args, exit 0)
+│           └── logger                        ← NEW: stub (no-op, exit 0)
+└── debian/
+    ├── rules                                 ← MODIFY: + sbin/ install block
+    ├── control                               ← MODIFY: + secubox-metablogizer dep
+    └── changelog                             ← MODIFY: bump 1.0.1 → 1.1.0
+```
+
+**Spec deviation noted:** the spec said `Depends: secubox-metablogizer (>= 2.0.0)` but live `metablogizer` is at `1.1.1-1~bookworm1`. This plan uses `>= 1.1` so apt doesn't refuse to install.
+
+---
+
+## Task 1: Bats infrastructure + fixtures + delegate stubs
+
+**Files:**
+- Create: `packages/secubox-droplet/tests/helpers.bash`
+- Create: `packages/secubox-droplet/tests/fixtures/bin/metablogizerctl`
+- Create: `packages/secubox-droplet/tests/fixtures/bin/logger`
+- Create: `packages/secubox-droplet/tests/test_dropletctl.bats`
+
+- [ ] **Step 1: Create the metablogizerctl stub**
+
+```bash
+mkdir -p packages/secubox-droplet/tests/fixtures/bin
+cat > packages/secubox-droplet/tests/fixtures/bin/metablogizerctl <<'EOF'
+#!/usr/bin/env bash
+# Stub for bats tests — logs args to $STUB_LOG, exit 0 unless STUB_METABLOGIZERCTL_FAIL=1.
+printf 'metablogizerctl %s\n' "$*" >> "${STUB_LOG:-/dev/null}"
+if [[ "${STUB_METABLOGIZERCTL_FAIL:-0}" = "1" ]]; then
+    echo "stub: forced failure" >&2
+    exit 1
+fi
+exit 0
+EOF
+chmod +x packages/secubox-droplet/tests/fixtures/bin/metablogizerctl
+```
+
+- [ ] **Step 2: Create the logger stub**
+
+```bash
+cat > packages/secubox-droplet/tests/fixtures/bin/logger <<'EOF'
+#!/usr/bin/env bash
+# Stub for bats tests — logs args, exit 0.
+printf 'logger %s\n' "$*" >> "${STUB_LOG:-/dev/null}"
+exit 0
+EOF
+chmod +x packages/secubox-droplet/tests/fixtures/bin/logger
+```
+
+- [ ] **Step 3: Create the helpers.bash test fixture-bootstrap**
+
+```bash
+cat > packages/secubox-droplet/tests/helpers.bash <<'EOF'
+#!/usr/bin/env bash
+# Shared bats helpers for dropletctl tests.
+
+# REPO_ROOT = top of the git checkout. PACKAGE_ROOT = packages/secubox-droplet/.
+export REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+export PACKAGE_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+export DROPLETCTL="$PACKAGE_ROOT/sbin/dropletctl"
+
+setup() {
+    # Per-test temp dir; gone after teardown.
+    TMP="$(mktemp -d "${BATS_TMPDIR}/droplet.XXXXXX")"
+    export TMP
+    export STUB_LOG="$TMP/stub.log"
+    export SITES_DIR="$TMP/srv/metablogizer/sites"
+    export TOML_PATH="$TMP/etc/secubox/droplet.toml"
+    mkdir -p "$SITES_DIR" "$(dirname "$TOML_PATH")"
+    : > "$STUB_LOG"
+    # Empty TOML scaffold — dropletctl creates [sites.<name>] sections in it.
+    printf '[droplet]\ndefault_domain = "gk2.secubox.in"\n' > "$TOML_PATH"
+    # PATH-shim the delegate stubs.
+    export PATH="$PACKAGE_ROOT/tests/fixtures/bin:$PATH"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+# Generate a 1-file HTML fixture at $1.
+make_html() {
+    local out="$1"
+    printf '<!doctype html><html><body><h1>fixture</h1></body></html>\n' > "$out"
+}
+
+# Generate a zip fixture with one nested top-level dir.
+make_zip_nested() {
+    local out="$1" workdir
+    workdir="$(mktemp -d "$TMP/mkzip.XXXXXX")"
+    mkdir "$workdir/site"
+    make_html "$workdir/site/index.html"
+    printf 'body { color: red; }\n' > "$workdir/site/style.css"
+    ( cd "$workdir" && zip -qr "$out" site )
+    rm -rf "$workdir"
+}
+
+# Generate a tarball fixture with one nested top-level dir.
+make_tarball_nested() {
+    local out="$1" workdir
+    workdir="$(mktemp -d "$TMP/mktar.XXXXXX")"
+    mkdir "$workdir/site"
+    make_html "$workdir/site/index.html"
+    printf 'body { color: red; }\n' > "$workdir/site/style.css"
+    ( cd "$workdir" && tar -czf "$out" site )
+    rm -rf "$workdir"
+}
+EOF
+```
+
+- [ ] **Step 4: Create the bats file with a single smoke test**
+
+```bash
+cat > packages/secubox-droplet/tests/test_dropletctl.bats <<'EOF'
+#!/usr/bin/env bats
+
+load helpers
+
+@test "dropletctl with no args prints usage" {
+    run "$DROPLETCTL"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage:" ]] || [[ "$output" =~ "dropletctl" ]]
+}
+EOF
+```
+
+- [ ] **Step 5: Verify bats picks up the suite (test will fail — dropletctl doesn't exist yet)**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: 1 test ran, FAIL with "DROPLETCTL: command not found" or "permission denied". This proves the harness loads.
+
+- [ ] **Step 6: Create the dropletctl skeleton so the smoke test passes**
+
+```bash
+mkdir -p packages/secubox-droplet/sbin
+cat > packages/secubox-droplet/sbin/dropletctl <<'EOF'
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+# SecuBox-Deb :: dropletctl — droplet content publisher (port from OpenWrt)
+set -euo pipefail
+
+readonly MODULE="dropletctl"
+readonly VERSION="1.1.0"
+
+case "${1:-}" in
+    "" | -h | --help)
+        cat <<USAGE
+Droplet Publisher — One-drop static-content publishing
+Usage: dropletctl <command> [args]
+
+Commands:
+  publish <file> <name> [domain]   Publish HTML/ZIP/tarball as a site
+  list                             List published droplets
+  remove <name>                    Remove a droplet
+  rename <old> <new>               Rename a droplet
+USAGE
+        exit 0
+        ;;
+    *)
+        echo "[ERROR] unknown subcommand: $1" >&2
+        exit 1
+        ;;
+esac
+EOF
+chmod +x packages/secubox-droplet/sbin/dropletctl
+```
+
+- [ ] **Step 7: Run bats to confirm green**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: `1 test, 0 failures`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/secubox-droplet/sbin/dropletctl \
+        packages/secubox-droplet/tests/helpers.bash \
+        packages/secubox-droplet/tests/test_dropletctl.bats \
+        packages/secubox-droplet/tests/fixtures/bin/metablogizerctl \
+        packages/secubox-droplet/tests/fixtures/bin/logger
+git commit -m "feat(droplet): scaffold dropletctl CLI + bats harness (ref #196)"
+```
+
+---
+
+## Task 2: publish argument validation (TDD: 3 error cases)
+
+**Files:**
+- Modify: `packages/secubox-droplet/sbin/dropletctl`
+- Modify: `packages/secubox-droplet/tests/test_dropletctl.bats`
+
+- [ ] **Step 1: Add 3 failing tests for argument validation**
+
+Append to `packages/secubox-droplet/tests/test_dropletctl.bats`:
+
+```bash
+@test "publish with no args exits 1 with Usage" {
+    run "$DROPLETCTL" publish
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Usage" ]]
+}
+
+@test "publish with missing file exits 1" {
+    run "$DROPLETCTL" publish "$TMP/does-not-exist.html" foo
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "not found" ]]
+}
+
+@test "publish with unsupported extension exits 1" {
+    : > "$TMP/bad.xyz"
+    run "$DROPLETCTL" publish "$TMP/bad.xyz" foo
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Unsupported file type" ]]
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: 4 tests, 3 failures (the new ones — dropletctl returns "unknown subcommand").
+
+- [ ] **Step 3: Implement publish dispatch + validation**
+
+Replace the `case` block in `packages/secubox-droplet/sbin/dropletctl` with:
+
+```bash
+case "${1:-}" in
+    "" | -h | --help)
+        cat <<USAGE
+Droplet Publisher — One-drop static-content publishing
+Usage: dropletctl <command> [args]
+
+Commands:
+  publish <file> <name> [domain]   Publish HTML/ZIP/tarball as a site
+  list                             List published droplets
+  remove <name>                    Remove a droplet
+  rename <old> <new>               Rename a droplet
+USAGE
+        exit 0
+        ;;
+    publish)
+        shift
+        cmd_publish "$@"
+        ;;
+    *)
+        echo "[ERROR] unknown subcommand: $1" >&2
+        exit 1
+        ;;
+esac
+```
+
+And add this function *above* the `case` block:
+
+```bash
+cmd_publish() {
+    local file="${1:-}"
+    local name="${2:-}"
+    local domain="${3:-}"
+
+    if [[ -z "$file" ]] || [[ -z "$name" ]]; then
+        echo "[ERROR] Usage: dropletctl publish <file> <name> [domain]" >&2
+        exit 1
+    fi
+    if [[ ! -e "$file" ]]; then
+        echo "[ERROR] not found: $file" >&2
+        exit 1
+    fi
+
+    local ext="${file##*.}"
+    ext="${ext,,}"  # bash 4 lowercase
+    # Handle .tar.gz double-extension
+    if [[ "$file" == *.tar.gz ]]; then ext="tar.gz"; fi
+
+    case "$ext" in
+        html|htm|zip|tgz|tar.gz)
+            : ;;
+        *)
+            echo "[ERROR] Unsupported file type: .$ext (expected .html .htm .zip .tar.gz .tgz)" >&2
+            exit 1
+            ;;
+    esac
+
+    # Stub — actual staging arrives in later tasks.
+    echo "[OK] (stub) would publish $file as $name"
+    echo "${name}.${domain:-gk2.secubox.in}"
+}
+```
+
+- [ ] **Step 4: Run tests to verify the 3 new ones pass**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: `4 tests, 0 failures`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/secubox-droplet/sbin/dropletctl \
+        packages/secubox-droplet/tests/test_dropletctl.bats
+git commit -m "feat(droplet): publish arg validation (3 error cases) (ref #196)"
+```
+
+---
+
+## Task 3: name sanitization + single HTML happy path
+
+**Files:**
+- Modify: `packages/secubox-droplet/sbin/dropletctl`
+- Modify: `packages/secubox-droplet/tests/test_dropletctl.bats`
+
+- [ ] **Step 1: Add 2 failing tests for HTML publish + name sanitization**
+
+Append to `packages/secubox-droplet/tests/test_dropletctl.bats`:
+
+```bash
+@test "publish a single HTML stages it and delegates to metablogizerctl" {
+    make_html "$TMP/page.html"
+
+    run "$DROPLETCTL" publish "$TMP/page.html" mysite mydomain.test
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "[OK]" ]]
+    # API parses last stdout line as vhost.
+    last_line="$(printf '%s\n' "$output" | tail -1)"
+    [ "$last_line" = "mysite.mydomain.test" ]
+    # Docroot has the staged file.
+    [ -f "$SITES_DIR/mysite/index.html" ]
+    grep -q "fixture" "$SITES_DIR/mysite/index.html"
+    # Delegate was called with the right args.
+    grep -q "metablogizerctl site publish mysite" "$STUB_LOG"
+}
+
+@test "publish sanitizes uppercase + special chars in name" {
+    make_html "$TMP/page.html"
+
+    run "$DROPLETCTL" publish "$TMP/page.html" "MyCool Site!" mydomain.test
+    [ "$status" -eq 0 ]
+    last_line="$(printf '%s\n' "$output" | tail -1)"
+    [ "$last_line" = "mycool_site_.mydomain.test" ]
+    [ -d "$SITES_DIR/mycool_site_" ]
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: 6 tests, 2 failures (the HTML stage / delegate / docroot checks fail because cmd_publish is still a stub).
+
+- [ ] **Step 3: Implement name sanitization + HTML staging + delegate call**
+
+Replace `cmd_publish` in `packages/secubox-droplet/sbin/dropletctl` with the full implementation:
+
+```bash
+# Environment overrides for tests (default to production paths if unset).
+: "${SITES_DIR:=/srv/metablogizer/sites}"
+: "${TOML_PATH:=/etc/secubox/droplet.toml}"
+: "${LOG_TAG:=droplet}"
+
+log_info()  { logger -t "$LOG_TAG" -p user.info  "$*" 2>/dev/null || true; echo "[INFO] $*"; }
+log_error() { logger -t "$LOG_TAG" -p user.error "$*" 2>/dev/null || true; echo "[ERROR] $*" >&2; }
+log_ok()    { echo "[OK] $*"; }
+
+# Lowercase + replace non-[a-z0-9_-] with '_'. Empty result -> caller errors.
+sanitize_name() {
+    printf '%s' "$1" | awk '{print tolower($0)}' | sed 's/[^a-z0-9_-]/_/g'
+}
+
+# Read default_domain from droplet.toml. Falls back to gk2.secubox.in.
+default_domain() {
+    [[ -r "$TOML_PATH" ]] || { echo "gk2.secubox.in"; return; }
+    local v
+    v=$(grep -E '^default_domain\s*=' "$TOML_PATH" 2>/dev/null \
+        | head -1 | sed -E 's/^default_domain\s*=\s*"?([^"]*)"?\s*$/\1/')
+    echo "${v:-gk2.secubox.in}"
+}
+
+# Stage <src> into a fresh temp dir. Echoes the staging dir path.
+stage_content() {
+    local src="$1"
+    local staging
+    staging="$(mktemp -d /tmp/droplet.XXXXXX)"
+
+    local ext="${src##*.}"
+    ext="${ext,,}"
+    if [[ "$src" == *.tar.gz ]]; then ext="tar.gz"; fi
+
+    case "$ext" in
+        html|htm)
+            cp "$src" "$staging/index.html"
+            ;;
+        zip|tgz|tar.gz)
+            log_error "extraction not implemented yet"
+            rm -rf "$staging"
+            exit 3
+            ;;
+    esac
+
+    echo "$staging"
+}
+
+cmd_publish() {
+    local file="${1:-}"
+    local name_raw="${2:-}"
+    local domain="${3:-$(default_domain)}"
+
+    if [[ -z "$file" ]] || [[ -z "$name_raw" ]]; then
+        echo "[ERROR] Usage: dropletctl publish <file> <name> [domain]" >&2
+        exit 1
+    fi
+    if [[ ! -e "$file" ]]; then
+        echo "[ERROR] not found: $file" >&2
+        exit 1
+    fi
+
+    local ext="${file##*.}"; ext="${ext,,}"
+    [[ "$file" == *.tar.gz ]] && ext="tar.gz"
+    case "$ext" in
+        html|htm|zip|tgz|tar.gz) : ;;
+        *)
+            echo "[ERROR] Unsupported file type: .$ext (expected .html .htm .zip .tar.gz .tgz)" >&2
+            exit 1
+            ;;
+    esac
+
+    local name; name="$(sanitize_name "$name_raw")"
+    if [[ -z "$name" ]]; then
+        echo "[ERROR] Invalid name '$name_raw'" >&2
+        exit 2
+    fi
+
+    local vhost="${name}.${domain}"
+    local staging; staging="$(stage_content "$file")"
+    trap 'rm -rf "$staging"' EXIT
+
+    log_info "Publishing: $file as $vhost"
+
+    # Permissions: 644 files, 755 dirs.
+    find "$staging" -type f -exec chmod 644 {} +
+    find "$staging" -type d -exec chmod 755 {} +
+
+    # Deploy to /srv/metablogizer/sites/<name>/ (idempotent overwrite).
+    mkdir -p "$SITES_DIR/$name"
+    rsync -a --delete "$staging"/ "$SITES_DIR/$name"/
+
+    # Upsert TOML entry. Section format: [sites.<name>] domain="<d>" type="static".
+    upsert_toml_site "$name" "$domain" "static"
+
+    # Delegate the HTTP-facing work.
+    if ! command -v metablogizerctl >/dev/null 2>&1; then
+        log_error "metablogizerctl not found — install secubox-metablogizer"
+        exit 4
+    fi
+    if ! metablogizerctl site publish "$name"; then
+        log_error "metablogizerctl failed for $name"
+        exit 5
+    fi
+
+    log_ok "Published: https://$vhost/"
+    echo "$vhost"
+}
+
+# Upsert [sites.<name>] section. Uses python3 for safe TOML rewrite.
+upsert_toml_site() {
+    local name="$1" domain="$2" type="$3"
+    python3 - "$TOML_PATH" "$name" "$domain" "$type" <<'PY'
+import sys, re, os, tempfile
+
+path, name, domain, type_ = sys.argv[1:]
+section = f"[sites.{name}]"
+new_block = f'{section}\ndomain = "{domain}"\ntype = "{type_}"\n'
+
+if os.path.exists(path):
+    with open(path) as f:
+        content = f.read()
+else:
+    content = ""
+
+# Match the section + its body up to the next [section] or EOF.
+pattern = re.compile(
+    rf'^{re.escape(section)}\s*\n(?:(?!^\[).*\n?)*',
+    flags=re.MULTILINE,
+)
+if pattern.search(content):
+    new_content = pattern.sub(new_block, content)
+else:
+    if content and not content.endswith('\n'):
+        content += '\n'
+    if content and not content.endswith('\n\n'):
+        content += '\n'
+    new_content = content + new_block
+
+# Atomic write.
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or '.', prefix='.droplet.', suffix='.toml')
+os.write(fd, new_content.encode())
+os.close(fd)
+os.replace(tmp, path)
+PY
+}
+```
+
+- [ ] **Step 4: Run tests to verify all 6 pass**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: `6 tests, 0 failures`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/secubox-droplet/sbin/dropletctl \
+        packages/secubox-droplet/tests/test_dropletctl.bats
+git commit -m "feat(droplet): name sanitization + HTML staging + metablogizerctl delegation (ref #196)"
+```
+
+---
+
+## Task 4: ZIP extraction with nested-dir unwrap
+
+**Files:**
+- Modify: `packages/secubox-droplet/sbin/dropletctl`
+- Modify: `packages/secubox-droplet/tests/test_dropletctl.bats`
+
+- [ ] **Step 1: Add failing test for ZIP publish with nested top-level dir**
+
+Append to `packages/secubox-droplet/tests/test_dropletctl.bats`:
+
+```bash
+@test "publish a zip with one nested top dir unwraps it" {
+    make_zip_nested "$TMP/site.zip"
+
+    run "$DROPLETCTL" publish "$TMP/site.zip" zipsite mydomain.test
+    [ "$status" -eq 0 ]
+    # Unwrapped: NOT $SITES_DIR/zipsite/site/index.html, but directly:
+    [ -f "$SITES_DIR/zipsite/index.html" ]
+    [ -f "$SITES_DIR/zipsite/style.css" ]
+    # Nested wrapper dir is gone.
+    [ ! -d "$SITES_DIR/zipsite/site" ]
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: 7 tests, 1 failure (the ZIP path hits the stubbed "extraction not implemented" exit 3).
+
+- [ ] **Step 3: Implement ZIP extraction with unwrap**
+
+Replace the `stage_content` function in `packages/secubox-droplet/sbin/dropletctl` with:
+
+```bash
+# Stage <src> into a fresh temp dir. Echoes the staging dir path.
+stage_content() {
+    local src="$1"
+    local staging
+    staging="$(mktemp -d /tmp/droplet.XXXXXX)"
+
+    local ext="${src##*.}"
+    ext="${ext,,}"
+    if [[ "$src" == *.tar.gz ]]; then ext="tar.gz"; fi
+
+    case "$ext" in
+        html|htm)
+            cp "$src" "$staging/index.html"
+            ;;
+        zip)
+            if ! unzip -q "$src" -d "$staging"; then
+                log_error "Failed to extract zip: $src"
+                rm -rf "$staging"
+                exit 3
+            fi
+            unwrap_single_nested "$staging"
+            ;;
+        tgz|tar.gz)
+            log_error "tarball extraction not implemented yet"
+            rm -rf "$staging"
+            exit 3
+            ;;
+    esac
+
+    echo "$staging"
+}
+
+# If $1 contains exactly one entry and it's a directory, move its contents up.
+unwrap_single_nested() {
+    local dir="$1"
+    local entries=("$dir"/*)
+    if [[ ${#entries[@]} -eq 1 ]] && [[ -d "${entries[0]}" ]]; then
+        local nested="${entries[0]}"
+        # Use a temp move to avoid name collision when nested basename matches dir.
+        local stash; stash="$(mktemp -d "$dir/.unwrap.XXXXXX")"
+        mv "$nested"/* "$nested"/.[!.]* "$stash"/ 2>/dev/null || true
+        rmdir "$nested"
+        mv "$stash"/* "$stash"/.[!.]* "$dir"/ 2>/dev/null || true
+        rmdir "$stash"
+    fi
+}
+```
+
+- [ ] **Step 4: Run tests to confirm all 7 pass**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: `7 tests, 0 failures`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/secubox-droplet/sbin/dropletctl \
+        packages/secubox-droplet/tests/test_dropletctl.bats
+git commit -m "feat(droplet): ZIP extraction with single-nested-dir unwrap (ref #196)"
+```
+
+---
+
+## Task 5: tarball extraction (.tar.gz / .tgz) + plain-directory input
+
+**Files:**
+- Modify: `packages/secubox-droplet/sbin/dropletctl`
+- Modify: `packages/secubox-droplet/tests/test_dropletctl.bats`
+
+- [ ] **Step 1: Add failing tests for tarball publish AND directory input**
+
+Append to `packages/secubox-droplet/tests/test_dropletctl.bats`:
+
+```bash
+@test "publish a tarball with one nested top dir unwraps it" {
+    make_tarball_nested "$TMP/site.tar.gz"
+
+    run "$DROPLETCTL" publish "$TMP/site.tar.gz" tarsite mydomain.test
+    [ "$status" -eq 0 ]
+    [ -f "$SITES_DIR/tarsite/index.html" ]
+    [ -f "$SITES_DIR/tarsite/style.css" ]
+    [ ! -d "$SITES_DIR/tarsite/site" ]
+}
+
+@test "publish a plain directory copies its tree verbatim" {
+    mkdir -p "$TMP/site_src"
+    make_html "$TMP/site_src/index.html"
+    printf 'body { color: blue; }\n' > "$TMP/site_src/style.css"
+
+    run "$DROPLETCTL" publish "$TMP/site_src" dirsite mydomain.test
+    [ "$status" -eq 0 ]
+    [ -f "$SITES_DIR/dirsite/index.html" ]
+    [ -f "$SITES_DIR/dirsite/style.css" ]
+    grep -q "fixture" "$SITES_DIR/dirsite/index.html"
+}
+```
+
+- [ ] **Step 2: Run to verify both new tests fail**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: 9 tests, 2 failures (tarball still stubbed; directory hits the extension validation as "Unsupported file type: .site_src").
+
+- [ ] **Step 3: Wire tarball extraction + add directory branch in cmd_publish**
+
+(a) In `packages/secubox-droplet/sbin/dropletctl`, replace the `tgz|tar.gz)` branch inside `stage_content`:
+
+```bash
+        tgz|tar.gz)
+            if ! tar -xzf "$src" -C "$staging"; then
+                log_error "Failed to extract tarball: $src"
+                rm -rf "$staging"
+                exit 3
+            fi
+            unwrap_single_nested "$staging"
+            ;;
+        dir)
+            # Caller passed a directory — rsync its contents verbatim.
+            rsync -a "$src"/ "$staging"/
+            ;;
+```
+
+(b) Adjust the extension-detection block in `cmd_publish` so that a directory short-circuits the `.ext` check. Replace the extension/case block in `cmd_publish` with:
+
+```bash
+    # If the path is a directory, skip extension validation entirely.
+    local ext
+    if [[ -d "$file" ]]; then
+        ext="dir"
+    else
+        ext="${file##*.}"; ext="${ext,,}"
+        [[ "$file" == *.tar.gz ]] && ext="tar.gz"
+        case "$ext" in
+            html|htm|zip|tgz|tar.gz) : ;;
+            *)
+                echo "[ERROR] Unsupported file type: .$ext (expected .html .htm .zip .tar.gz .tgz or directory)" >&2
+                exit 1
+                ;;
+        esac
+    fi
+```
+
+And in `stage_content`, the dispatch needs to also accept the `dir` synthetic ext, which the patch in (a) already wires. Confirm the `stage_content` `case "$ext" in` now reads:
+
+```bash
+    case "$ext" in
+        html|htm) ... ;;
+        zip)      ... ;;
+        tgz|tar.gz) ... ;;
+        dir)      ... ;;
+    esac
+```
+
+(c) `stage_content`'s ext-detection block currently re-derives the extension from the filename. Update it so a directory also resolves to `ext=dir`:
+
+```bash
+    local ext
+    if [[ -d "$src" ]]; then
+        ext="dir"
+    else
+        ext="${src##*.}"; ext="${ext,,}"
+        [[ "$src" == *.tar.gz ]] && ext="tar.gz"
+    fi
+```
+
+- [ ] **Step 4: Run tests to confirm all 9 pass**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: `9 tests, 0 failures`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/secubox-droplet/sbin/dropletctl \
+        packages/secubox-droplet/tests/test_dropletctl.bats
+git commit -m "feat(droplet): tarball + plain-directory input (ref #196)"
+```
+
+---
+
+## Task 6: idempotent re-publish (overwrite + no TOML duplicates)
+
+**Files:**
+- Modify: `packages/secubox-droplet/tests/test_dropletctl.bats`
+
+- [ ] **Step 1: Add failing test for double-publish idempotency**
+
+Append to `packages/secubox-droplet/tests/test_dropletctl.bats`:
+
+```bash
+@test "publish twice for same name overwrites docroot, no TOML dupes" {
+    make_html "$TMP/v1.html"
+    make_html "$TMP/v2.html"
+    # Make v2 distinguishable.
+    printf '<!doctype html><html><body><h2>v2</h2></body></html>\n' > "$TMP/v2.html"
+
+    run "$DROPLETCTL" publish "$TMP/v1.html" rev mydomain.test
+    [ "$status" -eq 0 ]
+    grep -q "fixture" "$SITES_DIR/rev/index.html"
+
+    run "$DROPLETCTL" publish "$TMP/v2.html" rev mydomain.test
+    [ "$status" -eq 0 ]
+    # v2 overwrote v1.
+    grep -q "v2" "$SITES_DIR/rev/index.html"
+    ! grep -q "fixture" "$SITES_DIR/rev/index.html"
+    # Exactly one [sites.rev] block in the TOML.
+    count="$(grep -c '^\[sites\.rev\]' "$TOML_PATH")"
+    [ "$count" = "1" ]
+}
+```
+
+- [ ] **Step 2: Run to verify the test passes already**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: `10 tests, 0 failures`. The `upsert_toml_site` from Task 3 already handles the idempotency via its regex substitution + `rsync --delete` handles the overwrite. This test pins the behavior so future refactors don't regress.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/secubox-droplet/tests/test_dropletctl.bats
+git commit -m "test(droplet): pin idempotent re-publish behavior (ref #196)"
+```
+
+---
+
+## Task 7: remove subcommand
+
+**Files:**
+- Modify: `packages/secubox-droplet/sbin/dropletctl`
+- Modify: `packages/secubox-droplet/tests/test_dropletctl.bats`
+
+- [ ] **Step 1: Add failing test for remove after publish**
+
+Append to `packages/secubox-droplet/tests/test_dropletctl.bats`:
+
+```bash
+@test "remove deletes docroot, TOML entry, and calls metablogizerctl unpublish + delete" {
+    make_html "$TMP/page.html"
+    run "$DROPLETCTL" publish "$TMP/page.html" doomed mydomain.test
+    [ "$status" -eq 0 ]
+    [ -d "$SITES_DIR/doomed" ]
+    grep -q '^\[sites\.doomed\]' "$TOML_PATH"
+
+    # Reset stub log so we only see remove's calls.
+    : > "$STUB_LOG"
+    run "$DROPLETCTL" remove doomed
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "[OK]" ]]
+    [ ! -d "$SITES_DIR/doomed" ]
+    ! grep -q '^\[sites\.doomed\]' "$TOML_PATH"
+    grep -q "metablogizerctl site unpublish doomed" "$STUB_LOG"
+    grep -q "metablogizerctl site delete doomed" "$STUB_LOG"
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: 11 tests, 1 failure (`unknown subcommand: remove`).
+
+- [ ] **Step 3: Implement cmd_remove + TOML delete helper + dispatch**
+
+In `packages/secubox-droplet/sbin/dropletctl`, add this function above the `case` block:
+
+```bash
+cmd_remove() {
+    local name_raw="${1:-}"
+    if [[ -z "$name_raw" ]]; then
+        echo "[ERROR] Usage: dropletctl remove <name>" >&2
+        exit 1
+    fi
+    local name; name="$(sanitize_name "$name_raw")"
+    if [[ -z "$name" ]]; then
+        echo "[ERROR] Invalid name '$name_raw'" >&2
+        exit 2
+    fi
+
+    if ! command -v metablogizerctl >/dev/null 2>&1; then
+        log_error "metablogizerctl not found — install secubox-metablogizer"
+        exit 4
+    fi
+    metablogizerctl site unpublish "$name" || true
+    metablogizerctl site delete "$name"    || true
+
+    rm -rf "$SITES_DIR/$name"
+    remove_toml_site "$name"
+    log_ok "Removed: $name"
+}
+
+# Drop the [sites.<name>] block from droplet.toml. No-op if not present.
+remove_toml_site() {
+    local name="$1"
+    [[ -e "$TOML_PATH" ]] || return 0
+    python3 - "$TOML_PATH" "$name" <<'PY'
+import sys, re, os, tempfile
+path, name = sys.argv[1:]
+with open(path) as f:
+    content = f.read()
+pattern = re.compile(
+    rf'^\[sites\.{re.escape(name)}\]\s*\n(?:(?!^\[).*\n?)*',
+    flags=re.MULTILINE,
+)
+new = pattern.sub('', content)
+if new == content:
+    sys.exit(0)
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or '.', prefix='.droplet.', suffix='.toml')
+os.write(fd, new.encode())
+os.close(fd)
+os.replace(tmp, path)
+PY
+}
+```
+
+Add `remove)` to the dispatch `case`:
+
+```bash
+    remove)
+        shift
+        cmd_remove "$@"
+        ;;
+```
+
+- [ ] **Step 4: Run tests to confirm all 11 pass**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: `11 tests, 0 failures`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/secubox-droplet/sbin/dropletctl \
+        packages/secubox-droplet/tests/test_dropletctl.bats
+git commit -m "feat(droplet): remove subcommand + TOML section delete (ref #196)"
+```
+
+---
+
+## Task 8: rename subcommand
+
+**Files:**
+- Modify: `packages/secubox-droplet/sbin/dropletctl`
+- Modify: `packages/secubox-droplet/tests/test_dropletctl.bats`
+
+- [ ] **Step 1: Add failing test for rename**
+
+Append to `packages/secubox-droplet/tests/test_dropletctl.bats`:
+
+```bash
+@test "rename moves docroot, swaps TOML entry, calls delete+publish on delegate" {
+    make_html "$TMP/page.html"
+    run "$DROPLETCTL" publish "$TMP/page.html" oldname mydomain.test
+    [ "$status" -eq 0 ]
+    [ -d "$SITES_DIR/oldname" ]
+
+    : > "$STUB_LOG"
+    run "$DROPLETCTL" rename oldname newname
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "[OK]" ]]
+    [ ! -d "$SITES_DIR/oldname" ]
+    [ -d "$SITES_DIR/newname" ]
+    [ -f "$SITES_DIR/newname/index.html" ]
+    ! grep -q '^\[sites\.oldname\]' "$TOML_PATH"
+    grep -q '^\[sites\.newname\]' "$TOML_PATH"
+    # Delegate called: delete old, then publish new.
+    grep -q "metablogizerctl site delete oldname" "$STUB_LOG"
+    grep -q "metablogizerctl site publish newname" "$STUB_LOG"
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: 12 tests, 1 failure (`unknown subcommand: rename`).
+
+- [ ] **Step 3: Implement cmd_rename + dispatch**
+
+In `packages/secubox-droplet/sbin/dropletctl`, add this function above the `case` block:
+
+```bash
+cmd_rename() {
+    local old_raw="${1:-}" new_raw="${2:-}"
+    if [[ -z "$old_raw" ]] || [[ -z "$new_raw" ]]; then
+        echo "[ERROR] Usage: dropletctl rename <old> <new>" >&2
+        exit 1
+    fi
+    local old new
+    old="$(sanitize_name "$old_raw")"
+    new="$(sanitize_name "$new_raw")"
+    if [[ -z "$old" ]] || [[ -z "$new" ]]; then
+        echo "[ERROR] Invalid name(s): '$old_raw' or '$new_raw'" >&2
+        exit 2
+    fi
+    if [[ ! -d "$SITES_DIR/$old" ]]; then
+        echo "[ERROR] not found: $old" >&2
+        exit 1
+    fi
+
+    # Read old domain so the new site keeps the same default unless overridden.
+    local domain
+    domain=$(grep -A2 "^\[sites\.$old\]" "$TOML_PATH" 2>/dev/null \
+        | grep -E '^domain\s*=' | head -1 \
+        | sed -E 's/^domain\s*=\s*"?([^"]*)"?\s*$/\1/')
+    domain="${domain:-$(default_domain)}"
+
+    if ! command -v metablogizerctl >/dev/null 2>&1; then
+        log_error "metablogizerctl not found — install secubox-metablogizer"
+        exit 4
+    fi
+
+    mv "$SITES_DIR/$old" "$SITES_DIR/$new"
+    remove_toml_site "$old"
+    # Compute new domain by replacing the leading <old>. prefix if present, else use original.
+    local new_domain="$domain"
+    if [[ "$domain" == "${old}."* ]]; then
+        new_domain="${new}.${domain#*.}"
+    fi
+    upsert_toml_site "$new" "$new_domain" "static"
+
+    metablogizerctl site delete "$old"  || true
+    metablogizerctl site publish "$new" || {
+        log_error "metablogizerctl failed for $new"
+        exit 5
+    }
+    log_ok "Renamed: $old -> $new"
+}
+```
+
+Add `rename)` to dispatch:
+
+```bash
+    rename)
+        shift
+        cmd_rename "$@"
+        ;;
+```
+
+- [ ] **Step 4: Run tests to confirm all 12 pass**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: `12 tests, 0 failures`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/secubox-droplet/sbin/dropletctl \
+        packages/secubox-droplet/tests/test_dropletctl.bats
+git commit -m "feat(droplet): rename subcommand (ref #196)"
+```
+
+---
+
+## Task 9: list subcommand
+
+**Files:**
+- Modify: `packages/secubox-droplet/sbin/dropletctl`
+- Modify: `packages/secubox-droplet/tests/test_dropletctl.bats`
+
+- [ ] **Step 1: Add failing test for list**
+
+Append to `packages/secubox-droplet/tests/test_dropletctl.bats`:
+
+```bash
+@test "list prints one row per [sites.<name>] in droplet.toml" {
+    make_html "$TMP/page.html"
+    run "$DROPLETCTL" publish "$TMP/page.html" first mydomain.test
+    [ "$status" -eq 0 ]
+    run "$DROPLETCTL" publish "$TMP/page.html" second mydomain.test
+    [ "$status" -eq 0 ]
+
+    run "$DROPLETCTL" list
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "first" ]]
+    [[ "$output" =~ "first.mydomain.test" ]]
+    [[ "$output" =~ "second" ]]
+    [[ "$output" =~ "second.mydomain.test" ]]
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: 13 tests, 1 failure (`unknown subcommand: list`).
+
+- [ ] **Step 3: Implement cmd_list + dispatch**
+
+In `packages/secubox-droplet/sbin/dropletctl`, add this function above the `case` block:
+
+```bash
+cmd_list() {
+    [[ -r "$TOML_PATH" ]] || { echo "(no droplets)"; return 0; }
+    python3 - "$TOML_PATH" <<'PY'
+import sys, re
+path = sys.argv[1]
+with open(path) as f:
+    content = f.read()
+# Capture [sites.<name>] then the immediate `domain = "..."` line in its block.
+section_re = re.compile(r'^\[sites\.([^\]]+)\]\s*\n((?:(?!^\[).*\n?)*)', re.MULTILINE)
+for m in section_re.finditer(content):
+    name = m.group(1)
+    body = m.group(2)
+    dm = re.search(r'^domain\s*=\s*"?([^"\n]+)"?', body, re.MULTILINE)
+    domain = dm.group(1).strip() if dm else "?"
+    print(f"{name:<30s} [ON]  https://{domain}/")
+PY
+}
+```
+
+Add `list)` to dispatch:
+
+```bash
+    list)
+        cmd_list
+        ;;
+```
+
+- [ ] **Step 4: Run tests to confirm all 13 pass**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: `13 tests, 0 failures`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/secubox-droplet/sbin/dropletctl \
+        packages/secubox-droplet/tests/test_dropletctl.bats
+git commit -m "feat(droplet): list subcommand (ref #196)"
+```
+
+---
+
+## Task 10: Debian packaging (rules + control + changelog)
+
+**Files:**
+- Modify: `packages/secubox-droplet/debian/rules`
+- Modify: `packages/secubox-droplet/debian/control`
+- Modify: `packages/secubox-droplet/debian/changelog`
+
+- [ ] **Step 1: Add the install block in `debian/rules`**
+
+Append to the existing `override_dh_auto_install:` target (after the last `cp` line):
+
+```make
+	# Install the dropletctl CLI to /usr/sbin/ (new in 1.1.0).
+	install -d debian/secubox-droplet/usr/sbin
+	install -m 0755 sbin/dropletctl debian/secubox-droplet/usr/sbin/dropletctl
+```
+
+- [ ] **Step 2: Add the metablogizer dependency in `debian/control`**
+
+Replace the `Depends:` line:
+
+```
+Depends: ${misc:Depends}, secubox-core (>= 1.0), python3-uvicorn | python3-pip, python3-aiofiles, secubox-metablogizer (>= 1.1)
+```
+
+- [ ] **Step 3: Bump the changelog**
+
+Prepend to `packages/secubox-droplet/debian/changelog`:
+
+```
+secubox-droplet (1.1.0-1~bookworm1) bookworm; urgency=medium
+
+  * Add dropletctl CLI at /usr/sbin/dropletctl (port from OpenWrt
+    secubox-app-droplet 1.0.0). Subcommands: publish, list, remove,
+    rename. Static-only (HTML / ZIP / tarball). Delegates HTTP-facing
+    work (nginx vhost, HAProxy ACL, mitmproxy route) to
+    metablogizerctl site publish.
+  * Depends: secubox-metablogizer (>= 1.1) — runtime dependency for
+    publish/unpublish/delete.
+  * Closes: #196
+
+ -- Gerald KERMA <devel@cybermind.fr>  Mon, 18 May 2026 09:00:00 +0200
+
+```
+
+(The trailing blank line is required — preserve the existing changelog below it.)
+
+- [ ] **Step 4: Sanity-check the build manifest**
+
+Run: `cd packages/secubox-droplet && dpkg-buildpackage -us -uc -b 2>&1 | tail -20`
+Expected: build succeeds; the manifest line lists `usr/sbin/dropletctl` (search the build output for `dropletctl`).
+
+If the build host doesn't have the chroot, just lint:
+Run: `cd packages/secubox-droplet && dpkg-checkbuilddeps`
+Expected: no missing deps; if any, install them.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/secubox-droplet/debian/rules \
+        packages/secubox-droplet/debian/control \
+        packages/secubox-droplet/debian/changelog
+git commit -m "build(droplet): ship dropletctl + Depends: metablogizer, bump to 1.1.0 (ref #196)"
+```
+
+---
+
+## Task 11: lint + final test sweep
+
+**Files:**
+- Touch: nothing — pure verification + commit gate
+
+- [ ] **Step 1: bash syntax check**
+
+Run: `bash -n packages/secubox-droplet/sbin/dropletctl`
+Expected: exit 0, no output.
+
+- [ ] **Step 2: shellcheck**
+
+Run: `shellcheck packages/secubox-droplet/sbin/dropletctl packages/secubox-droplet/tests/fixtures/bin/metablogizerctl packages/secubox-droplet/tests/fixtures/bin/logger`
+Expected: exit 0. If shellcheck flags items: fix them inline and re-run. Common acceptable disables: `# shellcheck disable=SC2155` for `local x="$(…)"` patterns where capturing exit code isn't needed.
+
+- [ ] **Step 3: full bats sweep**
+
+Run: `cd packages/secubox-droplet && bats tests/test_dropletctl.bats`
+Expected: `13 tests, 0 failures`
+
+- [ ] **Step 4: confirm git tree is clean**
+
+Run: `git status -s`
+Expected: empty output (no uncommitted changes).
+
+- [ ] **Step 5: commit a trivial CHANGELOG note marker if shellcheck required any disable comments**
+
+(Skip if Step 2 was clean.) Otherwise:
+
+```bash
+git add packages/secubox-droplet/sbin/dropletctl
+git commit -m "chore(droplet): shellcheck-clean dropletctl (ref #196)"
+```
+
+- [ ] **Step 6: Final sanity — print the diff stat**
+
+Run: `git diff --stat origin/master..HEAD`
+Expected: ~3 source files (dropletctl + helpers.bash + test_dropletctl.bats), 2 stub bin files, 3 debian/ files modified. Total around +500 / −10 lines.
+
+---
+
+## Hardware deploy (deferred, post-merge)
+
+Not part of this plan. Once PR merges to master, deploy on `gk2` (192.168.1.200) per spec §"Deploy path on gk2":
+
+```bash
+cd packages/secubox-droplet
+dpkg-buildpackage -a arm64 --host-arch arm64 -us -uc -b
+scp ../secubox-droplet_1.1.0-1~bookworm1_all.deb root@admin.gk2.secubox.in:/tmp/
+ssh root@admin.gk2.secubox.in 'apt install /tmp/secubox-droplet_1.1.0-1~bookworm1_all.deb'
+
+# Smoke test:
+ssh root@admin.gk2.secubox.in 'which dropletctl'   # /usr/sbin/dropletctl
+ssh root@admin.gk2.secubox.in 'echo "<h1>smoke</h1>" > /tmp/smoke.html && \
+    dropletctl publish /tmp/smoke.html smoke gk2.secubox.in'
+curl -sSI https://smoke.gk2.secubox.in/   # expect 200 OK
+ssh root@admin.gk2.secubox.in 'dropletctl remove smoke'
+```
+
+If the live deploy uncovers issues, file a fix-followup against this branch before opening the PR for review.

--- a/docs/superpowers/specs/2026-05-18-dropletctl-design.md
+++ b/docs/superpowers/specs/2026-05-18-dropletctl-design.md
@@ -1,0 +1,325 @@
+# dropletctl CLI — Design Spec
+
+**Issue:** [#196](https://github.com/CyberMind-FR/secubox-deb/issues/196)
+**Author:** Claude (Opus 4.7, 1M context)
+**Date:** 2026-05-18
+**Status:** Awaiting user review before invoking `superpowers:writing-plans`
+
+---
+
+## Context
+
+`packages/secubox-droplet/api/main.py` (839 lines) is a comprehensive FastAPI app
+that shells out to a `dropletctl` binary for `publish` / `remove` / `rename`:
+
+```python
+subprocess.run(["dropletctl", "publish", file_path, name, domain], ...)
+subprocess.run(["dropletctl", "remove", req.name], ...)
+subprocess.run(["dropletctl", "rename", req.old, req.new], ...)
+```
+
+The `dropletctl` CLI **does not exist** anywhere in the Debian repo — every
+upload/remove/rename API call fails at runtime. `secubox-droplet 1.0.1-1~bookworm1`
+is installed live on `192.168.1.200` (`gk2`); the service is active; `which
+dropletctl` returns nothing.
+
+The OpenWrt counterpart `secubox-app-droplet` ships a working 349-line bash CLI
+at `package/secubox/secubox-app-droplet/files/usr/sbin/dropletctl` in
+https://github.com/gkerma/secubox-openwrt. This spec ports that CLI to Debian,
+narrowed to static-only content and the Debian peer-CLI ecosystem.
+
+## Scope (v1.1.0)
+
+**In:**
+- `publish`, `remove`, `rename`, `list` subcommands
+- Static content: single HTML, `.zip`, `.tar.gz` / `.tgz`, plain directory
+- Idempotent `publish` (overwrite semantics on the docroot)
+- Full delegation of nginx vhost + HAProxy ACL + mitmproxy route work to
+  `metablogizerctl site publish` (single source of truth)
+- Bats unit tests with PATH-shimmed `metablogizerctl` / `logger` stubs
+- Debian packaging update + changelog bump to `1.1.0-1~bookworm1`
+
+**Out (deferred to ≥ v1.2.0):**
+- Streamlit content type (would require Debian `streamlitctl` parity check)
+- Hexo content type
+- Gitea git-versioning (OpenWrt does `git init + commit` per publish)
+- Atomic publish rollback (currently: rsync overwrites; failure leaves staged
+  content on disk, caller must `dropletctl remove` to clean up)
+- TLS certificate provisioning (out of dropletctl scope; `metablogizerctl` /
+  `vhostctl` own that)
+
+## Architecture
+
+`dropletctl` is a thin bash orchestrator at `/usr/sbin/dropletctl`. It owns:
+input validation, name sanitization, file staging (HTML / ZIP / tarball
+extraction), site metadata writing into `/etc/secubox/droplet.toml`, and
+delegation to peer CLIs. It does NOT touch nginx, HAProxy, or mitmproxy
+directly.
+
+```
+┌─────────────────┐         ┌─────────────────────────────┐
+│  POST /upload   │────────▶│  api/main.py (FastAPI)      │
+│  (multipart)    │         │  subprocess.run(dropletctl…)│
+└─────────────────┘         └────────────┬────────────────┘
+                                         │
+                            ┌────────────▼─────────────┐
+                            │  dropletctl publish      │
+                            │  ────────────────────    │
+                            │  1. sanitize name        │
+                            │  2. extract → /tmp/      │
+                            │  3. detect_type (static) │
+                            │  4. rsync → /srv/        │
+                            │  5. write droplet.toml   │
+                            │  6. exec metablogizerctl │
+                            └────────────┬─────────────┘
+                                         │
+                            ┌────────────▼──────────────────┐
+                            │  metablogizerctl site publish │
+                            │  (does nginx + haproxy +      │
+                            │   mitmproxy sync — owned by   │
+                            │   metablogizer package)       │
+                            └───────────────────────────────┘
+```
+
+**Rejected alternative — absorb metablogizer logic in-line:** would violate the
+"handle one time only" principle the user articulated on 2026-05-17 during the
+ckwa.gk2.secubox.in 502 debug. If `metablogizerctl`'s nginx / HAProxy / mitmproxy
+plumbing ever changes, dropletctl would drift silently.
+
+**Rejected alternative — Python module reusing `secubox_core.config`:** adds a
+Python dependency to a CLI typically invoked as root via subprocess; harder to
+debug from a tty.
+
+## Components & interfaces
+
+### File layout in the repo
+
+```
+packages/secubox-droplet/
+├── sbin/dropletctl                           ← new bash CLI (~180 lines)
+├── tests/
+│   ├── test_dropletctl.bats                  ← new bats suite
+│   └── fixtures/
+│       ├── simple.html
+│       ├── simple.zip                        ← 1 nested dir, index.html + style.css
+│       ├── simple.tar.gz                     ← same shape as simple.zip
+│       └── bin/
+│           ├── metablogizerctl               ← stub (echo + exit 0)
+│           └── logger                        ← stub
+└── debian/
+    ├── rules                                 ← + install line for sbin/
+    ├── control                               ← + Depends: secubox-metablogizer (>= 2.0.0)
+    └── changelog                             ← bump 1.0.1 → 1.1.0
+```
+
+### CLI surface
+
+| Command | Args | Behavior | Output (success) |
+|---|---|---|---|
+| `publish` | `<path>` `<name>` `[<domain>]` | Stage `<path>` (HTML / .zip / .tar.gz / .tgz / dir) → `/srv/metablogizer/sites/<name>/`. Write `[sites.<name>] domain=…` into `/etc/secubox/droplet.toml`. Exec `metablogizerctl site publish <name>`. Idempotent overwrite. | `[OK] Published: https://<vhost>/` then `<vhost>` on stdout last line (API parses this) |
+| `remove` | `<name>` | Delete `/srv/metablogizer/sites/<name>/`. Remove from `droplet.toml`. Exec `metablogizerctl site unpublish <name>` then `metablogizerctl site delete <name>`. | `[OK] Removed: <name>` |
+| `rename` | `<old>` `<new>` | `mv` docroot. Update `droplet.toml` (`old → new` section + new domain). Exec `metablogizerctl site delete <old>` then `metablogizerctl site publish <new>`. | `[OK] Renamed: <old> -> <new>` |
+| `list` | — | Read `droplet.toml` sites, print `name  [ON/OFF]  https://<domain>/` one per line | the table |
+
+### Inputs / disk surface
+
+- **Reads:** `/etc/secubox/droplet.toml` (defaults: `upload_dir=/srv/droplet`,
+  `default_domain` mirrors API config; the CLI's TOML reader is ~20 lines of
+  grep/sed for the few keys it needs).
+- **Reads:** `<path>` argument (file or directory).
+- **Writes:** `/srv/metablogizer/sites/<name>/`, `/etc/secubox/droplet.toml`.
+- **Execs:** `metablogizerctl` (must exist in PATH; CLI fails with `[ERROR]`
+  if missing).
+
+### Output contract for the API
+
+`[OK]` substring in stdout + final stdout line = `<vhost>`. The API already
+parses these:
+
+```python
+if result.returncode == 0 and "[OK]" in result.stdout:
+    vhost = result.stdout.strip().split("\n")[-1]
+```
+
+## Data flow
+
+Happy path for `dropletctl publish /tmp/foo.html bar gk2.secubox.in`:
+
+```
+1. validate_args            ─→ <path> exists, <name> non-empty, <domain> may default
+2. sanitize_name            ─→ awk tolower + sed s/[^a-z0-9_-]/_/g  (matches OpenWrt)
+3. mktemp -d /tmp/droplet.XXXXXX
+4. extract_to_staging       ─→ case ext in
+                                  .html|.htm) cp $path $staging/index.html
+                                  .zip)       unzip -q $path -d $staging
+                                  .tgz|.tar.gz) tar -xzf $path -C $staging
+                                  *)          [ERROR] unsupported ext
+                                end
+                                # for .zip and tarballs: unwrap single-nested top dir
+5. detect_type              ─→ require index.html OR index.htm → "static"
+                                else → [ERROR] (no streamlit/hexo in v1.1.0)
+6. fix_perms                ─→ find -type f -exec chmod 644; -type d -exec chmod 755
+7. rsync -a --delete $staging/ /srv/metablogizer/sites/<name>/
+8. write_droplet_toml       ─→ [sites.<name>] domain="<domain>" type="static"
+9. exec metablogizerctl site publish <name>
+                            ─→ on success: echo "[OK] Published: https://<domain>/"
+                                          echo "<domain>"   ← API parses this line
+10. rm -rf $staging         ─→ via trap EXIT
+```
+
+## Error handling
+
+| Exit code | Trigger | stderr | Recovery |
+|---|---|---|---|
+| 0 | success | — | — |
+| 1 | bad args / unsupported ext / file missing | `[ERROR] <msg>` | caller fixes args |
+| 2 | sanitization rejects name (empty after strip) | `[ERROR] Invalid name '<orig>'` | caller picks new name |
+| 3 | staging extract fails | `[ERROR] Failed to extract <ext>: <stderr>` | log details to journald via `logger -t droplet -p user.error` |
+| 4 | metablogizerctl missing in PATH | `[ERROR] metablogizerctl not found — install secubox-metablogizer` | install dep |
+| 5 | metablogizerctl returncode != 0 | `[ERROR] metablogizerctl failed: <stderr 200ch tail>` | troubleshoot metablogizer; staging already deleted (no half-published state) |
+
+### Idempotency invariants (publish called twice with same name)
+
+- `rsync -a --delete` overwrites the docroot atomically — old content removed,
+  new written.
+- `write_droplet_toml` rewrites the `[sites.<name>]` block in place via
+  python3 stdlib `tomllib` + atomic `mv`.
+- `metablogizerctl site publish` is called regardless — it's idempotent on its
+  side (existing nginx vhost gets reloaded, HAProxy ACL is a no-op if present).
+- `<domain>` arg ignored if `droplet.toml` already has it for this name — we
+  DON'T silently swap domains on a republish. (User wants a domain change →
+  `dropletctl remove` then re-`publish`.)
+
+### Rollback
+
+None for v1.1.0. If step 9 fails after step 7+8 succeeded, the docroot exists on
+disk and the TOML entry exists, but no public vhost serves it. Caller can
+`dropletctl remove` to clean up. (Adding atomic rollback would require staging
+metadata to a separate file + on-failure unwind — punted to v1.2.0.)
+
+### Logging
+
+Every step logs to journald via `logger -t droplet -p user.{info,error}` +
+echoes to stdout/stderr. Matches OpenWrt convention. `journalctl -u
+secubox-droplet -t droplet` tails all CLI invocations on the board.
+
+## Testing
+
+### Bats unit suite
+
+`packages/secubox-droplet/tests/test_dropletctl.bats`. Follows the
+per-package bats convention used by `secubox-mail`
+(`test_install_lib.bats`, `test_lxc_lib.bats`, `test_migrate_lib.bats`) and
+`secubox-system` (`test_leasewatch.bats`) — invoke directly with
+`bats packages/secubox-droplet/tests/`. Tests stub `metablogizerctl`,
+`logger`, and the filesystem via PATH-shimmed fakes in `tests/fixtures/bin/`.
+
+### Test cases (10)
+
+| # | Case | Asserts |
+|---|---|---|
+| 1 | `publish` with no args | exit 1, stderr contains "Usage" |
+| 2 | `publish file.html foo` with missing file | exit 1, stderr contains "not found" |
+| 3 | `publish bad.xyz foo` | exit 1, stderr contains "Unsupported file type" |
+| 4 | `publish fixture.html foo` happy path | exit 0, stdout last line == `foo.gk2.secubox.in`, docroot exists with `index.html` matching, fake `metablogizerctl site publish foo` was called |
+| 5 | `publish fixture.zip foo` with nested single dir | docroot unwrapped (no `archive_name/index.html`, just `/srv/.../foo/index.html`) |
+| 6 | `publish fixture.tar.gz foo` | same as #5 for tarball |
+| 7 | `publish` twice for same name | second call rsync-overwrites, exit 0, no duplicate TOML entries |
+| 8 | `publish foo.html FOO` (uppercase) | name sanitized to `foo`, vhost `foo.<domain>` |
+| 9 | `remove foo` after publish | docroot gone, TOML entry gone, fake `metablogizerctl site delete foo` was called |
+| 10 | `rename old new` | docroot renamed, TOML key renamed, delegates called in correct order |
+
+### Fixtures
+
+`tests/fixtures/` contains `simple.html`, `simple.zip` (1 nested dir with
+`index.html` + `style.css`), `simple.tar.gz` (same shape), and
+`tests/fixtures/bin/{metablogizerctl,logger}` shims that just `echo
+"stub-call: $*" >> $BATS_TMPDIR/stub.log; exit 0`.
+
+### Test isolation
+
+Each test sets up `BATS_TMPDIR/srv/metablogizer/sites/`,
+`BATS_TMPDIR/etc/secubox/droplet.toml`, `PATH=$BATS_TMPDIR/bin:$PATH`, and runs
+dropletctl with `SITES_DIR=...`, `TOML_PATH=...`, `LOG_TAG=droplet-test` env
+vars (CLI accepts these for test mode). No real filesystem writes outside the
+temp dir.
+
+### Lint gates also in CI
+
+- `bash -n packages/secubox-droplet/sbin/dropletctl`
+- `shellcheck packages/secubox-droplet/sbin/dropletctl tests/fixtures/bin/*`
+
+### No netns / no end-to-end in this PR
+
+End-to-end deferred to the manual gk2 bench step (issue acceptance #196 last
+checkbox).
+
+### Coverage target
+
+10/10 green. No coverage % metric (bash without bashcov).
+
+## Packaging
+
+### `packages/secubox-droplet/debian/rules` — add one install block
+
+```make
+# Existing block (api/, www/, menu.d/, nginx/) stays as-is.
+
+# NEW: install the CLI to /usr/sbin/
+install -d debian/secubox-droplet/usr/sbin
+install -m 0755 sbin/dropletctl debian/secubox-droplet/usr/sbin/dropletctl
+```
+
+### `packages/secubox-droplet/debian/changelog` — bump
+
+```
+secubox-droplet (1.1.0-1~bookworm1) bookworm; urgency=medium
+
+  * Add dropletctl CLI at /usr/sbin/dropletctl (port from OpenWrt
+    secubox-app-droplet 1.0.0). Subcommands: publish, list, remove,
+    rename. Static-only (HTML / ZIP / tarball). Delegates HTTP-facing
+    work (nginx vhost, HAProxy ACL, mitmproxy route) to
+    metablogizerctl site publish.
+  * Depends: secubox-metablogizer (>= 2.0.0)  — runtime dependency for
+    publish/unpublish/delete.
+  * Closes: #196
+
+ -- Gerald KERMA <devel@cybermind.fr>  Mon, 18 May 2026 09:00:00 +0200
+```
+
+### `packages/secubox-droplet/debian/control` — add dependency
+
+`Depends: secubox-metablogizer (>= 2.0.0)` so apt enforces it at install time.
+
+## Deploy path on `gk2` (post-merge)
+
+1. Build .deb locally: `cd packages/secubox-droplet && dpkg-buildpackage -a arm64 --host-arch arm64 -us -uc -b`
+2. `scp ../secubox-droplet_1.1.0-1~bookworm1_all.deb root@admin.gk2.secubox.in:/tmp/`
+3. SSH: `apt install /tmp/secubox-droplet_1.1.0-1~bookworm1_all.deb`
+4. Verify: `which dropletctl` → `/usr/sbin/dropletctl`
+5. Smoke test: `curl -X POST -F "file=@simple.html" -F "name=smoke" https://admin.gk2.secubox.in/api/v1/droplet/upload` → expect 200 + job_id, then `dropletctl list` shows `smoke`, then `curl https://smoke.gk2.secubox.in/` returns the HTML content.
+
+### Rollback if deploy goes wrong
+
+`apt install secubox-droplet=1.0.1-1~bookworm1` (the previously-installed
+pinned version) reverts the CLI. Site docroots remain on disk unaffected (the
+CLI doesn't touch them on uninstall; that's `postrm`'s job which we don't change
+in this PR).
+
+### No systemd unit changes
+
+The existing `secubox-droplet.service` (FastAPI process) is unaffected. The CLI
+is invoked by the service via subprocess; once installed, it's available
+immediately without a restart.
+
+## References
+
+- OpenWrt source: `https://github.com/gkerma/secubox-openwrt` →
+  `package/secubox/secubox-app-droplet/files/usr/sbin/dropletctl` (349 lines)
+- Debian API consumer: `packages/secubox-droplet/api/main.py` (839 lines)
+- Sibling pattern: `packages/secubox-vhost/sbin/vhostctl` (Debian conventions
+  for nginx vhost mgmt)
+- Sibling delegate: `packages/secubox-metablogizer/sbin/metablogizerctl`
+  (`site create|publish|unpublish|delete|list` surface)
+- `sync-mitmproxy-routes.sh` regex fix the publish path depends on: master
+  `531fd878`

--- a/packages/secubox-droplet/debian/changelog
+++ b/packages/secubox-droplet/debian/changelog
@@ -1,3 +1,18 @@
+secubox-droplet (1.1.0-1~bookworm1) bookworm; urgency=medium
+
+  * Add dropletctl static-publisher CLI at /usr/sbin/dropletctl (port
+    from OpenWrt secubox-app-droplet 1.0.0). Replaces the API-wrapper
+    dropletctl shipped in 1.0.2 (issue #181). Subcommands: publish,
+    list, remove, rename. Static-only (HTML / ZIP / tarball /
+    directory). Delegates HTTP-facing work (nginx vhost, HAProxy
+    ACL, mitmproxy route) to metablogizerctl site publish.
+  * Depends: secubox-metablogizer (>= 1.1), rsync, unzip, python3 —
+    runtime dependencies for publish/unpublish/delete and TOML
+    manipulation.
+  * Closes: #196
+
+ -- Gerald KERMA <devel@cybermind.fr>  Mon, 18 May 2026 14:00:00 +0200
+
 secubox-droplet (1.0.2-1~bookworm1) bookworm; urgency=medium
 
   * Forge dropletctl (issue #181) — third routing verb on the publishing

--- a/packages/secubox-droplet/debian/control
+++ b/packages/secubox-droplet/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 4.6.2
 
 Package: secubox-droplet
 Architecture: all
-Depends: ${misc:Depends}, secubox-core (>= 1.0), python3-uvicorn | python3-pip, python3-aiofiles
+Depends: ${misc:Depends}, secubox-core (>= 1.0), python3-uvicorn | python3-pip, python3-aiofiles, secubox-metablogizer (>= 1.1), rsync, unzip, python3
 Description: SecuBox Droplet File Publisher
  Dashboard pour la publication de fichiers et sites statiques.
  Port Debian bookworm de luci-app-droplet (SecuBox OpenWrt).

--- a/packages/secubox-droplet/debian/rules
+++ b/packages/secubox-droplet/debian/rules
@@ -12,6 +12,6 @@ override_dh_auto_install:
 	# Modular nginx config
 	install -d debian/secubox-droplet/etc/nginx/secubox.d
 	[ -f nginx/droplet.conf ] && cp nginx/droplet.conf debian/secubox-droplet/etc/nginx/secubox.d/ || true
-	# dropletctl (issue #181)
+	# dropletctl — static publisher (rewritten for issue #196 — superseded #181)
 	install -d debian/secubox-droplet/usr/sbin
 	install -m 755 sbin/dropletctl debian/secubox-droplet/usr/sbin/

--- a/packages/secubox-droplet/sbin/dropletctl
+++ b/packages/secubox-droplet/sbin/dropletctl
@@ -121,6 +121,14 @@ cmd_publish() {
         esac
     fi
 
+    # Validate domain syntactically. Allow ASCII letters/digits/dot/hyphen
+    # (RFC 1035 hostname plus dots). Reject anything else to keep the TOML
+    # writer safe from injection.
+    if [[ ! "$domain" =~ ^[a-zA-Z0-9.-]+$ ]]; then
+        echo "[ERROR] Invalid domain '$domain'" >&2
+        exit 2
+    fi
+
     local name; name="$(sanitize_name "$name_raw")"
     if [[ -z "$name" ]]; then
         echo "[ERROR] Invalid name '$name_raw'" >&2
@@ -285,12 +293,16 @@ cmd_rename() {
 
     mv "$SITES_DIR/$old" "$SITES_DIR/$new"
     remove_toml_site "$old"
-    # Compute new domain by replacing the leading <old>. prefix if present, else use original.
-    local new_domain="$domain"
+    # Preserve the BARE BASE DOMAIN in TOML. If $domain happens to be a
+    # prefixed FQDN like "oldname.example.com" (from a legacy rename or
+    # hand-edit), strip the prefix to recover the base. cmd_publish stores
+    # the base; we maintain the same invariant here so cmd_list can always
+    # compute the vhost as "$name.$domain".
+    local base_domain="$domain"
     if [[ "$domain" == "${old}."* ]]; then
-        new_domain="${new}.${domain#*.}"
+        base_domain="${domain#*.}"
     fi
-    upsert_toml_site "$new" "$new_domain" "static"
+    upsert_toml_site "$new" "$base_domain" "static"
 
     # delete is tolerant: old vhost may never have been registered.
     metablogizerctl site delete "$old"  || true

--- a/packages/secubox-droplet/sbin/dropletctl
+++ b/packages/secubox-droplet/sbin/dropletctl
@@ -302,6 +302,25 @@ cmd_rename() {
     log_ok "Renamed: $old -> $new"
 }
 
+cmd_list() {
+    [[ -r "$TOML_PATH" ]] || { echo "(no droplets)"; return 0; }
+    python3 - "$TOML_PATH" <<'PY'
+import sys, re
+path = sys.argv[1]
+with open(path) as f:
+    content = f.read()
+# Capture [sites.<name>] then the immediate `domain = "..."` line in its block.
+section_re = re.compile(r'^\[sites\.([^\]]+)\]\s*\n((?:(?!^\[).*\n?)*)', re.MULTILINE)
+for m in section_re.finditer(content):
+    name = m.group(1)
+    body = m.group(2)
+    dm = re.search(r'^domain\s*=\s*"?([^"\n]+)"?', body, re.MULTILINE)
+    domain = dm.group(1).strip() if dm else "?"
+    vhost = f"{name}.{domain}"
+    print(f"{name:<30s} [ON]  https://{vhost}/")
+PY
+}
+
 case "${1:-}" in
     "" | -h | --help)
         cat <<USAGE
@@ -327,6 +346,9 @@ USAGE
     rename)
         shift
         cmd_rename "$@"
+        ;;
+    list)
+        cmd_list
         ;;
     *)
         echo "[ERROR] unknown subcommand: $1" >&2

--- a/packages/secubox-droplet/sbin/dropletctl
+++ b/packages/secubox-droplet/sbin/dropletctl
@@ -1,225 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: LicenseRef-CMSD-1.0
 # Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
 # Source-Disclosed License — All rights reserved except as expressly granted.
 # See LICENCE-CMSD-1.0.md for terms.
-#
-# dropletctl — SecuBox Droplet File Publisher control (issue #181)
-#
-# Third routing verb on the publishing layer, parallel to:
-#   haproxyctl   vhost  add/remove    (routing)
-#   mitmproxyctl route  add/remove    (interception, #173)
-#   giteactl     repo   mirror add    (replication, #176)
-#   dropletctl   file   upload/list   (publishing, this)
-#
-# The Droplet API exposes /upload, /list, /remove, /rename over a Unix
-# socket; this ctl wraps those endpoints under a coherent <noun> <verb>
-# grammar so operators don't have to curl by hand.
 
+# SecuBox-Deb :: dropletctl — droplet content publisher (port from OpenWrt)
 set -euo pipefail
 
-VERSION="0.1.0"
-SOCKET="${DROPLET_SOCKET:-/run/secubox/droplet.sock}"
-API_BASE="http://localhost/api/v1/droplet"
-SERVICE="secubox-droplet.service"
-
-GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
-log()   { printf "${GREEN}[DROPLET]${NC} %s\n" "$*"; }
-warn()  { printf "${YELLOW}[WARN]${NC} %s\n" "$*"; }
-error() { printf "${RED}[ERROR]${NC} %s\n" "$*" >&2; }
-
-# ── Helpers ───────────────────────────────────────────────────────────────
-
-require_socket() {
-    if [ ! -S "$SOCKET" ]; then
-        error "API socket $SOCKET not present — start $SERVICE first"
-        exit 2
-    fi
-}
-
-api() {
-    local method="$1" path="$2"
-    shift 2
-    require_socket
-    curl --unix-socket "$SOCKET" -sS -X "$method" \
-        -w "\nHTTP_CODE:%{http_code}\n" \
-        "${API_BASE}${path}" "$@"
-}
-
-api_code() {
-    echo "$1" | grep '^HTTP_CODE:' | cut -d: -f2
-}
-
-api_body() {
-    echo "$1" | sed '/^HTTP_CODE:/d'
-}
-
-# ── Lifecycle (top-level, mirrors mitmproxyctl/giteactl) ──────────────────
-
-cmd_install()  { log "install via dpkg; this ctl assumes package already installed"; return 0; }
-cmd_start()    { systemctl start   "$SERVICE"   && log "started";  }
-cmd_stop()     { systemctl stop    "$SERVICE"   && log "stopped";  }
-cmd_restart()  { systemctl restart "$SERVICE"   && log "restarted";}
-cmd_status()   {
-    systemctl is-active "$SERVICE" >/dev/null 2>&1 \
-        && echo "active" || echo "inactive"
-}
-cmd_logs() {
-    journalctl -u "$SERVICE" -n "${1:-50}" --no-pager
-}
-
-# ── Three-fold (giteactl convention: components / status / access JSON) ───
-
-cmd_components() {
-    cat <<EOF
-{
-  "service": "$SERVICE",
-  "socket": "$SOCKET",
-  "api_base": "$API_BASE",
-  "ctl_version": "$VERSION"
-}
-EOF
-}
-
-cmd_access() {
-    cat <<EOF
-{
-  "socket": "$SOCKET",
-  "api_paths": {
-    "upload": "POST   /api/v1/droplet/upload",
-    "list":   "GET    /api/v1/droplet/list",
-    "remove": "POST   /api/v1/droplet/remove",
-    "rename": "POST   /api/v1/droplet/rename",
-    "info":   "GET    /api/v1/droplet/droplet/{name}",
-    "stats":  "GET    /api/v1/droplet/stats",
-    "storage":"GET    /api/v1/droplet/storage"
-  }
-}
-EOF
-}
-
-# ── file noun verbs (the missing grammar — issue #181) ────────────────────
-
-cmd_file() {
-    local action="${1:-}"; shift || true
-    case "$action" in
-        upload)  cmd_file_upload "$@" ;;
-        remove|rm|del) cmd_file_remove "$@" ;;
-        rename)  cmd_file_rename "$@" ;;
-        list|ls) cmd_file_list "$@" ;;
-        info)    cmd_file_info "$@" ;;
-        *)
-            cat <<EOF
-File commands:
-  file upload <path> [--public] [--ttl <e.g. 7d>]
-  file remove <name>
-  file rename <old> <new>
-  file list [--limit N]
-  file info <name>
-EOF
-            ;;
-    esac
-}
-
-cmd_file_upload() {
-    local path="$1"; shift || { error "file upload <path> required"; return 1; }
-    [ -f "$path" ] || { error "file not found: $path"; return 1; }
-    local public=false ttl=""
-    while [ $# -gt 0 ]; do
-        case "$1" in
-            --public) public=true ;;
-            --ttl) ttl="$2"; shift ;;
-            *) error "unknown flag: $1"; return 1 ;;
-        esac; shift
-    done
-    log "uploading $path (public=$public ttl=${ttl:-default})"
-    local args=("-F" "file=@${path}")
-    $public && args+=("-F" "public=true")
-    [ -n "$ttl" ] && args+=("-F" "ttl=$ttl")
-    local out
-    out=$(api POST "/upload" "${args[@]}")
-    local code; code=$(api_code "$out")
-    case "$code" in
-        200|201) api_body "$out" ;;
-        *) error "upload failed (HTTP $code): $(api_body "$out" | head -3)"; return 1 ;;
-    esac
-}
-
-cmd_file_remove() {
-    local name="$1"
-    [ -z "$name" ] && { error "file remove <name> required"; return 1; }
-    log "removing $name"
-    local out
-    out=$(api POST "/remove" -H "Content-Type: application/json" \
-        -d "$(printf '{"name":"%s"}' "$name")")
-    local code; code=$(api_code "$out")
-    [ "$code" = "200" ] || { error "remove failed (HTTP $code): $(api_body "$out")"; return 1; }
-    log "removed $name"
-}
-
-cmd_file_rename() {
-    local old="$1" new="$2"
-    [ -z "$old" ] || [ -z "$new" ] && { error "file rename <old> <new> required"; return 1; }
-    log "renaming $old -> $new"
-    local out
-    out=$(api POST "/rename" -H "Content-Type: application/json" \
-        -d "$(printf '{"old":"%s","new":"%s"}' "$old" "$new")")
-    local code; code=$(api_code "$out")
-    [ "$code" = "200" ] || { error "rename failed (HTTP $code): $(api_body "$out")"; return 1; }
-    log "renamed"
-}
-
-cmd_file_list() {
-    local limit=""
-    [ "${1:-}" = "--limit" ] && { limit="?limit=$2"; }
-    local out
-    out=$(api GET "/list${limit}")
-    api_body "$out"
-}
-
-cmd_file_info() {
-    local name="$1"
-    [ -z "$name" ] && { error "file info <name> required"; return 1; }
-    local out
-    out=$(api GET "/droplet/${name}")
-    api_body "$out"
-}
-
-# ── Main dispatch ─────────────────────────────────────────────────────────
-
-show_help() {
-    cat <<EOF
-SecuBox Droplet Controller v$VERSION (issue #181)
-File publisher CLI — parallel to giteactl, mitmproxyctl
-
-Usage: dropletctl <command> [options]
-
-Lifecycle:
-  install / start / stop / restart / status / logs
-
-Three-fold (JSON):
-  components / access
-
-Files (issue #181):
-  file upload <path> [--public] [--ttl 7d]
-  file remove <name>
-  file rename <old> <new>
-  file list   [--limit N]
-  file info   <name>
-
-Examples:
-  dropletctl file upload /tmp/report.pdf --public --ttl 7d
-  dropletctl file list
-  dropletctl access | jq .api_paths
-EOF
-}
+readonly MODULE="dropletctl"
+readonly VERSION="1.1.0"
 
 case "${1:-}" in
-    install|start|stop|restart|status) cmd="$1"; shift; cmd_$cmd "$@" ;;
-    logs)        shift; cmd_logs "$@" ;;
-    components)  cmd_components ;;
-    access)      cmd_access ;;
-    file)        shift; cmd_file "$@" ;;
-    help|--help|-h|'') show_help ;;
-    *) error "unknown command: $1"; show_help; exit 1 ;;
+    "" | -h | --help)
+        cat <<USAGE
+Droplet Publisher — One-drop static-content publishing
+Usage: dropletctl <command> [args]
+
+Commands:
+  publish <file> <name> [domain]   Publish HTML/ZIP/tarball as a site
+  list                             List published droplets
+  remove <name>                    Remove a droplet
+  rename <old> <new>               Rename a droplet
+USAGE
+        exit 0
+        ;;
+    *)
+        echo "[ERROR] unknown subcommand: $1" >&2
+        exit 1
+        ;;
 esac

--- a/packages/secubox-droplet/sbin/dropletctl
+++ b/packages/secubox-droplet/sbin/dropletctl
@@ -39,9 +39,13 @@ stage_content() {
     local staging
     staging="$(mktemp -d /tmp/droplet.XXXXXX)"
 
-    local ext="${src##*.}"
-    ext="${ext,,}"
-    if [[ "$src" == *.tar.gz ]]; then ext="tar.gz"; fi
+    local ext
+    if [[ -d "$src" ]]; then
+        ext="dir"
+    else
+        ext="${src##*.}"; ext="${ext,,}"
+        [[ "$src" == *.tar.gz ]] && ext="tar.gz"
+    fi
 
     case "$ext" in
         html|htm)
@@ -56,9 +60,16 @@ stage_content() {
             unwrap_single_nested "$staging"
             ;;
         tgz|tar.gz)
-            log_error "tarball extraction not implemented yet"
-            rm -rf "$staging"
-            exit 3
+            if ! tar -xzf "$src" -C "$staging"; then
+                log_error "Failed to extract tarball: $src"
+                rm -rf "$staging"
+                exit 3
+            fi
+            unwrap_single_nested "$staging"
+            ;;
+        dir)
+            # Caller passed a directory — rsync its contents verbatim.
+            rsync -a "$src"/ "$staging"/
             ;;
     esac
 
@@ -94,15 +105,21 @@ cmd_publish() {
         exit 1
     fi
 
-    local ext="${file##*.}"; ext="${ext,,}"
-    [[ "$file" == *.tar.gz ]] && ext="tar.gz"
-    case "$ext" in
-        html|htm|zip|tgz|tar.gz) : ;;
-        *)
-            echo "[ERROR] Unsupported file type: .$ext (expected .html .htm .zip .tar.gz .tgz)" >&2
-            exit 1
-            ;;
-    esac
+    # If the path is a directory, skip extension validation entirely.
+    local ext
+    if [[ -d "$file" ]]; then
+        ext="dir"
+    else
+        ext="${file##*.}"; ext="${ext,,}"
+        [[ "$file" == *.tar.gz ]] && ext="tar.gz"
+        case "$ext" in
+            html|htm|zip|tgz|tar.gz) : ;;
+            *)
+                echo "[ERROR] Unsupported file type: .$ext (expected .html .htm .zip .tar.gz .tgz or directory)" >&2
+                exit 1
+                ;;
+        esac
+    fi
 
     local name; name="$(sanitize_name "$name_raw")"
     if [[ -z "$name" ]]; then

--- a/packages/secubox-droplet/sbin/dropletctl
+++ b/packages/secubox-droplet/sbin/dropletctl
@@ -244,6 +244,53 @@ os.replace(tmp, path)
 PY
 }
 
+cmd_rename() {
+    local old_raw="${1:-}" new_raw="${2:-}"
+    if [[ -z "$old_raw" ]] || [[ -z "$new_raw" ]]; then
+        echo "[ERROR] Usage: dropletctl rename <old> <new>" >&2
+        exit 1
+    fi
+    local old new
+    old="$(sanitize_name "$old_raw")"
+    new="$(sanitize_name "$new_raw")"
+    if [[ -z "$old" ]] || [[ -z "$new" ]]; then
+        echo "[ERROR] Invalid name(s): '$old_raw' or '$new_raw'" >&2
+        exit 2
+    fi
+    if [[ ! -d "$SITES_DIR/$old" ]]; then
+        echo "[ERROR] not found: $old" >&2
+        exit 1
+    fi
+
+    # Read old domain so the new site keeps the same default unless overridden.
+    local domain
+    domain=$(grep -A2 "^\[sites\.$old\]" "$TOML_PATH" 2>/dev/null \
+        | grep -E '^domain\s*=' | head -1 \
+        | sed -E 's/^domain\s*=\s*"?([^"]*)"?\s*$/\1/')
+    domain="${domain:-$(default_domain)}"
+
+    if ! command -v metablogizerctl >/dev/null 2>&1; then
+        log_error "metablogizerctl not found — install secubox-metablogizer"
+        exit 4
+    fi
+
+    mv "$SITES_DIR/$old" "$SITES_DIR/$new"
+    remove_toml_site "$old"
+    # Compute new domain by replacing the leading <old>. prefix if present, else use original.
+    local new_domain="$domain"
+    if [[ "$domain" == "${old}."* ]]; then
+        new_domain="${new}.${domain#*.}"
+    fi
+    upsert_toml_site "$new" "$new_domain" "static"
+
+    metablogizerctl site delete "$old"  || true
+    metablogizerctl site publish "$new" || {
+        log_error "metablogizerctl failed for $new"
+        exit 5
+    }
+    log_ok "Renamed: $old -> $new"
+}
+
 case "${1:-}" in
     "" | -h | --help)
         cat <<USAGE
@@ -265,6 +312,10 @@ USAGE
     remove)
         shift
         cmd_remove "$@"
+        ;;
+    rename)
+        shift
+        cmd_rename "$@"
         ;;
     *)
         echo "[ERROR] unknown subcommand: $1" >&2

--- a/packages/secubox-droplet/sbin/dropletctl
+++ b/packages/secubox-droplet/sbin/dropletctl
@@ -197,6 +197,53 @@ os.replace(tmp, path)
 PY
 }
 
+cmd_remove() {
+    local name_raw="${1:-}"
+    if [[ -z "$name_raw" ]]; then
+        echo "[ERROR] Usage: dropletctl remove <name>" >&2
+        exit 1
+    fi
+    local name; name="$(sanitize_name "$name_raw")"
+    if [[ -z "$name" ]]; then
+        echo "[ERROR] Invalid name '$name_raw'" >&2
+        exit 2
+    fi
+
+    if ! command -v metablogizerctl >/dev/null 2>&1; then
+        log_error "metablogizerctl not found — install secubox-metablogizer"
+        exit 4
+    fi
+    metablogizerctl site unpublish "$name" || true
+    metablogizerctl site delete "$name"    || true
+
+    rm -rf "$SITES_DIR/$name"
+    remove_toml_site "$name"
+    log_ok "Removed: $name"
+}
+
+# Drop the [sites.<name>] block from droplet.toml. No-op if not present.
+remove_toml_site() {
+    local name="$1"
+    [[ -e "$TOML_PATH" ]] || return 0
+    python3 - "$TOML_PATH" "$name" <<'PY'
+import sys, re, os, tempfile
+path, name = sys.argv[1:]
+with open(path) as f:
+    content = f.read()
+pattern = re.compile(
+    rf'^\[sites\.{re.escape(name)}\]\s*\n(?:(?!^\[).*\n?)*',
+    flags=re.MULTILINE,
+)
+new = pattern.sub('', content)
+if new == content:
+    sys.exit(0)
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or '.', prefix='.droplet.', suffix='.toml')
+os.write(fd, new.encode())
+os.close(fd)
+os.replace(tmp, path)
+PY
+}
+
 case "${1:-}" in
     "" | -h | --help)
         cat <<USAGE
@@ -214,6 +261,10 @@ USAGE
     publish)
         shift
         cmd_publish "$@"
+        ;;
+    remove)
+        shift
+        cmd_remove "$@"
         ;;
     *)
         echo "[ERROR] unknown subcommand: $1" >&2

--- a/packages/secubox-droplet/sbin/dropletctl
+++ b/packages/secubox-droplet/sbin/dropletctl
@@ -10,6 +10,39 @@ set -euo pipefail
 readonly MODULE="dropletctl"
 readonly VERSION="1.1.0"
 
+cmd_publish() {
+    local file="${1:-}"
+    local name="${2:-}"
+    local domain="${3:-}"
+
+    if [[ -z "$file" ]] || [[ -z "$name" ]]; then
+        echo "[ERROR] Usage: dropletctl publish <file> <name> [domain]" >&2
+        exit 1
+    fi
+    if [[ ! -e "$file" ]]; then
+        echo "[ERROR] not found: $file" >&2
+        exit 1
+    fi
+
+    local ext="${file##*.}"
+    ext="${ext,,}"  # bash 4 lowercase
+    # Handle .tar.gz double-extension
+    if [[ "$file" == *.tar.gz ]]; then ext="tar.gz"; fi
+
+    case "$ext" in
+        html|htm|zip|tgz|tar.gz)
+            : ;;
+        *)
+            echo "[ERROR] Unsupported file type: .$ext (expected .html .htm .zip .tar.gz .tgz)" >&2
+            exit 1
+            ;;
+    esac
+
+    # Stub — actual staging arrives in later tasks.
+    echo "[OK] (stub) would publish $file as $name"
+    echo "${name}.${domain:-gk2.secubox.in}"
+}
+
 case "${1:-}" in
     "" | -h | --help)
         cat <<USAGE
@@ -23,6 +56,10 @@ Commands:
   rename <old> <new>               Rename a droplet
 USAGE
         exit 0
+        ;;
+    publish)
+        shift
+        cmd_publish "$@"
         ;;
     *)
         echo "[ERROR] unknown subcommand: $1" >&2

--- a/packages/secubox-droplet/sbin/dropletctl
+++ b/packages/secubox-droplet/sbin/dropletctl
@@ -10,12 +10,59 @@ set -euo pipefail
 readonly MODULE="dropletctl"
 readonly VERSION="1.1.0"
 
+# Environment overrides for tests (default to production paths if unset).
+: "${SITES_DIR:=/srv/metablogizer/sites}"
+: "${TOML_PATH:=/etc/secubox/droplet.toml}"
+: "${LOG_TAG:=droplet}"
+
+log_info()  { logger -t "$LOG_TAG" -p user.info  "$*" 2>/dev/null || true; echo "[INFO] $*"; }
+log_error() { logger -t "$LOG_TAG" -p user.error "$*" 2>/dev/null || true; echo "[ERROR] $*" >&2; }
+log_ok()    { echo "[OK] $*"; }
+
+# Lowercase + replace non-[a-z0-9_-] with '_'. Empty result -> caller errors.
+sanitize_name() {
+    printf '%s' "$1" | awk '{print tolower($0)}' | sed 's/[^a-z0-9_-]/_/g'
+}
+
+# Read default_domain from droplet.toml. Falls back to gk2.secubox.in.
+default_domain() {
+    [[ -r "$TOML_PATH" ]] || { echo "gk2.secubox.in"; return; }
+    local v
+    v=$(grep -E '^default_domain\s*=' "$TOML_PATH" 2>/dev/null \
+        | head -1 | sed -E 's/^default_domain\s*=\s*"?([^"]*)"?\s*$/\1/')
+    echo "${v:-gk2.secubox.in}"
+}
+
+# Stage <src> into a fresh temp dir. Echoes the staging dir path.
+stage_content() {
+    local src="$1"
+    local staging
+    staging="$(mktemp -d /tmp/droplet.XXXXXX)"
+
+    local ext="${src##*.}"
+    ext="${ext,,}"
+    if [[ "$src" == *.tar.gz ]]; then ext="tar.gz"; fi
+
+    case "$ext" in
+        html|htm)
+            cp "$src" "$staging/index.html"
+            ;;
+        zip|tgz|tar.gz)
+            log_error "extraction not implemented yet"
+            rm -rf "$staging"
+            exit 3
+            ;;
+    esac
+
+    echo "$staging"
+}
+
 cmd_publish() {
     local file="${1:-}"
-    local name="${2:-}"
-    local domain="${3:-}"
+    local name_raw="${2:-}"
+    local domain="${3:-$(default_domain)}"
 
-    if [[ -z "$file" ]] || [[ -z "$name" ]]; then
+    if [[ -z "$file" ]] || [[ -z "$name_raw" ]]; then
         echo "[ERROR] Usage: dropletctl publish <file> <name> [domain]" >&2
         exit 1
     fi
@@ -24,23 +71,90 @@ cmd_publish() {
         exit 1
     fi
 
-    local ext="${file##*.}"
-    ext="${ext,,}"  # bash 4 lowercase
-    # Handle .tar.gz double-extension
-    if [[ "$file" == *.tar.gz ]]; then ext="tar.gz"; fi
-
+    local ext="${file##*.}"; ext="${ext,,}"
+    [[ "$file" == *.tar.gz ]] && ext="tar.gz"
     case "$ext" in
-        html|htm|zip|tgz|tar.gz)
-            : ;;
+        html|htm|zip|tgz|tar.gz) : ;;
         *)
             echo "[ERROR] Unsupported file type: .$ext (expected .html .htm .zip .tar.gz .tgz)" >&2
             exit 1
             ;;
     esac
 
-    # Stub — actual staging arrives in later tasks.
-    echo "[OK] (stub) would publish $file as $name"
-    echo "${name}.${domain:-gk2.secubox.in}"
+    local name; name="$(sanitize_name "$name_raw")"
+    if [[ -z "$name" ]]; then
+        echo "[ERROR] Invalid name '$name_raw'" >&2
+        exit 2
+    fi
+
+    local vhost="${name}.${domain}"
+    # staging is intentionally not declared local so the EXIT trap can reference it.
+    staging="$(stage_content "$file")"
+    trap 'rm -rf "$staging"' EXIT
+
+    log_info "Publishing: $file as $vhost"
+
+    # Permissions: 644 files, 755 dirs.
+    find "$staging" -type f -exec chmod 644 {} +
+    find "$staging" -type d -exec chmod 755 {} +
+
+    # Deploy to /srv/metablogizer/sites/<name>/ (idempotent overwrite).
+    mkdir -p "$SITES_DIR/$name"
+    rsync -a --delete "$staging"/ "$SITES_DIR/$name"/
+
+    # Upsert TOML entry. Section format: [sites.<name>] domain="<d>" type="static".
+    upsert_toml_site "$name" "$domain" "static"
+
+    # Delegate the HTTP-facing work.
+    if ! command -v metablogizerctl >/dev/null 2>&1; then
+        log_error "metablogizerctl not found — install secubox-metablogizer"
+        exit 4
+    fi
+    if ! metablogizerctl site publish "$name"; then
+        log_error "metablogizerctl failed for $name"
+        exit 5
+    fi
+
+    log_ok "Published: https://$vhost/"
+    echo "$vhost"
+}
+
+# Upsert [sites.<name>] section. Uses python3 for safe TOML rewrite.
+upsert_toml_site() {
+    local name="$1" domain="$2" type="$3"
+    python3 - "$TOML_PATH" "$name" "$domain" "$type" <<'PY'
+import sys, re, os, tempfile
+
+path, name, domain, type_ = sys.argv[1:]
+section = f"[sites.{name}]"
+new_block = f'{section}\ndomain = "{domain}"\ntype = "{type_}"\n'
+
+if os.path.exists(path):
+    with open(path) as f:
+        content = f.read()
+else:
+    content = ""
+
+# Match the section + its body up to the next [section] or EOF.
+pattern = re.compile(
+    rf'^{re.escape(section)}\s*\n(?:(?!^\[).*\n?)*',
+    flags=re.MULTILINE,
+)
+if pattern.search(content):
+    new_content = pattern.sub(new_block, content)
+else:
+    if content and not content.endswith('\n'):
+        content += '\n'
+    if content and not content.endswith('\n\n'):
+        content += '\n'
+    new_content = content + new_block
+
+# Atomic write.
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or '.', prefix='.droplet.', suffix='.toml')
+os.write(fd, new_content.encode())
+os.close(fd)
+os.replace(tmp, path)
+PY
 }
 
 case "${1:-}" in

--- a/packages/secubox-droplet/sbin/dropletctl
+++ b/packages/secubox-droplet/sbin/dropletctl
@@ -257,6 +257,10 @@ cmd_rename() {
         echo "[ERROR] Invalid name(s): '$old_raw' or '$new_raw'" >&2
         exit 2
     fi
+    if [[ "$old" == "$new" ]]; then
+        echo "[ERROR] old and new names are identical after sanitization" >&2
+        exit 2
+    fi
     if [[ ! -d "$SITES_DIR/$old" ]]; then
         echo "[ERROR] not found: $old" >&2
         exit 1
@@ -274,6 +278,11 @@ cmd_rename() {
         exit 4
     fi
 
+    if [[ -e "$SITES_DIR/$new" ]]; then
+        echo "[ERROR] target already exists: $new" >&2
+        exit 1
+    fi
+
     mv "$SITES_DIR/$old" "$SITES_DIR/$new"
     remove_toml_site "$old"
     # Compute new domain by replacing the leading <old>. prefix if present, else use original.
@@ -283,7 +292,9 @@ cmd_rename() {
     fi
     upsert_toml_site "$new" "$new_domain" "static"
 
+    # delete is tolerant: old vhost may never have been registered.
     metablogizerctl site delete "$old"  || true
+    # publish must succeed: failure leaves site half-renamed and unreachable.
     metablogizerctl site publish "$new" || {
         log_error "metablogizerctl failed for $new"
         exit 5

--- a/packages/secubox-droplet/sbin/dropletctl
+++ b/packages/secubox-droplet/sbin/dropletctl
@@ -47,14 +47,37 @@ stage_content() {
         html|htm)
             cp "$src" "$staging/index.html"
             ;;
-        zip|tgz|tar.gz)
-            log_error "extraction not implemented yet"
+        zip)
+            if ! unzip -q "$src" -d "$staging"; then
+                log_error "Failed to extract zip: $src"
+                rm -rf "$staging"
+                exit 3
+            fi
+            unwrap_single_nested "$staging"
+            ;;
+        tgz|tar.gz)
+            log_error "tarball extraction not implemented yet"
             rm -rf "$staging"
             exit 3
             ;;
     esac
 
     echo "$staging"
+}
+
+# If $1 contains exactly one entry and it's a directory, move its contents up.
+unwrap_single_nested() {
+    local dir="$1"
+    local entries=("$dir"/*)
+    if [[ ${#entries[@]} -eq 1 ]] && [[ -d "${entries[0]}" ]]; then
+        local nested="${entries[0]}"
+        # Use a temp move to avoid name collision when nested basename matches dir.
+        local stash; stash="$(mktemp -d "$dir/.unwrap.XXXXXX")"
+        mv "$nested"/* "$nested"/.[!.]* "$stash"/ 2>/dev/null || true
+        rmdir "$nested"
+        mv "$stash"/* "$stash"/.[!.]* "$dir"/ 2>/dev/null || true
+        rmdir "$stash"
+    fi
 }
 
 cmd_publish() {

--- a/packages/secubox-droplet/tests/fixtures/bin/logger
+++ b/packages/secubox-droplet/tests/fixtures/bin/logger
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub for bats tests — logs args, exit 0.
+printf 'logger %s\n' "$*" >> "${STUB_LOG:-/dev/null}"
+exit 0

--- a/packages/secubox-droplet/tests/fixtures/bin/metablogizerctl
+++ b/packages/secubox-droplet/tests/fixtures/bin/metablogizerctl
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Stub for bats tests — logs args to $STUB_LOG, exit 0 unless STUB_METABLOGIZERCTL_FAIL=1.
+printf 'metablogizerctl %s\n' "$*" >> "${STUB_LOG:-/dev/null}"
+if [[ "${STUB_METABLOGIZERCTL_FAIL:-0}" = "1" ]]; then
+    echo "stub: forced failure" >&2
+    exit 1
+fi
+exit 0

--- a/packages/secubox-droplet/tests/helpers.bash
+++ b/packages/secubox-droplet/tests/helpers.bash
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Shared bats helpers for dropletctl tests.
+
+# REPO_ROOT = top of the git checkout. PACKAGE_ROOT = packages/secubox-droplet/.
+export REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+export PACKAGE_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+export DROPLETCTL="$PACKAGE_ROOT/sbin/dropletctl"
+
+setup() {
+    # Per-test temp dir; gone after teardown.
+    TMP="$(mktemp -d "${BATS_TMPDIR}/droplet.XXXXXX")"
+    export TMP
+    export STUB_LOG="$TMP/stub.log"
+    export SITES_DIR="$TMP/srv/metablogizer/sites"
+    export TOML_PATH="$TMP/etc/secubox/droplet.toml"
+    mkdir -p "$SITES_DIR" "$(dirname "$TOML_PATH")"
+    : > "$STUB_LOG"
+    # Empty TOML scaffold — dropletctl creates [sites.<name>] sections in it.
+    printf '[droplet]\ndefault_domain = "gk2.secubox.in"\n' > "$TOML_PATH"
+    # PATH-shim the delegate stubs.
+    export PATH="$PACKAGE_ROOT/tests/fixtures/bin:$PATH"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+# Generate a 1-file HTML fixture at $1.
+make_html() {
+    local out="$1"
+    printf '<!doctype html><html><body><h1>fixture</h1></body></html>\n' > "$out"
+}
+
+# Generate a zip fixture with one nested top-level dir.
+make_zip_nested() {
+    local out="$1" workdir
+    workdir="$(mktemp -d "$TMP/mkzip.XXXXXX")"
+    mkdir "$workdir/site"
+    make_html "$workdir/site/index.html"
+    printf 'body { color: red; }\n' > "$workdir/site/style.css"
+    ( cd "$workdir" && zip -qr "$out" site )
+    rm -rf "$workdir"
+}
+
+# Generate a tarball fixture with one nested top-level dir.
+make_tarball_nested() {
+    local out="$1" workdir
+    workdir="$(mktemp -d "$TMP/mktar.XXXXXX")"
+    mkdir "$workdir/site"
+    make_html "$workdir/site/index.html"
+    printf 'body { color: red; }\n' > "$workdir/site/style.css"
+    ( cd "$workdir" && tar -czf "$out" site )
+    rm -rf "$workdir"
+}

--- a/packages/secubox-droplet/tests/test_dropletctl.bats
+++ b/packages/secubox-droplet/tests/test_dropletctl.bats
@@ -64,3 +64,25 @@ load helpers
     # Nested wrapper dir is gone.
     [ ! -d "$SITES_DIR/zipsite/site" ]
 }
+
+@test "publish a tarball with one nested top dir unwraps it" {
+    make_tarball_nested "$TMP/site.tar.gz"
+
+    run "$DROPLETCTL" publish "$TMP/site.tar.gz" tarsite mydomain.test
+    [ "$status" -eq 0 ]
+    [ -f "$SITES_DIR/tarsite/index.html" ]
+    [ -f "$SITES_DIR/tarsite/style.css" ]
+    [ ! -d "$SITES_DIR/tarsite/site" ]
+}
+
+@test "publish a plain directory copies its tree verbatim" {
+    mkdir -p "$TMP/site_src"
+    make_html "$TMP/site_src/index.html"
+    printf 'body { color: blue; }\n' > "$TMP/site_src/style.css"
+
+    run "$DROPLETCTL" publish "$TMP/site_src" dirsite mydomain.test
+    [ "$status" -eq 0 ]
+    [ -f "$SITES_DIR/dirsite/index.html" ]
+    [ -f "$SITES_DIR/dirsite/style.css" ]
+    grep -q "fixture" "$SITES_DIR/dirsite/index.html"
+}

--- a/packages/secubox-droplet/tests/test_dropletctl.bats
+++ b/packages/secubox-droplet/tests/test_dropletctl.bats
@@ -144,3 +144,31 @@ load helpers
     grep -q "metablogizerctl site delete oldname" "$STUB_LOG"
     grep -q "metablogizerctl site publish newname" "$STUB_LOG"
 }
+
+@test "rename fails when target name already exists" {
+    make_html "$TMP/page.html"
+    run "$DROPLETCTL" publish "$TMP/page.html" srcsite mydomain.test
+    [ "$status" -eq 0 ]
+    run "$DROPLETCTL" publish "$TMP/page.html" dstsite mydomain.test
+    [ "$status" -eq 0 ]
+
+    run "$DROPLETCTL" rename srcsite dstsite
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "already exists" ]]
+    # Both docroots still present — no half-renamed state.
+    [ -d "$SITES_DIR/srcsite" ]
+    [ -d "$SITES_DIR/dstsite" ]
+}
+
+@test "rename fails when old and new are identical after sanitization" {
+    make_html "$TMP/page.html"
+    run "$DROPLETCTL" publish "$TMP/page.html" same mydomain.test
+    [ "$status" -eq 0 ]
+
+    # 'Same' sanitizes to 'same' — same as the existing 'same'.
+    run "$DROPLETCTL" rename Same same
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ "identical after sanitization" ]]
+    # Original still intact.
+    [ -d "$SITES_DIR/same" ]
+}

--- a/packages/secubox-droplet/tests/test_dropletctl.bats
+++ b/packages/secubox-droplet/tests/test_dropletctl.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "dropletctl with no args prints usage" {
+    run "$DROPLETCTL"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage:" ]] || [[ "$output" =~ "dropletctl" ]]
+}

--- a/packages/secubox-droplet/tests/test_dropletctl.bats
+++ b/packages/secubox-droplet/tests/test_dropletctl.bats
@@ -187,3 +187,39 @@ load helpers
     [[ "$output" =~ "second" ]]
     [[ "$output" =~ "second.mydomain.test" ]]
 }
+
+@test "rename then list shows the renamed site at the correct vhost (not double-prefixed)" {
+    make_html "$TMP/page.html"
+    run "$DROPLETCTL" publish "$TMP/page.html" original mydomain.test
+    [ "$status" -eq 0 ]
+
+    : > "$STUB_LOG"
+    run "$DROPLETCTL" rename original renamed
+    [ "$status" -eq 0 ]
+
+    run "$DROPLETCTL" list
+    [ "$status" -eq 0 ]
+    # Must show "renamed.mydomain.test" — NOT "renamed.renamed.mydomain.test".
+    [[ "$output" =~ "renamed.mydomain.test" ]]
+    [[ ! "$output" =~ "renamed.renamed" ]]
+}
+
+@test "publish rejects domain with invalid characters" {
+    make_html "$TMP/page.html"
+
+    # Quote injection attempt.
+    run "$DROPLETCTL" publish "$TMP/page.html" mysite 'evil"injected'
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ "Invalid domain" ]]
+
+    # Newline injection attempt.
+    run "$DROPLETCTL" publish "$TMP/page.html" mysite $'evil\nmalicious'
+    [ "$status" -eq 2 ]
+
+    # Space rejected.
+    run "$DROPLETCTL" publish "$TMP/page.html" mysite 'has space'
+    [ "$status" -eq 2 ]
+
+    # TOML is intact (no injected lines).
+    ! grep -q 'malicious' "$TOML_PATH"
+}

--- a/packages/secubox-droplet/tests/test_dropletctl.bats
+++ b/packages/secubox-droplet/tests/test_dropletctl.bats
@@ -7,3 +7,22 @@ load helpers
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Usage:" ]] || [[ "$output" =~ "dropletctl" ]]
 }
+
+@test "publish with no args exits 1 with Usage" {
+    run "$DROPLETCTL" publish
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Usage" ]]
+}
+
+@test "publish with missing file exits 1" {
+    run "$DROPLETCTL" publish "$TMP/does-not-exist.html" foo
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "not found" ]]
+}
+
+@test "publish with unsupported extension exits 1" {
+    : > "$TMP/bad.xyz"
+    run "$DROPLETCTL" publish "$TMP/bad.xyz" foo
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Unsupported file type" ]]
+}

--- a/packages/secubox-droplet/tests/test_dropletctl.bats
+++ b/packages/secubox-droplet/tests/test_dropletctl.bats
@@ -26,3 +26,29 @@ load helpers
     [ "$status" -eq 1 ]
     [[ "$output" =~ "Unsupported file type" ]]
 }
+
+@test "publish a single HTML stages it and delegates to metablogizerctl" {
+    make_html "$TMP/page.html"
+
+    run "$DROPLETCTL" publish "$TMP/page.html" mysite mydomain.test
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "[OK]" ]]
+    # API parses last stdout line as vhost.
+    last_line="$(printf '%s\n' "$output" | tail -1)"
+    [ "$last_line" = "mysite.mydomain.test" ]
+    # Docroot has the staged file.
+    [ -f "$SITES_DIR/mysite/index.html" ]
+    grep -q "fixture" "$SITES_DIR/mysite/index.html"
+    # Delegate was called with the right args.
+    grep -q "metablogizerctl site publish mysite" "$STUB_LOG"
+}
+
+@test "publish sanitizes uppercase + special chars in name" {
+    make_html "$TMP/page.html"
+
+    run "$DROPLETCTL" publish "$TMP/page.html" "MyCool Site!" mydomain.test
+    [ "$status" -eq 0 ]
+    last_line="$(printf '%s\n' "$output" | tail -1)"
+    [ "$last_line" = "mycool_site_.mydomain.test" ]
+    [ -d "$SITES_DIR/mycool_site_" ]
+}

--- a/packages/secubox-droplet/tests/test_dropletctl.bats
+++ b/packages/secubox-droplet/tests/test_dropletctl.bats
@@ -52,3 +52,15 @@ load helpers
     [ "$last_line" = "mycool_site_.mydomain.test" ]
     [ -d "$SITES_DIR/mycool_site_" ]
 }
+
+@test "publish a zip with one nested top dir unwraps it" {
+    make_zip_nested "$TMP/site.zip"
+
+    run "$DROPLETCTL" publish "$TMP/site.zip" zipsite mydomain.test
+    [ "$status" -eq 0 ]
+    # Unwrapped: NOT $SITES_DIR/zipsite/site/index.html, but directly:
+    [ -f "$SITES_DIR/zipsite/index.html" ]
+    [ -f "$SITES_DIR/zipsite/style.css" ]
+    # Nested wrapper dir is gone.
+    [ ! -d "$SITES_DIR/zipsite/site" ]
+}

--- a/packages/secubox-droplet/tests/test_dropletctl.bats
+++ b/packages/secubox-droplet/tests/test_dropletctl.bats
@@ -188,9 +188,13 @@ load helpers
     [[ "$output" =~ "second.mydomain.test" ]]
 }
 
-@test "rename then list shows the renamed site at the correct vhost (not double-prefixed)" {
+@test "rename strips legacy prefixed-FQDN domain from TOML (no double-prefix in list)" {
     make_html "$TMP/page.html"
-    run "$DROPLETCTL" publish "$TMP/page.html" original mydomain.test
+    # Seed the legacy condition: publish with the FQDN as the explicit
+    # domain arg. cmd_publish stores it verbatim → TOML now contains
+    # domain="original.mydomain.test", which is the precondition that
+    # historically caused cmd_rename to double-prefix the new domain.
+    run "$DROPLETCTL" publish "$TMP/page.html" original original.mydomain.test
     [ "$status" -eq 0 ]
 
     : > "$STUB_LOG"
@@ -199,7 +203,10 @@ load helpers
 
     run "$DROPLETCTL" list
     [ "$status" -eq 0 ]
-    # Must show "renamed.mydomain.test" — NOT "renamed.renamed.mydomain.test".
+    # On the buggy code, list would print "renamed.renamed.mydomain.test"
+    # (because rename stored the FQDN "renamed.mydomain.test", then list
+    # computes vhost as "renamed.<that>"). The fix strips the legacy prefix
+    # back to the bare base, so list prints "renamed.mydomain.test".
     [[ "$output" =~ "renamed.mydomain.test" ]]
     [[ ! "$output" =~ "renamed.renamed" ]]
 }

--- a/packages/secubox-droplet/tests/test_dropletctl.bats
+++ b/packages/secubox-droplet/tests/test_dropletctl.bats
@@ -172,3 +172,18 @@ load helpers
     # Original still intact.
     [ -d "$SITES_DIR/same" ]
 }
+
+@test "list prints one row per [sites.<name>] in droplet.toml" {
+    make_html "$TMP/page.html"
+    run "$DROPLETCTL" publish "$TMP/page.html" first mydomain.test
+    [ "$status" -eq 0 ]
+    run "$DROPLETCTL" publish "$TMP/page.html" second mydomain.test
+    [ "$status" -eq 0 ]
+
+    run "$DROPLETCTL" list
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "first" ]]
+    [[ "$output" =~ "first.mydomain.test" ]]
+    [[ "$output" =~ "second" ]]
+    [[ "$output" =~ "second.mydomain.test" ]]
+}

--- a/packages/secubox-droplet/tests/test_dropletctl.bats
+++ b/packages/secubox-droplet/tests/test_dropletctl.bats
@@ -86,3 +86,23 @@ load helpers
     [ -f "$SITES_DIR/dirsite/style.css" ]
     grep -q "fixture" "$SITES_DIR/dirsite/index.html"
 }
+
+@test "publish twice for same name overwrites docroot, no TOML dupes" {
+    make_html "$TMP/v1.html"
+    make_html "$TMP/v2.html"
+    # Make v2 distinguishable.
+    printf '<!doctype html><html><body><h2>v2</h2></body></html>\n' > "$TMP/v2.html"
+
+    run "$DROPLETCTL" publish "$TMP/v1.html" rev mydomain.test
+    [ "$status" -eq 0 ]
+    grep -q "fixture" "$SITES_DIR/rev/index.html"
+
+    run "$DROPLETCTL" publish "$TMP/v2.html" rev mydomain.test
+    [ "$status" -eq 0 ]
+    # v2 overwrote v1.
+    grep -q "v2" "$SITES_DIR/rev/index.html"
+    ! grep -q "fixture" "$SITES_DIR/rev/index.html"
+    # Exactly one [sites.rev] block in the TOML.
+    count="$(grep -c '^\[sites\.rev\]' "$TOML_PATH")"
+    [ "$count" = "1" ]
+}

--- a/packages/secubox-droplet/tests/test_dropletctl.bats
+++ b/packages/secubox-droplet/tests/test_dropletctl.bats
@@ -106,3 +106,21 @@ load helpers
     count="$(grep -c '^\[sites\.rev\]' "$TOML_PATH")"
     [ "$count" = "1" ]
 }
+
+@test "remove deletes docroot, TOML entry, and calls metablogizerctl unpublish + delete" {
+    make_html "$TMP/page.html"
+    run "$DROPLETCTL" publish "$TMP/page.html" doomed mydomain.test
+    [ "$status" -eq 0 ]
+    [ -d "$SITES_DIR/doomed" ]
+    grep -q '^\[sites\.doomed\]' "$TOML_PATH"
+
+    # Reset stub log so we only see remove's calls.
+    : > "$STUB_LOG"
+    run "$DROPLETCTL" remove doomed
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "[OK]" ]]
+    [ ! -d "$SITES_DIR/doomed" ]
+    ! grep -q '^\[sites\.doomed\]' "$TOML_PATH"
+    grep -q "metablogizerctl site unpublish doomed" "$STUB_LOG"
+    grep -q "metablogizerctl site delete doomed" "$STUB_LOG"
+}

--- a/packages/secubox-droplet/tests/test_dropletctl.bats
+++ b/packages/secubox-droplet/tests/test_dropletctl.bats
@@ -124,3 +124,23 @@ load helpers
     grep -q "metablogizerctl site unpublish doomed" "$STUB_LOG"
     grep -q "metablogizerctl site delete doomed" "$STUB_LOG"
 }
+
+@test "rename moves docroot, swaps TOML entry, calls delete+publish on delegate" {
+    make_html "$TMP/page.html"
+    run "$DROPLETCTL" publish "$TMP/page.html" oldname mydomain.test
+    [ "$status" -eq 0 ]
+    [ -d "$SITES_DIR/oldname" ]
+
+    : > "$STUB_LOG"
+    run "$DROPLETCTL" rename oldname newname
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "[OK]" ]]
+    [ ! -d "$SITES_DIR/oldname" ]
+    [ -d "$SITES_DIR/newname" ]
+    [ -f "$SITES_DIR/newname/index.html" ]
+    ! grep -q '^\[sites\.oldname\]' "$TOML_PATH"
+    grep -q '^\[sites\.newname\]' "$TOML_PATH"
+    # Delegate called: delete old, then publish new.
+    grep -q "metablogizerctl site delete oldname" "$STUB_LOG"
+    grep -q "metablogizerctl site publish newname" "$STUB_LOG"
+}


### PR DESCRIPTION
## Summary

Ports the OpenWrt `secubox-app-droplet` CLI into Debian as `/usr/sbin/dropletctl` in the `secubox-droplet` package. Static-only publisher (HTML / ZIP / tarball / directory) that delegates HTTP-facing work (nginx vhost, HAProxy ACL, mitmproxy route) to `metablogizerctl site publish`.

**Subcommands:** `publish` · `list` · `remove` · `rename`

**Tests:** 17 bats cases with PATH-shimmed `metablogizerctl` + `logger` stubs.

## Supersedes PR #185

The earlier merged PR #185 (issue #181) shipped a different `dropletctl` — a noun-verb wrapper over the Droplet API socket (\`file upload/list/rename/...\`). Per user direction, that 215-line implementation is replaced by the OpenWrt-derived static publisher in this PR. The changelog entry for `1.1.0-1~bookworm1` documents the supersession.

## Workflow

- Brainstormed → spec (`docs/superpowers/specs/2026-05-18-dropletctl-design.md`) → plan (`docs/superpowers/plans/2026-05-18-dropletctl.md`) → 11-task TDD subagent-driven execution with two-stage review (spec compliance + code quality) per task.
- Three plan deviations accepted (each a fix to a plan bug): T3 `staging` made script-global so EXIT trap works under `set -u`; T8 collision/same-name guards added; T9 `cmd_list` reconstructs vhost from `\$name.\$domain` because plan would have printed the bare domain.
- Final whole-branch review caught two real bugs not seen in per-task reviews: `cmd_rename` was storing prefixed FQDN instead of bare base (caused double-prefix in `list` post-rename), and `cmd_publish` accepted arbitrary `domain` strings (TOML injection). Both fixed before merge, both covered by red-on-old tests.

## Packaging

- Version bumped 1.0.2 → 1.1.0 (semver-major for behavior change)
- New runtime Depends: \`secubox-metablogizer (>= 1.1), rsync, unzip, python3\`
- \`debian/rules\` install line for \`/usr/sbin/dropletctl\` was already present from PR #185 — only the comment changed
- No postinst/prerm changes (stateless CLI)

## Deferred to follow-up issues

- Add \`flock\` around TOML writers for concurrency safety
- Refactor the 3 hand-rolled TOML regexes into a shared python helper
- Make \`cmd_rename\` revert state on metablogizerctl publish failure (currently leaves half-renamed state, exit 5)
- Replace \`[ON]\` literal in \`cmd_list\` with real metablogizerctl state query
- Write \`packages/secubox-droplet/README.md\` describing the new CLI
- Write a man page (\`debian/dropletctl.8\`) — the OpenWrt origin shipped one

## Test plan

- [ ] Local: \`cd packages/secubox-droplet && bats tests/test_dropletctl.bats\` → 17 tests, 0 failures
- [ ] Build: \`dpkg-buildpackage -us -uc -b\` succeeds, \`.deb\` ships \`/usr/sbin/dropletctl\`
- [ ] Hardware bench on gk2 (192.168.1.200): \`dropletctl publish /tmp/smoke.html smoke gk2.secubox.in\` → \`curl -sSI https://smoke.gk2.secubox.in/\` returns 200; \`dropletctl list\` shows it; \`dropletctl rename smoke smoke2\`; \`dropletctl remove smoke2\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)