### PR TITLE
fix(image): install flash/TUI tools + kiosk-tui alias on all images (#228)

### DIFF
--- a/image/build-image.sh
+++ b/image/build-image.sh
@@ -959,6 +959,24 @@ AUTOLOGIN
   ok "Kiosk service installed and enabled (graphical.target, TTY2 autologin)"
 fi
 
+# ── Operator tools: flash/install/TUI (all boards) ──────────────────
+# These are useful regardless of kiosk/X11 availability — flash internal
+# eMMC/disk from a running system, drop into the console TUI, perform a
+# factory reset. See issue #228.
+for tool in secubox-flash-disk secubox-flash-emmc secubox-console-tui secubox-factory-reset; do
+  if [[ -f "${SCRIPT_DIR}/sbin/${tool}" ]]; then
+    cp "${SCRIPT_DIR}/sbin/${tool}" "${ROOTFS}/usr/sbin/"
+    chmod +x "${ROOTFS}/usr/sbin/${tool}"
+  fi
+done
+
+# secubox-kiosk-tui: discoverable alias for the kiosk-mode fallback TUI
+# (the TTY-side dashboard operators reach when the X11 kiosk is down or
+# off). Matches the `kiosk` mode in secubox-mode.
+if [[ -f "${ROOTFS}/usr/sbin/secubox-console-tui" ]]; then
+  ln -sf secubox-console-tui "${ROOTFS}/usr/sbin/secubox-kiosk-tui"
+fi
+
 # ── Pre-generate SSL certificates for nginx ─────────────────────────
 # (firstboot will regenerate on first boot, but nginx needs certs to start)
 # Generate certs on HOST (chroot may lack /dev/urandom)

--- a/image/build-live-usb.sh
+++ b/image/build-live-usb.sh
@@ -1988,13 +1988,19 @@ log "5/8 Installing SecuBox scripts..."
 mkdir -p "${ROOTFS}/usr/sbin"
 mkdir -p "${ROOTFS}/usr/lib/secubox"
 
-# Copy scripts (including kiosk-launcher for robust startup, TUI, mode switcher, and disk flasher)
-for script in secubox-net-detect secubox-net-reset secubox-kiosk-setup secubox-cmdline-handler secubox-kiosk-launcher secubox-x11-splash secubox-console-tui secubox-mode secubox-flash-disk; do
+# Copy scripts (including kiosk-launcher for robust startup, TUI, mode switcher, disk/eMMC flashers)
+for script in secubox-net-detect secubox-net-reset secubox-kiosk-setup secubox-cmdline-handler secubox-kiosk-launcher secubox-x11-splash secubox-console-tui secubox-mode secubox-flash-disk secubox-flash-emmc; do
   if [[ -f "${SCRIPT_DIR}/sbin/${script}" ]]; then
     cp "${SCRIPT_DIR}/sbin/${script}" "${ROOTFS}/usr/sbin/"
     chmod +x "${ROOTFS}/usr/sbin/${script}"
   fi
 done
+
+# secubox-kiosk-tui: discoverable alias for the kiosk-mode fallback TUI
+# (matches the `kiosk` mode in secubox-mode) — see issue #228.
+if [[ -f "${ROOTFS}/usr/sbin/secubox-console-tui" ]]; then
+  ln -sf secubox-console-tui "${ROOTFS}/usr/sbin/secubox-kiosk-tui"
+fi
 
 # Copy overlay tools (v1.6.7.2+ - always included for factory reset capability)
 for script in secubox-overlay-init secubox-snapshot secubox-ramcache secubox-factory-reset; do


### PR DESCRIPTION
## Summary

Issue #228 — `secubox-flash-disk`, `secubox-flash-emmc`, `secubox-console-tui`, and `secubox-factory-reset` are missing from the system image; flash-emmc is also missing from the live-USB image; no `secubox-kiosk-tui` alias anywhere.

## Fix

### `image/build-image.sh`

After the kiosk install block, install on **every board**:
- `secubox-flash-disk`
- `secubox-flash-emmc`
- `secubox-console-tui`
- `secubox-factory-reset`
- symlink `secubox-kiosk-tui` -> `secubox-console-tui`

### `image/build-live-usb.sh:1992`

- Append `secubox-flash-emmc` to the first script-install loop (already had `secubox-flash-disk`).
- Same `secubox-kiosk-tui` -> `secubox-console-tui` symlink.

## Test plan

- [ ] Rebuild vm-x64 image; verify `/usr/sbin/{secubox-flash-disk,secubox-flash-emmc,secubox-console-tui,secubox-factory-reset,secubox-kiosk-tui}` present and executable.
- [ ] `secubox-kiosk-tui` invokes the console TUI.
- [ ] Rebuild live-USB; same checks; existing live-USB behaviour unchanged.
- [ ] Regression on mochabin arm64 image: same tools installed.