### PR TITLE
fix(kiosk): always pass --no-sandbox on Debian 12 AppArmor (#224)

### DIFF
--- a/image/sbin/secubox-kiosk-launcher
+++ b/image/sbin/secubox-kiosk-launcher
@@ -440,14 +440,20 @@ create_session() {
     local vm_type chromium_gpu_flags
     vm_type=$(systemd-detect-virt 2>/dev/null | tr -d '\n' || echo "none")
 
+    # --no-sandbox is always required on Debian 12: AppArmor restricts the
+    # unprivileged user namespaces that chromium's zygote needs, regardless
+    # of VM or bare-metal context. The kiosk runs as a dedicated unprivileged
+    # secubox-kiosk user on an isolated VT in a closed-network appliance, so
+    # the chromium sandbox provides marginal value vs. AppArmor's per-process
+    # profile (which still applies). See issue #224.
     if [[ "$vm_type" == "none" ]]; then
-        # Real hardware - enable GPU acceleration
-        chromium_gpu_flags="--enable-features=VaapiVideoDecoder"
-        log "Real hardware detected - GPU acceleration enabled"
+        # Real hardware - enable GPU acceleration, drop sandbox for AppArmor
+        chromium_gpu_flags="--no-sandbox --enable-features=VaapiVideoDecoder"
+        log "Real hardware detected - GPU acceleration enabled, sandbox disabled (AppArmor)"
     else
-        # VM - disable GPU to prevent crashes
-        chromium_gpu_flags="--disable-gpu --disable-gpu-compositing --disable-software-rasterizer --no-sandbox"
-        log "VM detected ($vm_type) - GPU disabled, sandbox disabled for VM"
+        # VM - disable GPU to prevent crashes, drop sandbox (same reason)
+        chromium_gpu_flags="--no-sandbox --disable-gpu --disable-gpu-compositing --disable-software-rasterizer"
+        log "VM detected ($vm_type) - GPU disabled, sandbox disabled"
     fi
 
     # Write GPU flags for session to read


### PR DESCRIPTION
## Summary

- Issue #224 — chromium fails on Debian 12 bare-metal because the zygote needs unprivileged user namespaces that AppArmor restricts. Error: `disabled unprivileged user namespaces with AppArmor, you can try using --no-sandbox.`
- Launcher only passed `--no-sandbox` for VM targets; bare-metal hit a restart loop until MAX_FAILURES disabled the kiosk and stranded X11 on VT7.

## Fix

Pass `--no-sandbox` in both branches (bare-metal + VM) of `image/sbin/secubox-kiosk-launcher`. Keep the VM-specific GPU-disable flags.

The SecuBox kiosk runs as a dedicated unprivileged `secubox-kiosk` user, on a single VT, in a closed-network appliance, with AppArmor still enforcing the per-process chromium profile — chromium's internal renderer sandbox provides marginal value vs. AppArmor's per-process protection while breaking the kiosk entirely on Debian 12.

## Test plan

- [ ] Rebuild vm-x64 image on this branch (only image build needed; not a .deb change)
- [ ] Flash USB, boot bare-metal x86_64: kiosk reaches the SecuBox login form, no restart loop
- [ ] VBox amd64: kiosk still works (regression check)

## References

- Reproducer: v2.10.0 image (CI 26088128896) flashed to USB, booted on bare-metal x86_64, /tmp/kiosk-session.log shows repeated zygote_host_impl_linux.cc errors with the suggested `--no-sandbox` workaround.