### PR TITLE
feat(metablogizer,droplet): orchestrate haproxy + mitmproxy on publish (closes #200)

### DIFF
--- a/packages/secubox-droplet/debian/changelog
+++ b/packages/secubox-droplet/debian/changelog
@@ -1,3 +1,20 @@
+secubox-droplet (1.1.1-1~bookworm1) bookworm; urgency=medium
+
+  * dropletctl publish / rename: pass --public-domain <vhost> to
+    metablogizerctl so the full HAProxy → mitmproxy chain is wired
+    automatically. Closes the end-to-end gap reported by the gk2
+    smoke test of 1.1.0 (curl https://smoke.gk2.secubox.in/ → 502
+    because metablogizerctl publish only configured nginx, leaving
+    HAProxy + mitmproxy uninstalled — fixed in metablogizer 1.2.0).
+  * Bump Depends: secubox-metablogizer (>= 1.2) — required for the
+    --public-domain flag.
+  * Tests updated to assert dropletctl invokes metablogizerctl with
+    the new flag on both publish and rename paths.
+  * Closes #200 (the droplet side; metablogizer 1.2.0 ships the
+    receiving end).
+
+ -- Gerald KERMA <devel@cybermind.fr>  Tue, 19 May 2026 07:15:00 +0200
+
 secubox-droplet (1.1.0-1~bookworm1) bookworm; urgency=medium
 
   * Add dropletctl static-publisher CLI at /usr/sbin/dropletctl (port

--- a/packages/secubox-droplet/debian/control
+++ b/packages/secubox-droplet/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 4.6.2
 
 Package: secubox-droplet
 Architecture: all
-Depends: ${misc:Depends}, secubox-core (>= 1.0), python3-uvicorn | python3-pip, python3-aiofiles, secubox-metablogizer (>= 1.1), rsync, unzip, python3
+Depends: ${misc:Depends}, secubox-core (>= 1.0), python3-uvicorn | python3-pip, python3-aiofiles, secubox-metablogizer (>= 1.2), rsync, unzip, python3
 Description: SecuBox Droplet File Publisher
  Dashboard pour la publication de fichiers et sites statiques.
  Port Debian bookworm de luci-app-droplet (SecuBox OpenWrt).

--- a/packages/secubox-droplet/sbin/dropletctl
+++ b/packages/secubox-droplet/sbin/dropletctl
@@ -158,7 +158,10 @@ cmd_publish() {
         log_error "metablogizerctl not found — install secubox-metablogizer"
         exit 4
     fi
-    if ! metablogizerctl site publish "$name"; then
+    # Pass the public vhost so metablogizerctl wires HAProxy + mitmproxy.
+    # Falls back gracefully on older metablogizer (which ignores the flag
+    # and only configures nginx — same behavior as droplet 1.1.0).
+    if ! metablogizerctl site publish "$name" --public-domain "$vhost"; then
         log_error "metablogizerctl failed for $name"
         exit 5
     fi
@@ -304,10 +307,15 @@ cmd_rename() {
     fi
     upsert_toml_site "$new" "$base_domain" "static"
 
+    # Public vhost for the new name (constructed from sanitized name + base
+    # domain just like cmd_publish does — keeps invariant consistent across
+    # publish/rename and ensures HAProxy is wired for the renamed site).
+    local new_vhost="${new}.${base_domain}"
+
     # delete is tolerant: old vhost may never have been registered.
     metablogizerctl site delete "$old"  || true
     # publish must succeed: failure leaves site half-renamed and unreachable.
-    metablogizerctl site publish "$new" || {
+    metablogizerctl site publish "$new" --public-domain "$new_vhost" || {
         log_error "metablogizerctl failed for $new"
         exit 5
     }

--- a/packages/secubox-droplet/tests/test_dropletctl.bats
+++ b/packages/secubox-droplet/tests/test_dropletctl.bats
@@ -39,8 +39,9 @@ load helpers
     # Docroot has the staged file.
     [ -f "$SITES_DIR/mysite/index.html" ]
     grep -q "fixture" "$SITES_DIR/mysite/index.html"
-    # Delegate was called with the right args.
-    grep -q "metablogizerctl site publish mysite" "$STUB_LOG"
+    # Delegate was called with the right args, INCLUDING the --public-domain
+    # flag so metablogizerctl can wire HAProxy + mitmproxy (issue #200).
+    grep -q "metablogizerctl site publish mysite --public-domain mysite.mydomain.test" "$STUB_LOG"
 }
 
 @test "publish sanitizes uppercase + special chars in name" {
@@ -142,7 +143,8 @@ load helpers
     grep -q '^\[sites\.newname\]' "$TOML_PATH"
     # Delegate called: delete old, then publish new.
     grep -q "metablogizerctl site delete oldname" "$STUB_LOG"
-    grep -q "metablogizerctl site publish newname" "$STUB_LOG"
+    # Rename also passes --public-domain so the new HAProxy vhost is wired (#200).
+    grep -q "metablogizerctl site publish newname --public-domain newname.mydomain.test" "$STUB_LOG"
 }
 
 @test "rename fails when target name already exists" {

--- a/packages/secubox-metablogizer/debian/changelog
+++ b/packages/secubox-metablogizer/debian/changelog
@@ -1,3 +1,29 @@
+secubox-metablogizer (1.2.0-1~bookworm1) bookworm; urgency=medium
+
+  * metablogizerctl site publish: new --public-domain <fqdn> flag.
+    When given:
+      - Inject the FQDN into the nginx vhost server_name (so the
+        same nginx instance answers Host: <fqdn> coming back through
+        HAProxy → mitmproxy).
+      - Persist public_domain in site.json (consumed by unpublish).
+      - Run `haproxyctl vhost add <fqdn> mitmproxy_inspector true`
+        to wire the routing-layer backend.
+      - Trigger the mitmproxy route sync via
+        `systemctl start sync-mitmproxy-routes.service`
+        (falls back to `sync-mitmproxy-routes.sh` in PATH; warns if
+        neither is available).
+    Without the flag the behavior is unchanged from 1.1.x (internal
+    nginx vhost only).
+  * metablogizerctl site unpublish: reads public_domain from site.json
+    and auto-reverses the HAProxy vhost add + re-triggers the route
+    sync. No-op if the site was never published with --public-domain.
+  * Validates --public-domain syntactically against
+    ^[a-zA-Z0-9.-]+$ (defence-in-depth: blocks shell/TOML injection
+    via the API boundary that callers like dropletctl expose).
+  * Closes #200.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Tue, 19 May 2026 07:10:00 +0200
+
 secubox-metablogizer (1.1.1-1~bookworm1) bookworm; urgency=medium
 
   * metablogizerctl: forge tor noun verbs (issue #184) — the Emancipate

--- a/packages/secubox-metablogizer/sbin/metablogizerctl
+++ b/packages/secubox-metablogizer/sbin/metablogizerctl
@@ -3,12 +3,20 @@
 # Static site publisher for Debian
 # Three-fold architecture: Components, Status, Access
 
-VERSION="1.1.0"
+VERSION="1.2.0"
 CONFIG_FILE="/etc/secubox/metablogizer.toml"
 SITES_ROOT="/srv/metablogizer/sites"
 DATA_PATH="/srv/metablogizer"
 NGINX_VHOST_DIR="/etc/nginx/sites-available"
 NGINX_ENABLED_DIR="/etc/nginx/sites-enabled"
+
+# Public-vhost wiring. Set to "1" to inject HAProxy + mitmproxy route on publish.
+# Triggered automatically when site_publish is called with --public-domain.
+# The sync script + service may live at non-standard paths on different hosts;
+# we try systemctl first, fall back to `command -v`.
+HAPROXYCTL="${HAPROXYCTL:-haproxyctl}"
+SYNC_SCRIPT="${SYNC_SCRIPT:-sync-mitmproxy-routes.sh}"
+SYNC_SERVICE="${SYNC_SERVICE:-sync-mitmproxy-routes.service}"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -124,11 +132,46 @@ site_delete() {
 }
 
 site_publish() {
-    local name="$1"
+    local name="" public_domain=""
+
+    # Parse args: positional <name> then optional --public-domain <fqdn>.
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --public-domain)
+                public_domain="$2"
+                shift 2
+                ;;
+            --public-domain=*)
+                public_domain="${1#--public-domain=}"
+                shift
+                ;;
+            -*)
+                error "Unknown option: $1"
+                return 1
+                ;;
+            *)
+                if [ -z "$name" ]; then
+                    name="$1"
+                else
+                    error "Unexpected argument: $1"
+                    return 1
+                fi
+                shift
+                ;;
+        esac
+    done
 
     if [ -z "$name" ]; then
-        echo "Usage: metablogizerctl site publish <name>"
+        echo "Usage: metablogizerctl site publish <name> [--public-domain <fqdn>]"
         return 1
+    fi
+
+    # Validate --public-domain syntactically (defence-in-depth: blocks shell/TOML injection).
+    if [ -n "$public_domain" ]; then
+        if ! printf '%s' "$public_domain" | grep -qE '^[a-zA-Z0-9.-]+$'; then
+            error "Invalid --public-domain '$public_domain'"
+            return 1
+        fi
     fi
 
     local site_dir="$SITES_ROOT/$name"
@@ -137,14 +180,22 @@ site_publish() {
         return 1
     fi
 
-    # Read site config
+    # Read existing internal domain from site.json (or fall back to <name>.<default>).
     local domain
     if [ -f "$site_dir/site.json" ]; then
         domain=$(grep '"domain"' "$site_dir/site.json" | cut -d'"' -f4)
     fi
     domain="${domain:-${name}.${DEFAULT_DOMAIN}}"
 
-    log "Publishing site: $name to $domain"
+    # The nginx vhost responds to BOTH the internal .secubox.local name and the
+    # public FQDN (so the same nginx instance answers Host: smoke.gk2.secubox.in
+    # coming back through HAProxy → mitmproxy).
+    local server_names="$domain"
+    if [ -n "$public_domain" ] && [ "$public_domain" != "$domain" ]; then
+        server_names="$domain $public_domain"
+    fi
+
+    log "Publishing site: $name to $domain${public_domain:+ (public: $public_domain)}"
 
     # Generate nginx config
     cat > "$NGINX_VHOST_DIR/${name}.conf" << EOF
@@ -153,7 +204,7 @@ site_publish() {
 
 server {
     listen 80;
-    server_name $domain;
+    server_name $server_names;
     root $site_dir/public;
     index index.html index.htm;
 
@@ -178,6 +229,115 @@ EOF
     nginx -t && systemctl reload nginx
 
     log "Site published: http://$domain"
+
+    # Public-vhost wiring (HAProxy + mitmproxy route sync).
+    # Only runs when --public-domain was passed AND the helper CLIs are present.
+    # Failures are tolerated so the nginx publish still counts as success.
+    if [ -n "$public_domain" ]; then
+        site_persist_public_domain "$name" "$public_domain"
+        site_wire_public_vhost "$public_domain"
+    fi
+}
+
+# Persist public_domain in site.json so site_unpublish can reverse the wiring.
+# Naïve TOML-style key/value: we keep the file as a flat JSON object with
+# "domain" + "public_domain" keys. Uses python3 if available for safe rewrite;
+# falls back to a grep/sed approach.
+site_persist_public_domain() {
+    local name="$1" public_domain="$2"
+    local site_dir="$SITES_ROOT/$name"
+    local site_json="$site_dir/site.json"
+
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "$site_json" "$public_domain" <<'PY'
+import json, os, sys, tempfile
+path, public_domain = sys.argv[1:]
+data = {}
+if os.path.exists(path):
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        data = {}
+data["public_domain"] = public_domain
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or ".", prefix=".site.", suffix=".json")
+os.write(fd, json.dumps(data, indent=2).encode() + b"\n")
+os.close(fd)
+os.replace(tmp, path)
+PY
+    else
+        # Minimal fallback: append/replace the "public_domain" line.
+        # Caller already validated the FQDN regex so quoting is safe.
+        if [ -f "$site_json" ] && grep -q '"public_domain"' "$site_json"; then
+            sed -i -E "s|\"public_domain\":[[:space:]]*\"[^\"]*\"|\"public_domain\": \"${public_domain}\"|" "$site_json"
+        elif [ -f "$site_json" ]; then
+            # Insert before the final }
+            sed -i -E "s|^}|  ,\"public_domain\": \"${public_domain}\"\n}|" "$site_json"
+        else
+            printf '{\n  "public_domain": "%s"\n}\n' "$public_domain" > "$site_json"
+        fi
+    fi
+}
+
+# Read public_domain from site.json. Echoes the value or empty string.
+site_read_public_domain() {
+    local name="$1"
+    local site_json="$SITES_ROOT/$name/site.json"
+    [ -f "$site_json" ] || return 0
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c "
+import json, sys
+try:
+    print(json.load(open('$site_json')).get('public_domain', ''))
+except Exception:
+    pass
+"
+    else
+        grep '"public_domain"' "$site_json" 2>/dev/null | head -1 | cut -d'"' -f4 || true
+    fi
+}
+
+# Wire the HAProxy vhost + trigger mitmproxy route sync for <public_domain>.
+# Tolerant of missing tools (logs a warning and continues).
+site_wire_public_vhost() {
+    local public_domain="$1"
+    if ! command -v "$HAPROXYCTL" >/dev/null 2>&1; then
+        warn "$HAPROXYCTL not found — skipping HAProxy vhost add for $public_domain"
+        return 0
+    fi
+    if "$HAPROXYCTL" vhost add "$public_domain" mitmproxy_inspector true 2>&1; then
+        log "HAProxy vhost added: $public_domain → mitmproxy_inspector (ssl)"
+    else
+        warn "haproxyctl vhost add failed for $public_domain (continuing)"
+    fi
+    site_trigger_sync
+}
+
+# Trigger mitmproxy route sync. Prefer systemctl unit, fall back to direct script.
+site_trigger_sync() {
+    if command -v systemctl >/dev/null 2>&1 && \
+       systemctl list-unit-files "$SYNC_SERVICE" >/dev/null 2>&1; then
+        systemctl start "$SYNC_SERVICE" 2>/dev/null || warn "systemctl start $SYNC_SERVICE failed"
+    elif command -v "$SYNC_SCRIPT" >/dev/null 2>&1; then
+        "$SYNC_SCRIPT" 2>&1 || warn "$SYNC_SCRIPT exited non-zero"
+    else
+        warn "no sync mechanism found (neither $SYNC_SERVICE nor $SYNC_SCRIPT in PATH) — mitmproxy routes NOT updated"
+    fi
+}
+
+# Reverse of site_wire_public_vhost: remove the HAProxy vhost + re-sync.
+site_unwire_public_vhost() {
+    local public_domain="$1"
+    if ! command -v "$HAPROXYCTL" >/dev/null 2>&1; then
+        warn "$HAPROXYCTL not found — skipping HAProxy vhost remove for $public_domain"
+        return 0
+    fi
+    if "$HAPROXYCTL" vhost remove "$public_domain" 2>&1; then
+        log "HAProxy vhost removed: $public_domain"
+    else
+        warn "haproxyctl vhost remove failed for $public_domain (continuing)"
+    fi
+    site_trigger_sync
 }
 
 site_unpublish() {
@@ -188,10 +348,19 @@ site_unpublish() {
         return 1
     fi
 
+    # Read public_domain BEFORE removing the site files (site_delete may follow).
+    local public_domain
+    public_domain="$(site_read_public_domain "$name")"
+
     rm -f "$NGINX_ENABLED_DIR/${name}.conf"
     systemctl reload nginx
 
     log "Site unpublished: $name"
+
+    # Reverse the HAProxy + mitmproxy wiring if site was publicly published.
+    if [ -n "$public_domain" ]; then
+        site_unwire_public_vhost "$public_domain"
+    fi
 }
 
 # ============================================================================
@@ -532,8 +701,11 @@ Information (Three-fold):
 Sites:
   site create <name> [domain] [template]  Create new site
   site delete <name>                       Delete site
-  site publish <name>                      Publish site (create nginx vhost)
-  site unpublish <name>                    Unpublish site
+  site publish <name> [--public-domain <fqdn>]
+                                           Publish site (nginx vhost + optional
+                                           HAProxy + mitmproxy route sync)
+  site unpublish <name>                    Unpublish site (auto-reverses HAProxy
+                                           if site was published with --public-domain)
   site list                                List all sites
 
 Tor (Punk Exposure / Emancipate, issue #184):


### PR DESCRIPTION
## Summary

Closes the end-to-end gap discovered during the gk2 smoke test of `dropletctl` 1.1.0: `curl https://smoke.gk2.secubox.in/` returned `502 Bad Gateway` because `metablogizerctl site publish` only configured nginx — it left HAProxy + mitmproxy unaware of the user-facing vhost.

This PR implements **Option A** of the design proposed in #200: extend `metablogizerctl site publish` to optionally orchestrate the whole routing chain.

## metablogizerctl 1.1.1 → 1.2.0

New `--public-domain <fqdn>` flag on `site publish`. When provided:

1. Injects the FQDN into the nginx vhost `server_name` (so the same nginx instance answers `Host: <fqdn>` coming back through HAProxy → mitmproxy)
2. Persists `public_domain` in `site.json` (consumed by `unpublish`)
3. Runs `haproxyctl vhost add <fqdn> mitmproxy_inspector true`
4. Triggers `systemctl start sync-mitmproxy-routes.service` (falls back to `sync-mitmproxy-routes.sh` in PATH; warns if neither available)

Without the flag, behaviour is unchanged from 1.1.x (nginx-only).

`site unpublish` now reads `public_domain` from `site.json` and auto-reverses the HAProxy add + re-triggers the route sync. No-op if the site was never published with `--public-domain`.

`--public-domain` is validated against `^[a-zA-Z0-9.-]+$` as defence-in-depth against shell/TOML injection from API callers.

## dropletctl 1.1.0 → 1.1.1

`cmd_publish` and `cmd_rename` now pass `--public-domain "$vhost"` to `metablogizerctl`. `cmd_remove` doesn't need change — metablogizer reads `public_domain` from `site.json` and reverses.

Depends: `secubox-metablogizer (>= 1.2)` — required for the new flag.

Bats tests tightened: the publish + rename cases now assert the full `--public-domain <fqdn>` argv was logged by the stub. **17/17 green** locally.

## Test plan

- [ ] `apt install` both .debs on gk2 (admin.gk2.secubox.in)
- [ ] `dropletctl publish /tmp/smoke.html smoke gk2.secubox.in` succeeds
- [ ] `curl -sSI https://smoke.gk2.secubox.in/` returns **200** (was 502 on 1.1.0)
- [ ] `dropletctl remove smoke` → vhost gone from HAProxy + mitmproxy routes table
- [ ] `metablogizerctl site publish foo` without --public-domain still works (internal-only, no haproxy)

## Related

- Surfaced by deploy of #196 / PR #199; filed as #200
- Builds on the dropletctl foundation merged via #199, #204, #205, #206, #208
- The on-host `sync-mitmproxy-routes.sh` is currently admin-deployed to `/usr/local/bin/` with a systemd timer; not packaged in-repo (separate concern, out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)