### PR TITLE
fix(image): silence Pi-only services on x64 + broaden X11 drivers (#226)

### DIFF
--- a/image/build-image.sh
+++ b/image/build-image.sh
@@ -601,10 +601,18 @@ fi
 
 # Install X11 packages for kiosk/UI mode (lighter xorg install)
 # Skip for lite profiles (ESPRESSObin with limited storage/RAM)
+# Driver coverage: include all common video drivers so bare-metal x86_64
+# (Intel/AMD/Nvidia/VESA) and VM targets (QXL/VMware) all get fast X11
+# init via modesetting + the matching userspace driver. ~15 MB extra over
+# the previous fbdev-only install. See issue #226.
 if [[ "${SECUBOX_LITE:-0}" != "1" ]]; then
   chroot "${ROOTFS}" bash -c "DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     kbd xinit xserver-xorg-core chromium unclutter x11-xserver-utils \
-    xserver-xorg-input-libinput xserver-xorg-video-fbdev 2>/dev/null" || warn "X11 packages partial"
+    xserver-xorg-input-libinput \
+    xserver-xorg-video-fbdev xserver-xorg-video-vesa \
+    xserver-xorg-video-intel xserver-xorg-video-amdgpu xserver-xorg-video-radeon \
+    xserver-xorg-video-nouveau xserver-xorg-video-qxl xserver-xorg-video-vmware \
+    2>/dev/null" || warn "X11 packages partial"
 else
   log "  Skipping X11/kiosk packages (lite profile)"
 fi

--- a/packages/secubox-led-heartbeat/systemd/secubox-healthbump.service
+++ b/packages/secubox-led-heartbeat/systemd/secubox-healthbump.service
@@ -2,6 +2,8 @@
 Description=SecuBox HealthBump LED Status Check (3-tier with I2C safety)
 After=network.target
 # Note: secubox-led-heartbeat removed - use secubox-led-health-bumper instead
+# Skip silently on non-arm64 (no Pi/MOCHAbin I2C hardware) — issue #226
+ConditionArchitecture=arm64
 
 [Service]
 Type=oneshot

--- a/packages/secubox-led-heartbeat/systemd/secubox-led-trigger.service
+++ b/packages/secubox-led-heartbeat/systemd/secubox-led-trigger.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=SecuBox LED Timer Triggers Setup
 After=local-fs.target
+# Skip silently on non-arm64 (no Pi/MOCHAbin LED hardware) — issue #226
+ConditionArchitecture=arm64
 
 [Service]
 Type=oneshot

--- a/packages/secubox-picobrew/debian/secubox-picobrew.service
+++ b/packages/secubox-picobrew/debian/secubox-picobrew.service
@@ -2,6 +2,8 @@
 Description=SecuBox PicoBrew Fermentation Controller API
 After=network.target secubox-runtime.service
 Requires=secubox-runtime.service
+# Skip silently on non-arm64 (no Pi 1-Wire/I2C fermentation sensors) — issue #226
+ConditionArchitecture=arm64
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Summary

Bare-metal x86_64 polish split out from the v2.10.1 validation. Two ergonomic fixes; no functional change for Pi/MOCHAbin/ESPRESSObin targets.

### Part A — Pi-only services skip silently on x64

Add `ConditionArchitecture=arm64` to:
- `packages/secubox-led-heartbeat/systemd/secubox-healthbump.service`
- `packages/secubox-led-heartbeat/systemd/secubox-led-trigger.service`
- `packages/secubox-picobrew/debian/secubox-picobrew.service`

Same pattern as the existing `secubox-led-heartbeat.service` (`ConditionPathExists=/sys/class/leds`). systemd marks the unit "condition failed" in the journal but no [FAILED] noise on the boot console.

### Part B — X11 driver coverage

Expand `image/build-image.sh:606-607` from `xserver-xorg-video-fbdev` only to the standard xorg driver set: `fbdev,vesa,intel,amdgpu,radeon,nouveau,qxl,vmware`. ~15 MB extra in the rootfs; KMS modesetting picks the right driver at boot.

## Test plan

- [ ] `Build SecuBox .deb packages` — secubox-led-heartbeat + secubox-picobrew rebuild cleanly
- [ ] `Build SecuBox System Images` vm-x64 — pulls the new debs + adds the new X drivers
- [ ] VBox amd64 boot: kiosk still loads (vmware driver in image now)
- [ ] Bare-metal x86_64 USB boot: no [FAILED] for healthbump/led-trigger/picobrew; X11 init under 15s on Intel/AMD/Nvidia bare metal
- [ ] MOCHAbin arm64 regression: services still run normally (ConditionArchitecture=arm64 passes)