### PR TITLE
feat(secubox-yacy): new LXC module for peer-to-peer sovereign search (#232)

### DIFF
--- a/packages/secubox-yacy/README.md
+++ b/packages/secubox-yacy/README.md
@@ -1,0 +1,75 @@
+# secubox-yacy
+
+[YaCy](https://yacy.net) peer-to-peer sovereign search engine for SecuBox.
+JVM + YaCy hosted in a Debian LXC at `10.100.0.80` on the SecuBox `br-lxc`
+bridge.
+
+Follows [`docs/MODULE-GUIDELINES.md`](../../docs/MODULE-GUIDELINES.md);
+opens the **SEARCH** layer of the SecuBox CTL grammar.
+
+## Quickstart
+
+```bash
+apt install secubox-yacy
+yacyctl install     # provisions LXC at 10.100.0.80, installs JVM + YaCy
+yacyctl status
+```
+
+Open `https://<your-secubox>/yacy/` and use the YaCy admin UI for search,
+peer config, and crawl scheduling.
+
+## CTL — `yacyctl`
+
+Three-fold introspection (always available):
+
+```text
+yacyctl components       # LXC + daemon + host-API states
+yacyctl status           # overall green/yellow/red
+yacyctl access list      # public URL(s) + auth method
+```
+
+Module-specific nouns (full implementation in v1.1.0 follow-up):
+
+```text
+yacyctl peer       list|add <url>|remove <hash>|status <hash>
+yacyctl index      status|build <urls.txt>|clear|optimize
+yacyctl query      test <terms>|count <terms>
+yacyctl blacklist  list|add <pattern>|remove <pattern>
+yacyctl crawler    list|start <profile>|stop <id>|schedule <profile> <cron>
+
+yacyctl install      # idempotent LXC + JVM + YaCy bootstrap
+yacyctl reload       # restart host FastAPI + yacy daemon
+```
+
+## Configuration
+
+`/etc/secubox/yacy.toml` (seeded from `yacy.toml.example` at install). Key
+fields: `lxc.{name,ip,bridge,path}`, `yacy.{http_port,heap_max,release_url}`,
+`peer.mode` (`standalone` / `freeworld` / `intranet`), `exposure.public_hostname`.
+
+## Files
+
+```text
+/etc/secubox/yacy.toml                # operator config
+/etc/secubox/secrets/yacy-admin       # admin password (generated at install)
+/etc/nginx/secubox.d/yacy.conf
+/var/lib/secubox/yacy/                # host state
+/usr/lib/secubox/yacy/api/            # host FastAPI
+/usr/share/secubox/lib/yacy/          # install-lxc.sh + provisioning
+/usr/share/secubox/www/yacy/          # SecuBox-themed web UI wrapper
+/usr/share/secubox/menu.d/60-yacy.json
+/data/lxc/yacy/                       # the LXC rootfs (created by yacyctl install)
+```
+
+## API
+
+FastAPI on `/run/secubox/yacy.sock`, exposed by nginx at `/api/v1/yacy/`.
+Mandatory endpoints: `/status`, `/components`, `/access`, `/healthz`,
+`/version`. Module-specific endpoints (one per CTL noun-verb pair) shell
+out to `yacyctl --json`.
+
+## Troubleshooting
+
+- `yacyctl status` shows `daemon: stopped` → `lxc-attach -n yacy -- systemctl status yacy`.
+- nginx 502 on `/yacy/` → check LXC IP `10.100.0.80` reachable, or re-run `yacyctl install`.
+- YaCy admin password rotation → write a new value to `/etc/secubox/secrets/yacy-admin` and update via the YaCy admin UI (or future `yacyctl admin passwd`).

--- a/packages/secubox-yacy/api/main.py
+++ b/packages/secubox-yacy/api/main.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+SecuBox-Deb :: secubox-yacy — host control plane API.
+
+FastAPI on /run/secubox/yacy.sock, proxied by nginx at /api/v1/yacy/.
+Mandatory endpoints per docs/MODULE-GUIDELINES.md §8.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+from fastapi import FastAPI, HTTPException
+
+VERSION = "1.0.0"
+CTL = shutil.which("yacyctl") or "/usr/sbin/yacyctl"
+
+app = FastAPI(
+    title="SecuBox YaCy",
+    version=VERSION,
+    docs_url=None,
+    redoc_url=None,
+    openapi_url=None,
+)
+
+
+def _ctl_json(*args: str) -> Dict[str, Any]:
+    cmd = [CTL, *args, "--json"]
+    try:
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=15)
+    except subprocess.CalledProcessError as e:
+        raise HTTPException(status_code=500, detail=f"yacyctl failed: {e.output!r}")
+    except FileNotFoundError:
+        raise HTTPException(status_code=500, detail=f"yacyctl not found at {CTL}")
+    try:
+        return json.loads(out.decode())
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=500, detail=f"yacyctl emitted non-JSON: {e}; raw={out!r}")
+
+
+@app.get("/healthz")
+def healthz() -> Dict[str, bool]:
+    return {"ok": True}
+
+
+@app.get("/version")
+def version() -> Dict[str, str]:
+    build_file = Path("/usr/share/doc/secubox-yacy/.build-sha")
+    build = build_file.read_text().strip() if build_file.is_file() else "unknown"
+    return {"version": VERSION, "build": build}
+
+
+@app.get("/status")
+def status() -> Dict[str, Any]:
+    return _ctl_json("status")
+
+
+@app.get("/components")
+def components() -> Dict[str, Any]:
+    return _ctl_json("components")
+
+
+@app.get("/access")
+def access() -> Dict[str, Any]:
+    return _ctl_json("access")

--- a/packages/secubox-yacy/conf/yacy.toml.example
+++ b/packages/secubox-yacy/conf/yacy.toml.example
@@ -1,0 +1,40 @@
+# /etc/secubox/yacy.toml — SecuBox YaCy module configuration
+
+# ── LXC ───────────────────────────────────────────────────────────────
+[lxc]
+name         = "yacy"
+ip           = "10.100.0.80"
+gateway      = "10.100.0.1"
+bridge       = "br-lxc"
+path         = "/data/lxc"
+debian_suite = "bookworm"
+
+# ── YaCy daemon (inside the LXC) ──────────────────────────────────────
+[yacy]
+http_port           = 8090
+admin_user          = "admin"
+admin_password_file = "/etc/secubox/secrets/yacy-admin"
+# YaCy v1.940 (https://release.yacy.net/)
+release_url         = "https://release.yacy.net/yacy_v1.940_20240319_10001.tar.gz"
+install_dir         = "/opt/yacy"
+# JVM heap (MB)
+heap_max            = 1024
+
+# ── Peer mode ─────────────────────────────────────────────────────────
+[peer]
+# "standalone" = local-only search, no public DHT participation
+# "freeworld"  = full peer-to-peer DHT (default)
+# "intranet"   = private intranet peer mode
+mode      = "standalone"
+peer_name = "secubox-yacy"
+
+# ── Public exposure (HAProxy vhost; see haproxyctl) ───────────────────
+[exposure]
+public_hostname = ""           # e.g. "yacy.gk2.secubox.in" — empty = LAN only
+waf_inspect     = true         # route through mitmproxy when exposed
+
+# ── Crawler defaults ──────────────────────────────────────────────────
+[crawler]
+default_depth      = 2
+default_must_match = ".*"
+default_must_not_match = ""

--- a/packages/secubox-yacy/debian/changelog
+++ b/packages/secubox-yacy/debian/changelog
@@ -1,0 +1,11 @@
+secubox-yacy (1.0.0-1~bookworm1) bookworm; urgency=medium
+
+  * Initial release: YaCy peer-to-peer search engine in LXC.
+  * Opens the SEARCH layer of the SecuBox CTL grammar.
+  * Three-fold CTL grammar (yacyctl: components, status, access).
+  * Module-specific nouns: peer, index, query, blacklist, crawler.
+  * LXC at 10.100.0.80 on br-lxc, default-jre-headless + YaCy v1.940.
+  * Follows docs/MODULE-GUIDELINES.md, pattern locked in by PR #231.
+  * Closes: #232
+
+ -- Gerald KERMA <devel@cybermind.fr>  Wed, 20 May 2026 10:30:00 +0200

--- a/packages/secubox-yacy/debian/control
+++ b/packages/secubox-yacy/debian/control
@@ -1,0 +1,36 @@
+Source: secubox-yacy
+Section: admin
+Priority: optional
+Maintainer: Gerald KERMA <devel@cybermind.fr>
+Build-Depends: debhelper-compat (= 13)
+Standards-Version: 4.6.2
+Homepage: https://cybermind.fr/secubox
+
+Package: secubox-yacy
+Architecture: all
+Depends: ${misc:Depends},
+         secubox-core (>= 1.0),
+         secubox-haproxy,
+         lxc,
+         lxc-templates,
+         debootstrap,
+         python3-uvicorn,
+         python3-fastapi,
+         python3-toml,
+         openssl,
+         curl,
+         jq
+Recommends: secubox-mitmproxy
+Description: SecuBox YaCy — peer-to-peer search engine
+ Hosts YaCy in a Debian LXC at 10.100.0.80 on br-lxc with a sovereign,
+ decentralised search index that does not depend on any third-party
+ search provider. Peer-to-peer discovery, configurable crawl profiles,
+ user-managed blacklist.
+ .
+ The host-side FastAPI control plane runs on /run/secubox/yacy.sock and
+ is exposed by nginx at /api/v1/yacy/. The native YaCy admin UI is
+ iframe-embedded under /yacy/ (proxy_pass to the LXC).
+ .
+ yacyctl exposes the canonical SecuBox three-fold introspection plus
+ peer/index/query/blacklist/crawler nouns matching the SEARCH layer of
+ the CTL grammar (sister to OPS MONITORING / healthctl / grafanactl).

--- a/packages/secubox-yacy/debian/postinst
+++ b/packages/secubox-yacy/debian/postinst
@@ -1,0 +1,32 @@
+#!/bin/sh
+# SecuBox YaCy — post-install
+set -e
+
+case "$1" in
+    configure)
+        getent group secubox >/dev/null || groupadd --system secubox
+        getent passwd secubox >/dev/null || useradd --system --gid secubox \
+            --home /var/lib/secubox --no-create-home --shell /usr/sbin/nologin secubox
+
+        install -d -m 0770 -o root -g secubox /etc/secubox
+        install -d -m 0755 -o secubox -g secubox /var/lib/secubox/yacy
+        install -d -m 0755 -o secubox -g secubox /var/log/secubox
+
+        if [ ! -f /etc/secubox/yacy.toml ] && [ -f /etc/secubox/yacy.toml.example ]; then
+            cp /etc/secubox/yacy.toml.example /etc/secubox/yacy.toml
+            chmod 640 /etc/secubox/yacy.toml
+            chown root:secubox /etc/secubox/yacy.toml
+        fi
+
+        if systemctl is-active --quiet nginx 2>/dev/null; then
+            nginx -t >/dev/null 2>&1 && systemctl reload nginx 2>/dev/null || true
+        fi
+
+        systemctl daemon-reload 2>/dev/null || true
+        systemctl enable secubox-yacy.service 2>/dev/null || true
+        # yacyctl install will start the FastAPI after the LXC is provisioned.
+        ;;
+esac
+
+#DEBHELPER#
+exit 0

--- a/packages/secubox-yacy/debian/postrm
+++ b/packages/secubox-yacy/debian/postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+case "$1" in
+    purge)
+        rm -f /etc/secubox/yacy.toml /etc/secubox/yacy.toml.example
+        rm -rf /var/lib/secubox/yacy
+        ;;
+esac
+#DEBHELPER#
+exit 0

--- a/packages/secubox-yacy/debian/prerm
+++ b/packages/secubox-yacy/debian/prerm
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+case "$1" in
+    remove|deconfigure|upgrade)
+        systemctl stop secubox-yacy.service 2>/dev/null || true
+        systemctl disable secubox-yacy.service 2>/dev/null || true
+        ;;
+esac
+#DEBHELPER#
+exit 0

--- a/packages/secubox-yacy/debian/rules
+++ b/packages/secubox-yacy/debian/rules
@@ -1,0 +1,19 @@
+#!/usr/bin/make -f
+%:
+	dh $@
+
+override_dh_auto_install:
+	install -d debian/secubox-yacy/usr/lib/secubox/yacy
+	cp -r api debian/secubox-yacy/usr/lib/secubox/yacy/
+	install -d debian/secubox-yacy/usr/sbin
+	install -m 755 sbin/yacyctl debian/secubox-yacy/usr/sbin/yacyctl
+	install -d debian/secubox-yacy/usr/share/secubox/www
+	[ -d www ] && cp -r www/. debian/secubox-yacy/usr/share/secubox/www/ || true
+	install -d debian/secubox-yacy/usr/share/secubox/menu.d
+	[ -d menu.d ] && cp -r menu.d/. debian/secubox-yacy/usr/share/secubox/menu.d/ || true
+	install -d debian/secubox-yacy/etc/nginx/secubox.d
+	[ -f nginx/yacy.conf ] && cp nginx/yacy.conf debian/secubox-yacy/etc/nginx/secubox.d/ || true
+	install -d debian/secubox-yacy/etc/secubox
+	[ -f conf/yacy.toml.example ] && cp conf/yacy.toml.example debian/secubox-yacy/etc/secubox/yacy.toml.example || true
+	install -d debian/secubox-yacy/usr/share/secubox/lib/yacy
+	[ -d lib/yacy ] && cp -r lib/yacy/. debian/secubox-yacy/usr/share/secubox/lib/yacy/ || true

--- a/packages/secubox-yacy/debian/secubox-yacy.service
+++ b/packages/secubox-yacy/debian/secubox-yacy.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=SecuBox YaCy — host control plane API
+Documentation=file:///usr/share/doc/secubox-yacy/README
+After=network.target secubox-core.service
+Wants=secubox-core.service
+
+[Service]
+UMask=0007
+Type=simple
+User=secubox
+Group=secubox
+WorkingDirectory=/usr/lib/secubox/yacy
+RuntimeDirectory=secubox
+RuntimeDirectoryMode=0755
+RuntimeDirectoryPreserve=yes
+ExecStartPre=/bin/mkdir -p /etc/secubox
+ExecStartPre=/bin/chown secubox:secubox /etc/secubox
+ExecStart=/usr/bin/python3 -m uvicorn api.main:app --uds /run/secubox/yacy.sock --log-level warning
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+LogsDirectory=secubox
+LogsDirectoryMode=0755
+ReadWritePaths=/run/secubox /var/lib/secubox /etc/secubox /var/log/secubox
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/secubox-yacy/lib/yacy/install-lxc.sh
+++ b/packages/secubox-yacy/lib/yacy/install-lxc.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# SecuBox-Deb :: secubox-yacy :: install-lxc.sh
+#
+# Idempotent LXC bootstrap for the YaCy module.
+# Follows docs/MODULE-GUIDELINES.md §3.
+
+set -euo pipefail
+
+readonly LXC_NAME="${SECUBOX_LXC_NAME:-yacy}"
+readonly LXC_IP="${SECUBOX_LXC_IP:-10.100.0.80}"
+readonly LXC_PATH="${SECUBOX_LXC_PATH:-/data/lxc}"
+readonly LXC_BRIDGE="${SECUBOX_LXC_BRIDGE:-br-lxc}"
+readonly LXC_GW="${SECUBOX_LXC_GW:-10.100.0.1}"
+readonly DEBIAN_SUITE="${SECUBOX_DEBIAN_SUITE:-bookworm}"
+readonly YACY_RELEASE_URL="${SECUBOX_YACY_RELEASE_URL:-https://release.yacy.net/yacy_v1.940_20240319_10001.tar.gz}"
+readonly YACY_INSTALL_DIR="${SECUBOX_YACY_INSTALL_DIR:-/opt/yacy}"
+readonly YACY_HEAP_MAX="${SECUBOX_YACY_HEAP_MAX:-1024}"
+readonly PROVISION_DIR="${SECUBOX_PROVISION_DIR:-/usr/share/secubox/lib/yacy/provision}"
+readonly STATE_DIR="${SECUBOX_STATE_DIR:-/var/lib/secubox/yacy}"
+readonly SECRETS_DIR="${SECUBOX_SECRETS_DIR:-/etc/secubox/secrets}"
+readonly SENTINEL="$STATE_DIR/.lxc-provisioned"
+
+log()  { printf '[yacy-install] %s\n' "$*"; }
+fail() { printf '[yacy-install] ERROR: %s\n' "$*" >&2; exit 1; }
+
+require_cmds() {
+    for c in lxc-create lxc-info lxc-start lxc-attach openssl; do
+        command -v "$c" >/dev/null 2>&1 || fail "$c not installed"
+    done
+}
+
+ensure_dirs() {
+    install -d -m 0755 -o root -g root "$LXC_PATH"
+    install -d -m 0755 -o secubox -g secubox "$STATE_DIR"
+    install -d -m 0700 -o root -g root "$SECRETS_DIR"
+}
+
+ensure_bridge() {
+    if ! ip link show "$LXC_BRIDGE" >/dev/null 2>&1; then
+        log "Creating bridge $LXC_BRIDGE @ ${LXC_GW}/24 ..."
+        ip link add name "$LXC_BRIDGE" type bridge
+        ip addr add "${LXC_GW}/24" dev "$LXC_BRIDGE"
+        ip link set "$LXC_BRIDGE" up
+        cat > /etc/systemd/network/10-secubox-lxc-bridge.netdev <<EOF
+[NetDev]
+Name=$LXC_BRIDGE
+Kind=bridge
+EOF
+        cat > /etc/systemd/network/10-secubox-lxc-bridge.network <<EOF
+[Match]
+Name=$LXC_BRIDGE
+
+[Network]
+Address=${LXC_GW}/24
+ConfigureWithoutCarrier=yes
+IPMasquerade=ipv4
+EOF
+        systemctl reload systemd-networkd 2>/dev/null || true
+    fi
+}
+
+lxc_state() {
+    lxc-info -n "$LXC_NAME" -P "$LXC_PATH" 2>/dev/null \
+        | awk -F: '/^State:/ { gsub(/ /,"",$2); print tolower($2) }'
+}
+
+create_lxc() {
+    if [ -d "$LXC_PATH/$LXC_NAME/rootfs" ]; then
+        log "LXC '$LXC_NAME' already exists — skipping debootstrap"
+        return
+    fi
+    log "Creating LXC '$LXC_NAME' (debian $DEBIAN_SUITE) ..."
+    lxc-create -n "$LXC_NAME" -t debian -P "$LXC_PATH" -- -r "$DEBIAN_SUITE"
+}
+
+write_lxc_config() {
+    log "Pinning network: $LXC_IP/24 on $LXC_BRIDGE, gw $LXC_GW"
+    cat > "$LXC_PATH/$LXC_NAME/config" <<EOF
+# SecuBox-managed — see secubox-yacy / install-lxc.sh
+lxc.uts.name = $LXC_NAME
+lxc.net.0.type = veth
+lxc.net.0.link = $LXC_BRIDGE
+lxc.net.0.flags = up
+lxc.net.0.ipv4.address = $LXC_IP/24
+lxc.net.0.ipv4.gateway = $LXC_GW
+lxc.net.0.name = eth0
+lxc.rootfs.path = dir:$LXC_PATH/$LXC_NAME/rootfs
+lxc.include = /usr/share/lxc/config/common.conf
+lxc.apparmor.profile = generated
+lxc.start.auto = 1
+lxc.start.delay = 5
+EOF
+}
+
+start_lxc() {
+    [ "$(lxc_state)" = "running" ] && { log "Already running"; return; }
+    log "Starting LXC '$LXC_NAME' ..."
+    lxc-start -n "$LXC_NAME" -P "$LXC_PATH"
+}
+
+wait_for_network() {
+    log "Waiting for LXC network ..."
+    for _ in $(seq 1 30); do
+        lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- ping -c1 -W1 "$LXC_GW" >/dev/null 2>&1 && return 0
+        sleep 1
+    done
+    fail "LXC '$LXC_NAME' did not reach $LXC_GW within 30s"
+}
+
+install_yacy_in_lxc() {
+    log "Installing JVM and YaCy in '$LXC_NAME' ..."
+    # Pass the parametric URL/dir via `env` to the in-LXC shell — the heredoc
+    # stays unquoted-friendly because INNER is single-quoted.
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- env \
+        YACY_RELEASE_URL="$YACY_RELEASE_URL" \
+        YACY_INSTALL_DIR="$YACY_INSTALL_DIR" \
+        YACY_HEAP_MAX="$YACY_HEAP_MAX" \
+        bash -e <<'INNER'
+        set -euo pipefail
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -q
+        apt-get install -y --no-install-recommends \
+            default-jre-headless wget ca-certificates tar
+
+        if [ ! -x "${YACY_INSTALL_DIR}/startYACY.sh" ]; then
+            mkdir -p "${YACY_INSTALL_DIR}"
+            cd /tmp
+            wget -q "${YACY_RELEASE_URL}" -O yacy.tar.gz
+            tar xzf yacy.tar.gz -C "${YACY_INSTALL_DIR}" --strip-components=1
+            rm -f yacy.tar.gz
+        fi
+
+        # JVM heap from env
+        if [ -f "${YACY_INSTALL_DIR}/defaults/yacy.init" ]; then
+            sed -i "s/^javastart_Xmx=.*/javastart_Xmx=Xmx${YACY_HEAP_MAX}m/" \
+                "${YACY_INSTALL_DIR}/defaults/yacy.init" || true
+        fi
+
+        # Dedicated user
+        if ! id -u yacy >/dev/null 2>&1; then
+            useradd -r -s /bin/false -d "${YACY_INSTALL_DIR}" yacy
+        fi
+        chown -R yacy:yacy "${YACY_INSTALL_DIR}"
+
+        # systemd unit
+        cat > /etc/systemd/system/yacy.service <<UNIT
+[Unit]
+Description=YaCy peer-to-peer search engine
+After=network.target
+
+[Service]
+Type=simple
+User=yacy
+WorkingDirectory=${YACY_INSTALL_DIR}
+ExecStart=${YACY_INSTALL_DIR}/startYACY.sh -f
+ExecStop=${YACY_INSTALL_DIR}/stopYACY.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+        systemctl daemon-reload
+        systemctl enable yacy
+        systemctl restart yacy
+INNER
+}
+
+provision_yacy() {
+    [ -d "$PROVISION_DIR" ] || { log "No provisioning dir — skipping"; return; }
+    log "Provisioning peer seed + blacklist ..."
+
+    if [ -f "$PROVISION_DIR/peers.seed.txt" ]; then
+        lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- bash -c "install -d -m 0755 /var/lib/yacy && chown yacy:yacy /var/lib/yacy"
+        lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- \
+            tee "/var/lib/yacy/peers.seed.txt" > /dev/null < "$PROVISION_DIR/peers.seed.txt"
+    fi
+    if [ -f "$PROVISION_DIR/blacklist.txt" ]; then
+        lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- \
+            tee "/var/lib/yacy/blacklist.txt" > /dev/null < "$PROVISION_DIR/blacklist.txt"
+    fi
+}
+
+generate_admin_password() {
+    if [ ! -f "$SECRETS_DIR/yacy-admin" ]; then
+        local pw; pw=$(openssl rand -hex 16)
+        echo "$pw" > "$SECRETS_DIR/yacy-admin"
+        chmod 600 "$SECRETS_DIR/yacy-admin"
+        log "Generated YaCy admin password (set via the YaCy admin UI on first login)."
+    fi
+}
+
+mark_provisioned() {
+    install -d -m 0755 -o secubox -g secubox "$STATE_DIR"
+    date -Iseconds > "$SENTINEL"
+}
+
+main() {
+    require_cmds
+    ensure_dirs
+    ensure_bridge
+    create_lxc
+    write_lxc_config
+    start_lxc
+    wait_for_network
+    install_yacy_in_lxc
+    generate_admin_password
+    provision_yacy
+    mark_provisioned
+    log "OK — LXC '$LXC_NAME' at $LXC_IP, yacy provisioned + running on port 8090."
+    log "Web UI: https://<host>/yacy/  (admin / $(cat "$SECRETS_DIR/yacy-admin"))"
+}
+
+main "$@"

--- a/packages/secubox-yacy/lib/yacy/provision/blacklist.txt
+++ b/packages/secubox-yacy/lib/yacy/provision/blacklist.txt
@@ -1,0 +1,7 @@
+# SecuBox YaCy — search blacklist seed.
+# One regex per line. Matches against URL host. Comments ignored.
+# Use `yacyctl blacklist add <pattern>` to extend at runtime.
+#
+# Block known phishing / malware-ad / spammy index farms.
+.*\.example-spam\.test
+.*\.malware-host\.test

--- a/packages/secubox-yacy/lib/yacy/provision/peers.seed.txt
+++ b/packages/secubox-yacy/lib/yacy/provision/peers.seed.txt
@@ -1,0 +1,7 @@
+# SecuBox YaCy — pre-seeded peer list.
+# Lines starting with '#' are ignored. One peer URL per line.
+# Use `yacyctl peer add <url>` to add more at runtime.
+#
+# Public freeworld peers (curated, last verified 2026-05-20).
+http://yacy.freeworld.de:8090
+http://search.yacy.net:8090

--- a/packages/secubox-yacy/menu.d/60-yacy.json
+++ b/packages/secubox-yacy/menu.d/60-yacy.json
@@ -1,0 +1,9 @@
+{
+  "title": "YaCy",
+  "subtitle": "Peer-to-peer search",
+  "icon": "fa-search",
+  "url": "/yacy/",
+  "section": "search",
+  "order": 60,
+  "module": "yacy"
+}

--- a/packages/secubox-yacy/nginx/yacy.conf
+++ b/packages/secubox-yacy/nginx/yacy.conf
@@ -1,0 +1,21 @@
+# /etc/nginx/secubox.d/yacy.conf
+# Installed by secubox-yacy (#232)
+
+location /api/v1/yacy/ {
+    proxy_pass http://unix:/run/secubox/yacy.sock:/;
+    include /etc/nginx/snippets/secubox-proxy.conf;
+}
+
+# Native YaCy admin UI (iframe target from /yacy/index.html in secubox-yacy)
+location /yacy/ {
+    proxy_pass http://10.100.0.80:8090/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_buffering off;
+    proxy_read_timeout 86400;
+}

--- a/packages/secubox-yacy/sbin/yacyctl
+++ b/packages/secubox-yacy/sbin/yacyctl
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# SecuBox-Deb :: yacyctl
+# CyberMind — https://cybermind.fr
+#
+# YaCy host-side controller — opens the SEARCH layer of the SecuBox CTL
+# grammar. Three-fold introspection + peer/index/query/blacklist/crawler
+# nouns. See docs/grammar.md and docs/MODULE-GUIDELINES.md.
+
+set -u
+
+readonly VERSION="1.0.0"
+readonly CONFIG_FILE="${SECUBOX_YACY_CONFIG:-/etc/secubox/yacy.toml}"
+readonly STATE_DIR="${SECUBOX_YACY_STATE:-/var/lib/secubox/yacy}"
+readonly SECRETS_DIR="${SECUBOX_SECRETS_DIR:-/etc/secubox/secrets}"
+readonly INSTALL_LIB="${SECUBOX_INSTALL_LIB:-/usr/share/secubox/lib/yacy/install-lxc.sh}"
+
+readonly RED='\033[0;31m'; readonly GREEN='\033[0;32m'; readonly YELLOW='\033[1;33m'; readonly NC='\033[0m'
+log()  { printf '%b[yacy]%b %s\n' "$GREEN" "$NC" "$*"; }
+warn() { printf '%b[warn]%b %s\n' "$YELLOW" "$NC" "$*" >&2; }
+err()  { printf '%b[error]%b %s\n' "$RED" "$NC" "$*" >&2; }
+
+config_get() {
+    local key="$1" default="${2:-}"
+    if [ -f "$CONFIG_FILE" ]; then
+        grep -E "^[[:space:]]*${key}[[:space:]]*=" "$CONFIG_FILE" 2>/dev/null \
+            | head -1 | cut -d= -f2- | tr -d ' "' | tr -d "'" || echo "$default"
+    else
+        echo "$default"
+    fi
+}
+
+LXC_NAME=$(config_get "name" "yacy")
+LXC_IP=$(config_get "ip" "10.100.0.80")
+LXC_PATH=$(config_get "path" "/data/lxc")
+HTTP_PORT=$(config_get "http_port" "8090")
+PEER_MODE=$(config_get "mode" "standalone")
+PUBLIC_HOSTNAME=$(config_get "public_hostname" "")
+
+lxc_state() {
+    lxc-info -n "$LXC_NAME" -P "$LXC_PATH" 2>/dev/null \
+        | awk -F: '/^State:/ { gsub(/ /,"",$2); print tolower($2) }'
+}
+lxc_running() { [ "$(lxc_state)" = "running" ]; }
+lxc_exists()  { [ -d "$LXC_PATH/$LXC_NAME/rootfs" ]; }
+daemon_running() {
+    lxc_running || return 1
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl is-active --quiet yacy 2>/dev/null
+}
+host_api_running() { systemctl is-active --quiet secubox-yacy.service 2>/dev/null; }
+
+emit_components_json() {
+    local lxc_st daemon_st api_st
+    if lxc_exists; then lxc_st=$(lxc_state); [ -z "$lxc_st" ] && lxc_st="absent"
+    else lxc_st="absent"; fi
+    daemon_running && daemon_st="running" || daemon_st="stopped"
+    host_api_running && api_st="running" || api_st="stopped"
+    cat <<EOF
+{
+  "module": "yacy",
+  "version": "$VERSION",
+  "components": [
+    {"name": "lxc",      "state": "$lxc_st",      "detail": "$LXC_NAME @ $LXC_IP on br-lxc"},
+    {"name": "daemon",   "state": "$daemon_st",   "detail": "yacy ($PEER_MODE), port $HTTP_PORT"},
+    {"name": "host-api", "state": "$api_st",      "detail": "secubox-yacy.service (uvicorn @ /run/secubox/yacy.sock)"}
+  ]
+}
+EOF
+}
+
+emit_components_text() {
+    printf '%-12s %-12s %s\n' "COMPONENT" "STATE" "DETAIL"
+    local s
+    if lxc_exists; then s=$(lxc_state); [ -z "$s" ] && s="absent"; printf '%-12s %-12s %s\n' "lxc" "$s" "$LXC_NAME @ $LXC_IP on br-lxc"
+    else printf '%-12s %-12s %s\n' "lxc" "absent" "$LXC_NAME — run 'yacyctl install'"; fi
+    daemon_running && printf '%-12s %-12s %s\n' "daemon" "running" "yacy ($PEER_MODE), port $HTTP_PORT" \
+                   || printf '%-12s %-12s %s\n' "daemon" "stopped" "yacy ($PEER_MODE), port $HTTP_PORT"
+    host_api_running && printf '%-12s %-12s %s\n' "host-api" "running" "secubox-yacy.service (uvicorn)" \
+                     || printf '%-12s %-12s %s\n' "host-api" "stopped" "secubox-yacy.service (uvicorn)"
+}
+
+emit_status_json() {
+    local overall
+    if lxc_running && daemon_running && host_api_running; then overall="green"
+    elif lxc_exists && (daemon_running || host_api_running); then overall="yellow"
+    else overall="red"; fi
+    cat <<EOF
+{"module": "yacy", "version": "$VERSION", "overall": "$overall"}
+EOF
+}
+
+emit_access_json() {
+    local lan_url public_url
+    lan_url="https://$(hostname -I | awk '{print $1}')/yacy/"
+    [ -n "$PUBLIC_HOSTNAME" ] && public_url="https://${PUBLIC_HOSTNAME}/yacy/" || public_url=""
+    cat <<EOF
+{
+  "module": "yacy",
+  "access": [
+    {"url": "$lan_url", "auth": "jwt|yacy-admin", "scope": "lan"}$( [ -n "$public_url" ] && echo ',' )
+    $( [ -n "$public_url" ] && printf '{"url": "%s", "auth": "jwt|yacy-admin", "scope": "public"}\n' "$public_url" )
+  ]
+}
+EOF
+}
+
+cmd_components() { case "${1:-}" in --json) emit_components_json ;; *) emit_components_text ;; esac; }
+cmd_status()     { case "${1:-}" in --json) emit_status_json ;; *) emit_components_text; echo; emit_status_json | python3 -c 'import json,sys; d=json.load(sys.stdin); print("overall:", d["overall"])' ;; esac; }
+cmd_access()     { case "${1:-}" in --json) emit_access_json ;; *) emit_access_json | python3 -m json.tool ;; esac; }
+
+cmd_install() {
+    [ -x "$INSTALL_LIB" ] || { err "install script not found at $INSTALL_LIB"; exit 2; }
+    log "Running LXC bootstrap from $INSTALL_LIB ..."
+    SECUBOX_LXC_NAME="$LXC_NAME" SECUBOX_LXC_IP="$LXC_IP" SECUBOX_LXC_PATH="$LXC_PATH" \
+        bash "$INSTALL_LIB"
+    systemctl start secubox-yacy.service 2>/dev/null || true
+    log "Done. Try 'yacyctl status' to verify."
+}
+
+cmd_reload() {
+    systemctl restart secubox-yacy.service 2>/dev/null || true
+    lxc_running && lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl restart yacy 2>/dev/null || true
+    log "Reloaded."
+}
+
+cmd_help() {
+    cat <<'HELP'
+yacyctl — SecuBox YaCy controller (SEARCH layer)
+
+Three-fold introspection:
+  yacyctl components [--json]
+  yacyctl status     [--json]
+  yacyctl access     [list|show <name>] [--json]
+
+Lifecycle:
+  yacyctl install                  # idempotent LXC + JVM + YaCy bootstrap
+  yacyctl reload                   # restart host FastAPI + yacy daemon
+
+Search-engine nouns:
+  yacyctl peer       list|add <url>|remove <hash>|status <hash>
+  yacyctl index      status|build <urls.txt>|clear|optimize
+  yacyctl query      test <terms>|count <terms>
+  yacyctl blacklist  list|add <pattern>|remove <pattern>
+  yacyctl crawler    list|start <profile>|stop <id>|schedule <profile> <cron>
+
+  (--json on any verb returns machine-readable output)
+
+For grammar details: docs/grammar.md (SEARCH layer)
+HELP
+}
+
+main() {
+    local noun="${1:-help}"
+    shift || true
+    case "$noun" in
+        components|status|access|install|reload) "cmd_${noun}" "$@" ;;
+        peer|index|query|blacklist|crawler)
+            err "noun '$noun' not yet implemented in v$VERSION — see #232 follow-up task"
+            exit 2 ;;
+        --help|-h|help|"") cmd_help ;;
+        --version|-V) echo "yacyctl $VERSION" ;;
+        *) err "unknown noun: $noun"; cmd_help; exit 1 ;;
+    esac
+}
+
+main "$@"

--- a/packages/secubox-yacy/www/yacy/index.html
+++ b/packages/secubox-yacy/www/yacy/index.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SecuBox — YaCy</title>
+<link rel="stylesheet" href="/shared/crt-light.css">
+<link rel="stylesheet" href="/shared/sidebar-light.css">
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; }
+  .layout { display: grid; grid-template-columns: 260px 1fr; height: 100vh; }
+  .yacy-frame { border: 0; width: 100%; height: 100%; background: var(--bg-1, #0f1320); }
+  .topbar {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0.5rem 1rem; background: var(--bg-2, #181c2c);
+    border-bottom: 1px solid var(--border, #2a3354);
+    color: var(--mesh-main, #2080c0);
+    font-family: 'JetBrains Mono', monospace; font-size: 0.85rem;
+  }
+  .topbar .actions a { color: var(--mesh-main); margin-left: 1rem; text-decoration: none; }
+  .topbar .actions a:hover { text-decoration: underline; }
+  .threefold {
+    display: grid; grid-template-columns: repeat(3, 1fr);
+    gap: 1rem; padding: 1rem; background: var(--bg-1);
+  }
+  .threefold article {
+    background: var(--bg-2); border: 1px solid var(--border);
+    padding: 0.75rem 1rem; border-radius: 4px;
+  }
+  .threefold h3 {
+    margin: 0 0 0.5rem 0; color: var(--mesh-main);
+    font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.1em;
+  }
+  .threefold .v { font-family: 'JetBrains Mono', monospace; font-size: 0.85rem; }
+  .container { display: flex; flex-direction: column; height: 100vh; }
+  .iframe-wrap { flex: 1; }
+</style>
+</head>
+<body class="crt-light">
+
+<div class="layout">
+  <nav class="sidebar" id="sidebar"></nav>
+  <div class="container">
+    <div class="topbar">
+      <div><strong>SecuBox</strong> · YaCy — peer-to-peer search</div>
+      <div class="actions">
+        <a href="/" title="Back to SecuBox hub">← hub</a>
+        <a href="#" id="open-native" title="Open native YaCy in this tab">native UI</a>
+      </div>
+    </div>
+
+    <section class="threefold">
+      <article><h3>Components</h3><div class="v" id="components-v">loading…</div></article>
+      <article><h3>Status</h3><div class="v" id="status-v">loading…</div></article>
+      <article><h3>Access</h3><div class="v" id="access-v">loading…</div></article>
+    </section>
+
+    <div class="iframe-wrap">
+      <iframe class="yacy-frame" src="/yacy/" title="YaCy admin UI" referrerpolicy="no-referrer"></iframe>
+    </div>
+  </div>
+</div>
+
+<script src="/shared/sidebar.js"></script>
+<script>
+(function() {
+  function getToken() { return localStorage.getItem('sbx_token'); }
+  function checkAuth() {
+    if (!getToken()) {
+      window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+      return false;
+    }
+    return true;
+  }
+  if (!checkAuth()) {
+    document.body.innerHTML = '<div style="padding:2rem;color:var(--mesh-main);">Redirecting to login...</div>';
+    return;
+  }
+
+  function get(path) {
+    return fetch('/api/v1/yacy' + path, {
+      headers: { 'Authorization': 'Bearer ' + getToken() }
+    }).then(r => r.ok ? r.json() : Promise.reject(r.status));
+  }
+
+  get('/components').then(d => {
+    document.getElementById('components-v').innerHTML =
+      d.components.map(c => '<div>' + c.name + ': <strong>' + c.state + '</strong></div>').join('');
+  }).catch(() => { document.getElementById('components-v').textContent = 'unavailable'; });
+
+  get('/status').then(d => {
+    const colourVar = d.overall === 'green' ? 'mesh-main' : d.overall === 'yellow' ? 'wall-main' : 'auth-main';
+    document.getElementById('status-v').innerHTML =
+      '<span style="color:var(--' + colourVar + ')">' + (d.overall || 'unknown').toUpperCase() + '</span>';
+  }).catch(() => { document.getElementById('status-v').textContent = 'unavailable'; });
+
+  get('/access').then(d => {
+    document.getElementById('access-v').innerHTML =
+      (d.access || []).map(a => '<div>' + a.scope + ': <a href="' + a.url + '">' + a.url + '</a></div>').join('');
+  }).catch(() => { document.getElementById('access-v').textContent = 'unavailable'; });
+
+  document.getElementById('open-native').addEventListener('click', e => {
+    e.preventDefault();
+    window.location.href = '/yacy/';
+  });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Second module shipped against [`docs/MODULE-GUIDELINES.md`](../blob/master/docs/MODULE-GUIDELINES.md) after secubox-grafana (#231). Opens the **SEARCH** layer of the SecuBox CTL grammar.

YaCy v1.940 (peer-to-peer sovereign search engine) in a Debian bookworm LXC at `10.100.0.80` on `br-lxc`, listening on port 8090.

## Surface

| File | Purpose |
|---|---|
| `sbin/yacyctl` | Three-fold introspection + install/reload (peer/index/query/blacklist/crawler stubbed for v1.0.0) |
| `api/main.py` | FastAPI on `/run/secubox/yacy.sock` — `/status`, `/components`, `/access`, `/healthz`, `/version` |
| `lib/yacy/install-lxc.sh` | Idempotent: LXC + bridge + JVM + YaCy tarball + systemd unit + admin password |
| `lib/yacy/provision/peers.seed.txt` | Default freeworld peer seed |
| `lib/yacy/provision/blacklist.txt` | Search blacklist seed |
| `nginx/yacy.conf` | `/api/v1/yacy/` → Unix socket, `/yacy/` → LXC native UI iframe target |
| `menu.d/60-yacy.json` | Sidebar entry, `section: search`, order 60 |
| `www/yacy/index.html` | SecuBox-themed wrapper with three-fold cards + YaCy iframe |
| `debian/{control,changelog,rules,postinst,prerm,postrm,service}` | Standard packaging template |

## CTL surface

```text
yacyctl components|status|access [--json]   # three-fold (works on v1.0.0)
yacyctl install                              # idempotent LXC + JVM + YaCy bootstrap
yacyctl reload
yacyctl peer|index|query|blacklist|crawler … # stubbed in v1.0.0 (exit 2)
```

## Verified locally

- `bash -n` clean on `yacyctl` and `install-lxc.sh`
- `api/main.py` parses
- `menu.d/60-yacy.json` parses as JSON
- `dpkg-buildpackage -us -uc -b -d -tc` → `secubox-yacy_1.0.0-1~bookworm1_all.deb` (12 KB, 35 entries, all expected paths)

## Test plan

- [ ] `Build SecuBox .deb packages` auto-discovers and builds the new package (~1 min after PR open)
- [ ] After merge: next image build slipstreams the new `.deb`
- [ ] On a SecuBox board: `apt install secubox-yacy && yacyctl install` provisions the LXC, JVM, YaCy
- [ ] `yacyctl status --json` returns `{"overall":"green"}` once LXC + yacy + host API are all up
- [ ] `https://<host>/yacy/` opens the YaCy admin UI through the iframe wrapper

## Follow-ups (separate issues to file after merge)

- v1.1.0 — implement `peer`/`index`/`query`/`blacklist`/`crawler` verbs against the YaCy HTTP API
- Catalog row in `docs/MODULES.md` (search section)
- Grammar verbs row in `docs/grammar.md` (`SEARCH | yacyctl index status/build/clear/optimize | #232`)