### PR TITLE
fix(health-doctor): drop act-runner-arm64 from vital REGISTRY (#214)

### DIFF
--- a/packages/secubox-health-doctor/api/checks.py
+++ b/packages/secubox-health-doctor/api/checks.py
@@ -174,16 +174,22 @@ def check_act_runner_arm64() -> tuple[bool, dict]:
 
 # ── Registry ──────────────────────────────────────────────────────────────
 
+# Vital — every entry here counts toward the "failing" tally in the doctor
+# summary. Keep this list strict: only services whose absence makes the
+# board itself unusable. CI runners, optional capacity probes, etc. should
+# go in REGISTRY_INFORMATIONAL once that tier is forged (#214 followup).
 REGISTRY: Dict[str, CheckFn] = {
-    "haproxy":            check_haproxy,
-    "nginx":              check_nginx,
-    "secubox-metrics":    check_secubox_metrics,
-    "secubox-hub":        check_secubox_hub,
-    "mitmproxy-lxc":      check_mitmproxy_lxc,
-    "gitea-lxc":          check_gitea_lxc,
-    "mail-lxc":           check_mail_lxc,
+    "haproxy":             check_haproxy,
+    "nginx":               check_nginx,
+    "secubox-metrics":     check_secubox_metrics,
+    "secubox-hub":         check_secubox_hub,
+    "mitmproxy-lxc":       check_mitmproxy_lxc,
+    "gitea-lxc":           check_gitea_lxc,
+    "mail-lxc":            check_mail_lxc,
     "cookie-audit-ledger": check_cookie_audit_ledger,
-    "crowdsec":           check_crowdsec,
-    "filesystems":        check_filesystems,
-    "act-runner-arm64":   check_act_runner_arm64,
+    "crowdsec":            check_crowdsec,
+    "filesystems":         check_filesystems,
 }
+# check_act_runner_arm64 kept as a module-level function (cheap) so a
+# future REGISTRY_INFORMATIONAL tier can reuse it without duplication.
+# Not vital — a stopped CI runner doesn't break the board (#214).

--- a/packages/secubox-health-doctor/debian/changelog
+++ b/packages/secubox-health-doctor/debian/changelog
@@ -1,3 +1,12 @@
+secubox-health-doctor (1.0.1-1~bookworm1) bookworm; urgency=medium
+
+  * Drop act-runner-arm64 from vital REGISTRY (#214). A stopped CI runner
+    doesn't break the board and shouldn't count as a vital-service failure.
+    The check_act_runner_arm64 function is kept at module level for reuse
+    by a future REGISTRY_INFORMATIONAL tier.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Tue, 19 May 2026 07:53:56 +0200
+
 secubox-health-doctor (1.0.0-1~bookworm1) bookworm; urgency=medium
 
   * Initial release (issue #212).


### PR DESCRIPTION
Closes #214. CI runner isn't vital — operator feedback after #213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)