### PR TITLE
fix(web): rewrite stale /portal/login.html -> /login.html (#222)

### DIFF
--- a/packages/secubox-ad-guard/www/ad-guard/index.html
+++ b/packages/secubox-ad-guard/www/ad-guard/index.html
@@ -258,7 +258,7 @@
             if (data) opts.body = JSON.stringify(data);
             try {
                 const res = await fetch(API_BASE + endpoint, opts);
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch (e) { return null; }
         }

--- a/packages/secubox-admin/www/admin/index.html
+++ b/packages/secubox-admin/www/admin/index.html
@@ -520,7 +520,7 @@
 
         function checkAuth() {
             if (!getToken()) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 return false;
             }
             return true;
@@ -534,7 +534,7 @@
             try {
                 const res = await fetch(API + endpoint, { ...options, headers });
                 if (res.status === 401) {
-                    window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                    window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                     return null;
                 }
                 return res.json();

--- a/packages/secubox-ai-gateway/www/ai-gateway/index.html
+++ b/packages/secubox-ai-gateway/www/ai-gateway/index.html
@@ -137,7 +137,7 @@
             const headers = { 'Content-Type': 'application/json', ...(token ? { 'Authorization': 'Bearer ' + token } : {}) };
             try {
                 const res = await fetch(API + path, { method, headers });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch { return null; }
         }

--- a/packages/secubox-ai-insights/www/ai-insights/index.html
+++ b/packages/secubox-ai-insights/www/ai-insights/index.html
@@ -446,7 +446,7 @@
             const headers = { 'Content-Type': 'application/json', ...(token ? { 'Authorization': 'Bearer ' + token } : {}) };
             try {
                 const res = await fetch(API + path, { method, headers, body: data ? JSON.stringify(data) : null });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch { return null; }
         }

--- a/packages/secubox-avatar/www/avatar/index.html
+++ b/packages/secubox-avatar/www/avatar/index.html
@@ -401,7 +401,7 @@
 
         function checkAuth() {
             if (!getToken()) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 return false;
             }
             return true;
@@ -422,7 +422,7 @@
                 }
                 const res = await fetch(API + endpoint, fetchOptions);
                 if (res.status === 401) {
-                    window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                    window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                     return null;
                 }
                 return res.json();

--- a/packages/secubox-backup/www/backup/index.html
+++ b/packages/secubox-backup/www/backup/index.html
@@ -375,7 +375,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch (e) { console.error(e); return null; }
         }

--- a/packages/secubox-config-advisor/www/config-advisor/index.html
+++ b/packages/secubox-config-advisor/www/config-advisor/index.html
@@ -115,7 +115,7 @@
             const headers = { 'Content-Type': 'application/json', ...(token ? { 'Authorization': 'Bearer ' + token } : {}) };
             try {
                 const res = await fetch(API + path, { method, headers, body: data ? JSON.stringify(data) : null });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch { return null; }
         }

--- a/packages/secubox-cookies/www/cookies/index.html
+++ b/packages/secubox-cookies/www/cookies/index.html
@@ -612,7 +612,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch (e) { console.error(e); return null; }
         }

--- a/packages/secubox-cve-triage/www/cve-triage/index.html
+++ b/packages/secubox-cve-triage/www/cve-triage/index.html
@@ -260,7 +260,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) return {};
                 const text = await res.text();
                 return text ? JSON.parse(text) : {};

--- a/packages/secubox-cyberfeed/www/cyberfeed/index.html
+++ b/packages/secubox-cyberfeed/www/cyberfeed/index.html
@@ -271,7 +271,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) return {};
                 const text = await res.text();
                 return text ? JSON.parse(text) : {};

--- a/packages/secubox-device-intel/www/device-intel/index.html
+++ b/packages/secubox-device-intel/www/device-intel/index.html
@@ -179,7 +179,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) return {};
                 const text = await res.text();
                 return text ? JSON.parse(text) : {};

--- a/packages/secubox-dns-guard/www/dns-guard/index.html
+++ b/packages/secubox-dns-guard/www/dns-guard/index.html
@@ -129,7 +129,7 @@
             const headers = { 'Content-Type': 'application/json', ...(token ? { 'Authorization': 'Bearer ' + token } : {}) };
             try {
                 const res = await fetch(API + path, { method, headers, body: data ? JSON.stringify(data) : null });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch { return null; }
         }

--- a/packages/secubox-exposure/www/exposure/index.html
+++ b/packages/secubox-exposure/www/exposure/index.html
@@ -439,7 +439,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch (e) { console.error(e); return null; }
         }

--- a/packages/secubox-glances/www/glances/index.html
+++ b/packages/secubox-glances/www/glances/index.html
@@ -472,7 +472,7 @@
 
         function checkAuth() {
             if (!getToken()) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 return false;
             }
             return true;
@@ -486,7 +486,7 @@
             try {
                 const res = await fetch(API + endpoint, { ...options, headers });
                 if (res.status === 401) {
-                    window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                    window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                     return null;
                 }
                 return res.json();

--- a/packages/secubox-gotosocial/www/gotosocial/index.html
+++ b/packages/secubox-gotosocial/www/gotosocial/index.html
@@ -560,7 +560,7 @@
             if (token) headers['Authorization'] = `Bearer ${token}`;
             const res = await fetch(API + endpoint, { ...options, headers, credentials: 'include' });
             if (res.status === 401) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 throw new Error('Unauthorized');
             }
             return res.json();

--- a/packages/secubox-hexo/www/hexo/index.html
+++ b/packages/secubox-hexo/www/hexo/index.html
@@ -615,7 +615,7 @@
             if (token) headers['Authorization'] = `Bearer ${token}`;
             const res = await fetch(API + endpoint, { ...options, headers, credentials: 'include' });
             if (res.status === 401) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 throw new Error('Unauthorized');
             }
             return res.json();

--- a/packages/secubox-hub/www/index.html
+++ b/packages/secubox-hub/www/index.html
@@ -714,7 +714,7 @@
 
         function checkAuth() {
             if (!getToken()) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 return false;
             }
             return true;
@@ -936,7 +936,7 @@
             await fetch('/api/v1/portal/logout', { method: 'POST', credentials: 'include' });
             localStorage.removeItem('secubox_token');
             localStorage.removeItem('sbx_token');
-            window.location.href = '/portal/login.html';
+            window.location.href = '/login.html';
         }
 
         async function loadNetworkMode() {

--- a/packages/secubox-hub/www/nac/index.html
+++ b/packages/secubox-hub/www/nac/index.html
@@ -593,7 +593,7 @@
     async function api(path, opts = {}) {
         try {
             const res = await fetch(API + path, { ...opts, headers: headers() });
-            if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+            if (res.status === 401) { window.location = '/login.html'; return {}; }
             if (!res.ok) return {};
             const text = await res.text();
             if (!text || text.trim().charAt(0) === '<') {

--- a/packages/secubox-hub/www/shared/api-utils.js
+++ b/packages/secubox-hub/www/shared/api-utils.js
@@ -108,7 +108,7 @@
             // Handle 401 - redirect to login
             if (res.status === 401) {
                 console.log('[API] 401 Unauthorized, redirecting to login');
-                window.location = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 return { ok: false, status: 401, error: 'Unauthorized', data: null };
             }
 

--- a/packages/secubox-hub/www/soc.html
+++ b/packages/secubox-hub/www/soc.html
@@ -897,7 +897,7 @@
 
         function checkAuth() {
             if (!getToken()) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 return false;
             }
             return true;

--- a/packages/secubox-hub/www/soc/index.html
+++ b/packages/secubox-hub/www/soc/index.html
@@ -1012,7 +1012,7 @@
 
         function checkAuth() {
             if (!getToken()) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 return false;
             }
             return true;

--- a/packages/secubox-identity/www/identity/index.html
+++ b/packages/secubox-identity/www/identity/index.html
@@ -149,7 +149,7 @@
             const headers = { 'Content-Type': 'application/json', ...(token ? { 'Authorization': 'Bearer ' + token } : {}) };
             try {
                 const res = await fetch(API + path, { method, headers, body: data ? JSON.stringify(data) : null });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch { return null; }
         }

--- a/packages/secubox-interceptor/www/interceptor/index.html
+++ b/packages/secubox-interceptor/www/interceptor/index.html
@@ -429,7 +429,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch (e) { console.error(e); return null; }
         }

--- a/packages/secubox-iot-guard/www/iot-guard/index.html
+++ b/packages/secubox-iot-guard/www/iot-guard/index.html
@@ -120,7 +120,7 @@
             const headers = { 'Content-Type': 'application/json', ...(token ? { 'Authorization': 'Bearer ' + token } : {}) };
             try {
                 const res = await fetch(API + path, { method, headers, body: data ? JSON.stringify(data) : null });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch { return null; }
         }

--- a/packages/secubox-ipblock/www/ipblock/index.html
+++ b/packages/secubox-ipblock/www/ipblock/index.html
@@ -378,7 +378,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) return {};
                 const text = await res.text();
                 return text ? JSON.parse(text) : {};

--- a/packages/secubox-jellyfin/www/jellyfin/index.html
+++ b/packages/secubox-jellyfin/www/jellyfin/index.html
@@ -445,7 +445,7 @@
             if (token) headers['Authorization'] = `Bearer ${token}`;
             const res = await fetch(API + endpoint, { ...options, headers, credentials: 'include' });
             if (res.status === 401) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 throw new Error('Unauthorized');
             }
             return res.json();

--- a/packages/secubox-jitsi/www/jitsi/index.html
+++ b/packages/secubox-jitsi/www/jitsi/index.html
@@ -605,7 +605,7 @@
             if (token) headers['Authorization'] = `Bearer ${token}`;
             const res = await fetch(API + endpoint, { ...options, headers, credentials: 'include' });
             if (res.status === 401) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 throw new Error('Unauthorized');
             }
             return res.json();

--- a/packages/secubox-ksm/www/ksm/index.html
+++ b/packages/secubox-ksm/www/ksm/index.html
@@ -381,7 +381,7 @@
 
         function checkAuth() {
             if (!getToken()) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 return false;
             }
             return true;
@@ -395,7 +395,7 @@
             try {
                 const res = await fetch(API + endpoint, { ...options, headers });
                 if (res.status === 401) {
-                    window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                    window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                     return null;
                 }
                 return res.json();

--- a/packages/secubox-localrecall/www/localrecall/index.html
+++ b/packages/secubox-localrecall/www/localrecall/index.html
@@ -116,7 +116,7 @@
             const headers = { 'Content-Type': 'application/json', ...(token ? { 'Authorization': 'Bearer ' + token } : {}) };
             try {
                 const res = await fetch(API + path, { method, headers, body: data ? JSON.stringify(data) : null });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch { return null; }
         }

--- a/packages/secubox-mac-guard/www/mac-guard/index.html
+++ b/packages/secubox-mac-guard/www/mac-guard/index.html
@@ -541,7 +541,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) return {};
                 const text = await res.text();
                 return text ? JSON.parse(text) : {};

--- a/packages/secubox-mail/www/mail/index.html
+++ b/packages/secubox-mail/www/mail/index.html
@@ -628,7 +628,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 return res.json();
             } catch { return {}; }
         }

--- a/packages/secubox-master-link/www/master-link/index.html
+++ b/packages/secubox-master-link/www/master-link/index.html
@@ -203,7 +203,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) return {};
                 const text = await res.text();
                 return text ? JSON.parse(text) : {};

--- a/packages/secubox-mcp-server/www/mcp-server/index.html
+++ b/packages/secubox-mcp-server/www/mcp-server/index.html
@@ -116,7 +116,7 @@
             const headers = { 'Content-Type': 'application/json', ...(token ? { 'Authorization': 'Bearer ' + token } : {}) };
             try {
                 const res = await fetch(API + path, { method, headers, body: data ? JSON.stringify(data) : null });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch { return null; }
         }

--- a/packages/secubox-mesh/www/mesh/index.html
+++ b/packages/secubox-mesh/www/mesh/index.html
@@ -179,7 +179,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) throw new Error(res.statusText);
                 return await res.json();
             } catch (e) { console.error(e); return { error: e.message }; }

--- a/packages/secubox-meshname/www/meshname/index.html
+++ b/packages/secubox-meshname/www/meshname/index.html
@@ -253,7 +253,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) return {};
                 const text = await res.text();
                 return text ? JSON.parse(text) : {};

--- a/packages/secubox-metabolizer/www/metabolizer/index.html
+++ b/packages/secubox-metabolizer/www/metabolizer/index.html
@@ -410,7 +410,7 @@
             try {
                 const res = await fetch(API + endpoint, opts);
                 if (res.status === 401) {
-                    window.location.href = '/portal/login.html';
+                    window.location.href = '/login.html';
                     return {};
                 }
                 return res.json();
@@ -423,7 +423,7 @@
         function checkAuth() {
             const token = localStorage.getItem('sbx_token');
             if (!token) {
-                window.location.href = '/portal/login.html';
+                window.location.href = '/login.html';
             }
         }
 

--- a/packages/secubox-metacatalog/www/metacatalog/index.html
+++ b/packages/secubox-metacatalog/www/metacatalog/index.html
@@ -602,7 +602,7 @@
         async function checkAuth() {
             const token = localStorage.getItem('sbx_token');
             if (!token) {
-                window.location.href = '/portal/login.html';
+                window.location.href = '/login.html';
                 return false;
             }
             return true;
@@ -621,7 +621,7 @@
             try {
                 const res = await fetch(API + endpoint, opts);
                 if (res.status === 401) {
-                    window.location.href = '/portal/login.html';
+                    window.location.href = '/login.html';
                     return null;
                 }
                 return res.json();

--- a/packages/secubox-metrics/www/metrics/index.html
+++ b/packages/secubox-metrics/www/metrics/index.html
@@ -406,7 +406,7 @@
                     headers: token ? { 'Authorization': 'Bearer ' + token } : {}
                 });
                 if (res.status === 401) {
-                    window.location.href = '/portal/login.html';
+                    window.location.href = '/login.html';
                     return {};
                 }
                 return res.json();

--- a/packages/secubox-mitmproxy/www/mitmproxy/filters.html
+++ b/packages/secubox-mitmproxy/www/mitmproxy/filters.html
@@ -304,7 +304,7 @@
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
                 if (res.status === 401) {
-                    window.location = '/portal/login.html';
+                    window.location = '/login.html';
                     return null;
                 }
                 return res.json();

--- a/packages/secubox-mitmproxy/www/mitmproxy/index.html
+++ b/packages/secubox-mitmproxy/www/mitmproxy/index.html
@@ -453,7 +453,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch (e) { console.error(e); return null; }
         }

--- a/packages/secubox-mitmproxy/www/mitmproxy/settings.html
+++ b/packages/secubox-mitmproxy/www/mitmproxy/settings.html
@@ -349,7 +349,7 @@
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
                 if (res.status === 401) {
-                    window.location = '/portal/login.html';
+                    window.location = '/login.html';
                     return null;
                 }
                 return res.json();

--- a/packages/secubox-mqtt/www/mqtt/index.html
+++ b/packages/secubox-mqtt/www/mqtt/index.html
@@ -557,7 +557,7 @@
         // Check auth on page load
         function checkAuth() {
             if (!getToken()) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 return false;
             }
             return true;
@@ -573,7 +573,7 @@
             try {
                 const response = await fetch(url, { ...options, headers });
                 if (response.status === 401) {
-                    window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                    window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                     return null;
                 }
                 if (!response.ok) {

--- a/packages/secubox-netdiag/www/netdiag/index.html
+++ b/packages/secubox-netdiag/www/netdiag/index.html
@@ -652,7 +652,7 @@
 
         function checkAuth() {
             if (!getToken()) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 return false;
             }
             return true;
@@ -672,7 +672,7 @@
             try {
                 const res = await fetch(API + endpoint, opts);
                 if (res.status === 401) {
-                    window.location.href = '/portal/login.html';
+                    window.location.href = '/login.html';
                     return { success: false, error: 'Unauthorized' };
                 }
                 return res.json();

--- a/packages/secubox-nettweak/www/nettweak/index.html
+++ b/packages/secubox-nettweak/www/nettweak/index.html
@@ -428,7 +428,7 @@
 
         function checkAuth() {
             if (!getToken()) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 return false;
             }
             return true;
@@ -442,7 +442,7 @@
             try {
                 const res = await fetch(API + endpoint, { ...options, headers });
                 if (res.status === 401) {
-                    window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                    window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                     return null;
                 }
                 return res.json();

--- a/packages/secubox-network-anomaly/www/network-anomaly/index.html
+++ b/packages/secubox-network-anomaly/www/network-anomaly/index.html
@@ -136,7 +136,7 @@
             const headers = { 'Content-Type': 'application/json', ...(token ? { 'Authorization': 'Bearer ' + token } : {}) };
             try {
                 const res = await fetch(API + path, { method, headers, body: data ? JSON.stringify(data) : null });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch { return null; }
         }

--- a/packages/secubox-newsbin/www/newsbin/index.html
+++ b/packages/secubox-newsbin/www/newsbin/index.html
@@ -623,7 +623,7 @@
             if (token) headers['Authorization'] = `Bearer ${token}`;
             const res = await fetch(API + endpoint, { ...options, headers, credentials: 'include' });
             if (res.status === 401) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 throw new Error('Unauthorized');
             }
             return res.json();

--- a/packages/secubox-ollama/www/ollama/index.html
+++ b/packages/secubox-ollama/www/ollama/index.html
@@ -481,7 +481,7 @@
             if (token) headers['Authorization'] = `Bearer ${token}`;
             const res = await fetch(API + endpoint, { ...options, headers, credentials: 'include' });
             if (res.status === 401) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 throw new Error('Unauthorized');
             }
             return res.json();

--- a/packages/secubox-openclaw/www/openclaw/index.html
+++ b/packages/secubox-openclaw/www/openclaw/index.html
@@ -346,7 +346,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) return {};
                 const text = await res.text();
                 return text ? JSON.parse(text) : {};

--- a/packages/secubox-peertube/www/peertube/index.html
+++ b/packages/secubox-peertube/www/peertube/index.html
@@ -599,7 +599,7 @@
             if (token) headers['Authorization'] = `Bearer ${token}`;
             const res = await fetch(API + endpoint, { ...options, headers, credentials: 'include' });
             if (res.status === 401) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 throw new Error('Unauthorized');
             }
             return res.json();

--- a/packages/secubox-photoprism/www/photoprism/index.html
+++ b/packages/secubox-photoprism/www/photoprism/index.html
@@ -587,7 +587,7 @@
             if (token) headers['Authorization'] = `Bearer ${token}`;
             const res = await fetch(API + endpoint, { ...options, headers, credentials: 'include' });
             if (res.status === 401) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 throw new Error('Unauthorized');
             }
             return res.json();

--- a/packages/secubox-reporter/www/reporter/index.html
+++ b/packages/secubox-reporter/www/reporter/index.html
@@ -430,7 +430,7 @@
             try {
                 const res = await fetch(API + endpoint, opts);
                 if (res.status === 401) {
-                    window.location.href = '/portal/login.html';
+                    window.location.href = '/login.html';
                     return {};
                 }
                 return res.json();
@@ -443,7 +443,7 @@
         function checkAuth() {
             const token = localStorage.getItem('sbx_token');
             if (!token) {
-                window.location.href = '/portal/login.html';
+                window.location.href = '/login.html';
             }
         }
 

--- a/packages/secubox-routes/www/routes/index.html
+++ b/packages/secubox-routes/www/routes/index.html
@@ -622,7 +622,7 @@
         async function checkAuth() {
             const token = localStorage.getItem('sbx_token');
             if (!token) {
-                window.location.href = '/portal/login.html';
+                window.location.href = '/login.html';
                 return false;
             }
             return true;
@@ -641,7 +641,7 @@
             try {
                 const res = await fetch(API + endpoint, opts);
                 if (res.status === 401) {
-                    window.location.href = '/portal/login.html';
+                    window.location.href = '/login.html';
                     return null;
                 }
                 return res.json();

--- a/packages/secubox-rtty/www/rtty/index.html
+++ b/packages/secubox-rtty/www/rtty/index.html
@@ -406,7 +406,7 @@
 
         function checkAuth() {
             if (!getToken()) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 return false;
             }
             return true;
@@ -424,7 +424,7 @@
             try {
                 const res = await fetch(API + endpoint, opts);
                 if (res.status === 401) {
-                    window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                    window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                     return {};
                 }
                 return res.json();

--- a/packages/secubox-smtp-relay/www/smtp-relay/index.html
+++ b/packages/secubox-smtp-relay/www/smtp-relay/index.html
@@ -311,7 +311,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 return res.json();
             } catch { return {}; }
         }
@@ -321,7 +321,7 @@
             // health endpoint doesn't require auth, but other endpoints do
             const tok = token();
             if (!tok) {
-                window.location = '/portal/login.html';
+                window.location = '/login.html';
             }
         }
 

--- a/packages/secubox-soc/www/soc/index.html
+++ b/packages/secubox-soc/www/soc/index.html
@@ -349,7 +349,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) return {};
                 const text = await res.text();
                 return text ? JSON.parse(text) : {};

--- a/packages/secubox-threat-analyst/www/threat-analyst/index.html
+++ b/packages/secubox-threat-analyst/www/threat-analyst/index.html
@@ -129,7 +129,7 @@
             const headers = { 'Content-Type': 'application/json', ...(token ? { 'Authorization': 'Bearer ' + token } : {}) };
             try {
                 const res = await fetch(API + path, { method, headers, body: data ? JSON.stringify(data) : null });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch { return null; }
         }

--- a/packages/secubox-threats/www/threats/index.html
+++ b/packages/secubox-threats/www/threats/index.html
@@ -408,7 +408,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) return {};
                 const text = await res.text();
                 return text ? JSON.parse(text) : {};

--- a/packages/secubox-tor/www/tor/index.html
+++ b/packages/secubox-tor/www/tor/index.html
@@ -383,7 +383,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch (e) { console.error(e); return null; }
         }

--- a/packages/secubox-torrent/www/torrent/index.html
+++ b/packages/secubox-torrent/www/torrent/index.html
@@ -671,7 +671,7 @@
             if (token) headers['Authorization'] = `Bearer ${token}`;
             const res = await fetch(API + endpoint, { ...options, headers, credentials: 'include' });
             if (res.status === 401) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 throw new Error('Unauthorized');
             }
             return res.json();

--- a/packages/secubox-traffic/www/traffic/index.html
+++ b/packages/secubox-traffic/www/traffic/index.html
@@ -487,7 +487,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch (e) { console.error(e); return null; }
         }

--- a/packages/secubox-turn/www/turn/index.html
+++ b/packages/secubox-turn/www/turn/index.html
@@ -375,7 +375,7 @@
 
         function checkAuth() {
             if (!getToken()) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 return false;
             }
             return true;
@@ -393,7 +393,7 @@
             try {
                 const res = await fetch(API + endpoint, opts);
                 if (res.status === 401) {
-                    window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                    window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                     return {};
                 }
                 return res.json();

--- a/packages/secubox-users/www/users/index.html
+++ b/packages/secubox-users/www/users/index.html
@@ -542,7 +542,7 @@
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
                 if (res.status === 401) {
-                    window.location = '/portal/login.html';
+                    window.location = '/login.html';
                     return null;
                 }
                 return res.json();

--- a/packages/secubox-voip/www/voip/index.html
+++ b/packages/secubox-voip/www/voip/index.html
@@ -695,7 +695,7 @@
             if (token) headers['Authorization'] = `Bearer ${token}`;
             const res = await fetch(API + endpoint, { ...options, headers, credentials: 'include' });
             if (res.status === 401) {
-                window.location.href = '/portal/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+                window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
                 throw new Error('Unauthorized');
             }
             return res.json();

--- a/packages/secubox-vortex-dns/www/vortex-dns/index.html
+++ b/packages/secubox-vortex-dns/www/vortex-dns/index.html
@@ -223,7 +223,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) return {};
                 const text = await res.text();
                 return text ? JSON.parse(text) : {};

--- a/packages/secubox-vortex-firewall/www/vortex-firewall/index.html
+++ b/packages/secubox-vortex-firewall/www/vortex-firewall/index.html
@@ -234,7 +234,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) return {};
                 const text = await res.text();
                 return text ? JSON.parse(text) : {};

--- a/packages/secubox-watchdog/www/watchdog/index.html
+++ b/packages/secubox-watchdog/www/watchdog/index.html
@@ -383,7 +383,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return null; }
+                if (res.status === 401) { window.location = '/login.html'; return null; }
                 return res.json();
             } catch (e) { console.error(e); return null; }
         }

--- a/packages/secubox-zkp/www/zkp/index.html
+++ b/packages/secubox-zkp/www/zkp/index.html
@@ -221,7 +221,7 @@
         async function api(path, opts = {}) {
             try {
                 const res = await fetch(API + path, { ...opts, headers: headers() });
-                if (res.status === 401) { window.location = '/portal/login.html'; return {}; }
+                if (res.status === 401) { window.location = '/login.html'; return {}; }
                 if (!res.ok) {
                     const err = await res.json().catch(() => ({}));
                     throw new Error(err.detail || 'API error');


### PR DESCRIPTION
## Summary

- Issue #222 — 67 source files (82 occurrences) still redirect to `/portal/login.html`, which doesn't exist since PR #169 moved login.html under secubox-portal at `/usr/share/secubox/www/login.html`.
- Effect: every appliance boot reaches the kiosk → infinite "Redirecting to login..." loop → no user can ever authenticate.

## Fix

Mechanical `sed` across `packages/*/www/`:
```
sed -i 's|/portal/login\.html|/login.html|g'
```
82 occurrences across 67 files (kiosk root, hub shared/api-utils.js, soc/nac pages, and 65 module index.html files).

Verified clean:
```
grep -rl '/portal/login\.html' packages/ | grep -v /debian/   # empty
```

The remaining `/portal/` references in the codebase are legitimate (API paths like `/api/v1/portal/logout`, portal package's own `/portal/index.html` landing page, menu.d entries) — not touched by this fix.

## Test plan

- [ ] `Build SecuBox .deb packages` CI on this branch — verify no package build breaks (mechanical change in HTML/JS)
- [ ] Rebuild system image (image build CI) on this branch (or after merge with master+#219)
- [ ] Boot fresh VBox amd64 from new image: kiosk reaches login form, `admin` / `secubox` accepted, forced password change UX appears

## References

- Related: #218 / PR #219 (image apt-get -f fix — needed before this UI bug is even reachable)
- Discovered while validating the firstboot v2-schema+argon2 chain end-to-end (#210 → #211 → #218)
- Prior partial fixes that missed these: `bcc6a781`, `464e3379`