### PR TITLE
fix(eye-square): rules drift — drop right_panel, install kiosk (closes #202)

### DIFF
--- a/packages/secubox-eye-square/debian/changelog
+++ b/packages/secubox-eye-square/debian/changelog
@@ -1,3 +1,15 @@
+secubox-eye-square (1.0.2-1~bookworm1) bookworm; urgency=medium
+
+  * Fix debian/rules content drift: drop the install block for
+    right_panel/secubox_eye_square_right_panel/ (a PySide6 component
+    anticipated in Phase 2 but dropped during the Phase 3 rewrite
+    to Pillow+framebuffer; the directory has never existed on disk).
+    Add an install block for kiosk/secubox_eye_square_kiosk/ which
+    DOES exist and is the actual Phase 3 framebuffer kiosk payload.
+  * Closes #202.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Tue, 19 May 2026 06:45:00 +0200
+
 secubox-eye-square (1.0.1-1~bookworm1) bookworm; urgency=medium
 
   * Switch Architecture: arm64 → all. The package is pure-Python

--- a/packages/secubox-eye-square/debian/rules
+++ b/packages/secubox-eye-square/debian/rules
@@ -6,8 +6,8 @@ override_dh_auto_install:
 	# Helper package
 	mkdir -p debian/secubox-eye-square/usr/lib/python3/dist-packages/eye_square_helper
 	cp -r helper/eye_square_helper/. debian/secubox-eye-square/usr/lib/python3/dist-packages/eye_square_helper/
-	# Right-panel package
-	mkdir -p debian/secubox-eye-square/usr/lib/python3/dist-packages/secubox_eye_square_right_panel
-	cp -r right_panel/secubox_eye_square_right_panel/. debian/secubox-eye-square/usr/lib/python3/dist-packages/secubox_eye_square_right_panel/
+	# Kiosk package (replaced the Phase 2 PySide6 right_panel during Phase 3 rewrite)
+	mkdir -p debian/secubox-eye-square/usr/lib/python3/dist-packages/secubox_eye_square_kiosk
+	cp -r kiosk/secubox_eye_square_kiosk/. debian/secubox-eye-square/usr/lib/python3/dist-packages/secubox_eye_square_kiosk/
 	# Config files (systemd units, nginx site, etc) from the sibling remote-ui/square/files/
 	cp -r ../../remote-ui/square/files/. debian/secubox-eye-square/


### PR DESCRIPTION
## Summary

Fix the `override_dh_auto_install` in `packages/secubox-eye-square/debian/rules`:

- **Drop** the install block for `right_panel/secubox_eye_square_right_panel/` — directory has never existed on disk; was anticipated by the Phase 2 PySide6 design but dropped during the Phase 3 rewrite to Pillow+framebuffer.
- **Add** an install block for `kiosk/secubox_eye_square_kiosk/` — exists on disk, is the Phase 3 payload, was never being installed.

Bump `1.0.1` → `1.0.2`.

## Local verification

`dpkg-buildpackage -us -uc -b` from the package dir now progresses through `override_dh_auto_install` cleanly and the kiosk module lands at `debian/secubox-eye-square/usr/lib/python3/dist-packages/secubox_eye_square_kiosk/` (verified via `find` on the staging tree).

## Known not-fixed-here

Build still fails later in `dh_usrlocal` because `remote-ui/square/files/usr/local/sbin/firstboot.sh` is a file under `/usr/local/`, which Debian policy reserves for the local admin. Pre-existing, unrelated to this fix. Filing a separate issue describing the policy violation and proposing relocation to `/usr/lib/secubox/` or `/usr/sbin/`.

## Test plan

- [ ] CI eye-square build progresses past the `cp -r right_panel/...` error (gets further; will still fail on dh_usrlocal until the follow-up lands)
- [ ] After both this PR and the dh_usrlocal follow-up merge, `dpkg-buildpackage` produces a valid .deb with `usr/lib/python3/dist-packages/secubox_eye_square_kiosk/` present
- [ ] No `usr/lib/python3/dist-packages/secubox_eye_square_right_panel/` in any built .deb

🤖 Generated with [Claude Code](https://claude.com/claude-code)