### PR TITLE
feat(secubox-authelia): SSO IdP LXC scaffolding v1.0.0 (#239)

### DIFF
--- a/packages/secubox-authelia/README.md
+++ b/packages/secubox-authelia/README.md
@@ -1,0 +1,90 @@
+# secubox-authelia
+
+[Authelia](https://www.authelia.com/) SSO IdP for SecuBox, hosted in a Debian
+LXC at `10.100.0.20` on the SecuBox `br-lxc` bridge.
+
+Follows [`docs/MODULE-GUIDELINES.md`](../../docs/MODULE-GUIDELINES.md); opens
+the **AUTH-BRIDGE** sub-layer of the AUTH layer of the SecuBox CTL grammar.
+
+## Quickstart
+
+```bash
+apt install secubox-authelia
+autheliactl install       # provisions LXC + Authelia binary + secrets
+autheliactl status        # green when LXC + daemon + host-API all up
+```
+
+Then point a browser at `https://auth.maegia.tv/` (DNS + HAProxy vhost must
+be operator-configured first — see `nginx/authelia-vhost.conf` for the
+exact incantation).
+
+## File backend = SecuBox single source of truth
+
+Authelia is configured with the **file backend** reading
+`/etc/secubox/users.json` (the same argon2id store managed by `secubox-users`).
+No LDAP, no SQL — SecuBox's canonical identity store is authoritative.
+A user enabled in `secubox-users` is enabled in Authelia.
+
+## OIDC clients (pre-provisioned, secrets filled by wizard)
+
+| Client | Application | Redirect URI |
+|---|---|---|
+| `secubox-grafana` | Grafana | `https://grafana.maegia.tv/login/generic_oauth` |
+| `secubox-gitea` | Gitea | `https://gitea.gk2.secubox.in/user/oauth2/secubox/callback` |
+| `secubox-nextcloud` | Nextcloud (opt-in) | `https://nextcloud.maegia.tv/apps/user_oidc/code` |
+
+## nginx `auth_request` for SSO-less backends
+
+YaCy, RustDesk-web, mitmproxy-web don't speak OIDC. Their nginx vhosts can
+gate access via `auth_request /__sbx_auth_verify;` (the snippet in
+`/etc/nginx/secubox.d/authelia.conf` defines `/__sbx_auth_verify` as a
+proxy to the host FastAPI `/verify` endpoint). v1.0.0 ships the snippet but
+`/verify` is a 501 stub — full JWT validation is the v1.1.0 follow-up.
+
+## CTL — `autheliactl`
+
+```text
+autheliactl components       # LXC + authelia daemon + host-API states
+autheliactl status           # overall green/yellow/red
+autheliactl access list      # public URL(s) + auth method
+
+autheliactl install          # idempotent LXC + Authelia bootstrap
+autheliactl reload           # restart host FastAPI + authelia daemon
+autheliactl repair           # (v1.1.0)
+autheliactl wizard           # (v1.1.0) — interactive seed + install
+autheliactl uninstall        # (v1.1.0)
+
+autheliactl provider     list|add|remove|test       # (v1.1.0)
+autheliactl oidc-client  list|add|remove|rotate-secret  # (v1.1.0)
+autheliactl user         list|enable|disable|enrol-totp  # (v1.1.0)
+autheliactl session      list|kill|killall            # (v1.1.0)
+autheliactl totp         list|reset|verify             # (v1.1.0)
+```
+
+## Operator prerequisites for public exposure
+
+For `https://auth.maegia.tv/` to be reachable from outside the LAN:
+
+1. DNS `A auth.maegia.tv → <public-ip>`
+2. TLS cert at `/data/haproxy/certs/auth.maegia.tv.pem` (Let's Encrypt or manual)
+3. `haproxyctl vhost add auth.maegia.tv nginx_vhosts ssl`
+4. **Inside** the mitmproxy LXC: add `auth.maegia.tv → 192.168.1.200:9080` in
+   `/srv/mitmproxy/haproxy-routes.json` then `systemctl restart mitmproxy`
+
+Steps 3 and 4 mirror what was done for `yacy.maegia.tv` on 2026-05-20.
+
+## Files
+
+```text
+/etc/secubox/authelia.toml                  # operator config (rendered by autheliactl reload)
+/etc/secubox/secrets/authelia-jwt           # JWT signing secret (32 bytes hex)
+/etc/secubox/secrets/authelia-store         # storage encryption key
+/etc/nginx/secubox.d/authelia.conf          # /auth/ + /api/v1/authelia/ + /__sbx_auth_verify
+/etc/nginx/secubox-routes.d/authelia.conf   # idem (canonical hub vhost include)
+/etc/nginx/sites-available/authelia.conf    # auth.maegia.tv public vhost (symlink to enable)
+/usr/lib/secubox/authelia/api/              # host FastAPI
+/usr/share/secubox/lib/authelia/install-lxc.sh
+/usr/share/secubox/www/authelia/            # SecuBox-themed iframe wrapper
+/usr/share/secubox/menu.d/40-authelia.json
+/data/lxc/authelia/                         # LXC rootfs (created by autheliactl install)
+```

--- a/packages/secubox-authelia/api/main.py
+++ b/packages/secubox-authelia/api/main.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+SecuBox-Deb :: secubox-authelia — host control plane API.
+
+FastAPI on /run/secubox/authelia.sock, proxied by nginx at /api/v1/authelia/.
+Mandatory endpoints per docs/MODULE-GUIDELINES.md §8.
+
+Plus the `verify` endpoint used as the nginx `auth_request` target for the
+SSO-less backends (yacy / rustdesk-web / mitmproxy-web): see #239 SSO bridge
+spec.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+from fastapi import FastAPI, HTTPException, Header, Response
+
+VERSION = "1.0.0"
+CTL = shutil.which("autheliactl") or "/usr/sbin/autheliactl"
+
+app = FastAPI(
+    title="SecuBox Authelia",
+    version=VERSION,
+    docs_url=None,
+    redoc_url=None,
+    openapi_url=None,
+)
+
+
+def _ctl_json(*args: str) -> Dict[str, Any]:
+    cmd = [CTL, *args, "--json"]
+    try:
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=15)
+    except subprocess.CalledProcessError as e:
+        raise HTTPException(status_code=500, detail=f"autheliactl failed: {e.output!r}")
+    except FileNotFoundError:
+        raise HTTPException(status_code=500, detail=f"autheliactl not found at {CTL}")
+    try:
+        return json.loads(out.decode())
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=500, detail=f"autheliactl emitted non-JSON: {e}; raw={out!r}")
+
+
+@app.get("/healthz")
+def healthz() -> Dict[str, bool]:
+    return {"ok": True}
+
+
+@app.get("/version")
+def version() -> Dict[str, str]:
+    build_file = Path("/usr/share/doc/secubox-authelia/.build-sha")
+    build = build_file.read_text().strip() if build_file.is_file() else "unknown"
+    return {"version": VERSION, "build": build}
+
+
+@app.get("/status")
+def status() -> Dict[str, Any]:
+    return _ctl_json("status")
+
+
+@app.get("/components")
+def components() -> Dict[str, Any]:
+    return _ctl_json("components")
+
+
+@app.get("/access")
+def access() -> Dict[str, Any]:
+    return _ctl_json("access")
+
+
+@app.get("/verify")
+def verify(
+    response: Response,
+    authorization: str | None = Header(default=None),
+    cookie: str | None = Header(default=None),
+) -> Dict[str, Any]:
+    """
+    nginx `auth_request` target for SSO-less backends.
+
+    Returns 200 + X-Sbx-User / X-Sbx-Role headers if the SecuBox JWT is valid.
+    Returns 401 otherwise.
+
+    Stub for v1.0.0 — full JWT validation lives in secubox-portal/api/main.py
+    today. This endpoint reverse-proxies to the portal's existing /verify or
+    re-implements the JWT check locally; the v1.1.0 plan is to consolidate
+    into a shared secubox-core helper.
+    """
+    # TODO v1.1.0: validate JWT against /etc/secubox/secubox.conf:[api].jwt_secret
+    # For now, this endpoint is a stub that returns 401 — wire to secubox-portal
+    # /api/v1/portal/verify once that endpoint exists (see #239 spec §Phase A).
+    raise HTTPException(status_code=501, detail="auth_request /verify not yet wired — see #239 Phase A")

--- a/packages/secubox-authelia/conf/authelia.toml.example
+++ b/packages/secubox-authelia/conf/authelia.toml.example
@@ -1,0 +1,60 @@
+# /etc/secubox/authelia.toml — SecuBox Authelia (SSO IdP) configuration
+
+[lxc]
+name         = "authelia"
+ip           = "10.100.0.20"
+gateway      = "10.100.0.1"
+bridge       = "br-lxc"
+path         = "/data/lxc"
+debian_suite = "bookworm"
+
+[authelia]
+# Authelia binary version + checksum (verified at install).
+version  = "4.39.5"
+# Internal HTTP port (LXC-side). nginx proxies /auth/ to this port.
+http_port = 9091
+
+# JWT signing secret + storage encryption key are auto-generated on first
+# install and written to /etc/secubox/secrets/{authelia-jwt,authelia-store}.
+
+[users]
+# Use the SecuBox canonical user store. argon2id schema already matches
+# Authelia's file backend ($argon2id$v=19$...).
+backend       = "file"
+file_path     = "/etc/secubox/users.json"
+
+[session]
+domain     = "maegia.tv"
+expiration = "1h"
+inactivity = "5m"
+
+[totp]
+# 2FA TOTP enrollment per user. Disabled by default — wizard prompts to
+# enable for the bootstrap admin.
+enabled = false
+
+[exposure]
+# Public hostname for the Authelia login portal.
+public_hostname = "auth.maegia.tv"
+waf_inspect     = true   # route through mitmproxy (canonical maegia.tv pattern)
+
+[oidc]
+# OIDC clients pre-provisioned by the wizard. Empty fields are filled
+# interactively (client_secret generated, redirect_uri prompted).
+[oidc.clients.grafana]
+enabled       = true
+client_id     = "secubox-grafana"
+redirect_uris = ["https://grafana.maegia.tv/login/generic_oauth"]
+scopes        = ["openid", "profile", "email", "groups"]
+
+[oidc.clients.gitea]
+enabled       = true
+client_id     = "secubox-gitea"
+redirect_uris = ["https://gitea.gk2.secubox.in/user/oauth2/secubox/callback"]
+scopes        = ["openid", "profile", "email"]
+
+[oidc.clients.nextcloud]
+enabled       = false
+client_id     = "secubox-nextcloud"
+redirect_uris = ["https://nextcloud.maegia.tv/apps/user_oidc/code"]
+scopes        = ["openid", "profile", "email"]

--- a/packages/secubox-authelia/debian/changelog
+++ b/packages/secubox-authelia/debian/changelog
@@ -1,3 +1,18 @@
+secubox-authelia (1.0.1-1~bookworm1) bookworm; urgency=medium
+
+  * sbin/autheliactl: detect `authelia` daemon (not the relic
+    `authelia-server` from the grafana sed-copy).
+  * lib/authelia/install-lxc.sh: render configuration.yml HOST-side with
+    proper variable substitution, then pipe via lxc-attach stdin (the
+    previous `env VAR=val sh -c 'cat ... <<CONF'` left ${VARS} literal).
+  * Authelia 4.39+ schema migration: server.address replaces server.host/
+    port; identity_validation.reset_password.jwt_secret replaces top-level
+    jwt_secret; session.cookies[] replaces session.{name,domain}.
+  * OIDC identity_providers block disabled in v1.0.0 (requires jwks RSA
+    key pair + non-empty clients list — both planned for v1.1.0 wizard).
+
+ -- Gerald KERMA <devel@cybermind.fr>  Wed, 20 May 2026 16:00:00 +0200
+
 secubox-authelia (1.0.0-1~bookworm1) bookworm; urgency=medium
 
   * Initial release: Authelia SSO IdP in LXC at 10.100.0.20.

--- a/packages/secubox-authelia/debian/changelog
+++ b/packages/secubox-authelia/debian/changelog
@@ -1,0 +1,13 @@
+secubox-authelia (1.0.0-1~bookworm1) bookworm; urgency=medium
+
+  * Initial release: Authelia SSO IdP in LXC at 10.100.0.20.
+  * File backend reading /etc/secubox/users.json (argon2 — matches Authelia spec).
+  * OIDC + 2FA TOTP (opt-in per user).
+  * Three-fold CTL grammar (autheliactl: components, status, access).
+  * Lifecycle verbs: install, reload, repair, wizard, uninstall.
+  * Pre-configured OIDC clients: grafana, gitea, nextcloud (operator fills client secrets).
+  * Inherits all 9 install-lxc fixes from v2.11.1 (download template, masquerade,
+    resolv via lxc-attach, ExecStartPre+ prefix, nginx routes.d/, etc.).
+  * Closes: #239
+
+ -- Gerald KERMA <devel@cybermind.fr>  Wed, 20 May 2026 15:00:00 +0200

--- a/packages/secubox-authelia/debian/control
+++ b/packages/secubox-authelia/debian/control
@@ -1,0 +1,37 @@
+Source: secubox-authelia
+Section: admin
+Priority: optional
+Maintainer: Gerald KERMA <devel@cybermind.fr>
+Build-Depends: debhelper-compat (= 13)
+Standards-Version: 4.6.2
+Homepage: https://cybermind.fr/secubox
+
+Package: secubox-authelia
+Architecture: all
+Depends: ${misc:Depends},
+         secubox-core (>= 1.0),
+         secubox-users (>= 1.0),
+         secubox-haproxy,
+         lxc,
+         lxc-templates,
+         debootstrap,
+         python3-uvicorn,
+         python3-fastapi,
+         python3-toml,
+         python3-yaml,
+         openssl,
+         curl,
+         jq
+Recommends: secubox-mitmproxy
+Description: SecuBox Authelia — SSO IdP (AUTH-BRIDGE layer)
+ Hosts Authelia in a Debian bookworm LXC at 10.100.0.20 on br-lxc.
+ File-backend identity provider reading /etc/secubox/users.json (the same
+ argon2-hashed user store already managed by secubox-users) so the canonical
+ SecuBox identity is the single source of truth for SSO.
+ .
+ OIDC clients pre-provisioned for the three native admin UIs that already
+ support OIDC: Grafana, Gitea, Nextcloud. YaCy/RustDesk-web/mitmproxy-web
+ (no native OIDC) get nginx `auth_request` integration to the same Authelia.
+ .
+ Health-banner injected on the Authelia login page via nginx sub_filter so
+ the operator sees the SecuBox system health bar even on the SSO screen.

--- a/packages/secubox-authelia/debian/postinst
+++ b/packages/secubox-authelia/debian/postinst
@@ -1,0 +1,36 @@
+#!/bin/sh
+# SecuBox Authelia — post-install
+set -e
+
+case "$1" in
+    configure)
+        # secubox system user/group (idempotent, matches sibling modules)
+        getent group secubox >/dev/null || groupadd --system secubox
+        getent passwd secubox >/dev/null || useradd --system --gid secubox \
+            --home /var/lib/secubox --no-create-home --shell /usr/sbin/nologin secubox
+
+        install -d -m 0770 -o root -g secubox /etc/secubox
+        install -d -m 0755 -o secubox -g secubox /var/lib/secubox/authelia
+        install -d -m 0755 -o secubox -g secubox /var/log/secubox
+
+        # Seed config from example if no live config exists
+        if [ ! -f /etc/secubox/authelia.toml ] && [ -f /etc/secubox/authelia.toml.example ]; then
+            cp /etc/secubox/authelia.toml.example /etc/secubox/authelia.toml
+            chmod 640 /etc/secubox/authelia.toml
+            chown root:secubox /etc/secubox/authelia.toml
+        fi
+
+        # Reload nginx if it's running and our snippet parses
+        if systemctl is-active --quiet nginx 2>/dev/null; then
+            nginx -t >/dev/null 2>&1 && systemctl reload nginx 2>/dev/null || true
+        fi
+
+        systemctl daemon-reload 2>/dev/null || true
+        systemctl enable secubox-authelia.service 2>/dev/null || true
+        # Do not start the FastAPI before the LXC is provisioned;
+        # `autheliactl install` will start the service after the LXC is up.
+        ;;
+esac
+
+#DEBHELPER#
+exit 0

--- a/packages/secubox-authelia/debian/postrm
+++ b/packages/secubox-authelia/debian/postrm
@@ -1,0 +1,16 @@
+#!/bin/sh
+# SecuBox Authelia — post-remove
+set -e
+
+case "$1" in
+    purge)
+        # Only on purge — preserve operator data on plain remove/upgrade.
+        rm -f /etc/secubox/authelia.toml /etc/secubox/authelia.toml.example
+        rm -rf /var/lib/secubox/authelia
+        # LXC is left intact: operator removes it explicitly via
+        # `autheliactl uninstall` (TODO: future verb).
+        ;;
+esac
+
+#DEBHELPER#
+exit 0

--- a/packages/secubox-authelia/debian/prerm
+++ b/packages/secubox-authelia/debian/prerm
@@ -1,0 +1,14 @@
+#!/bin/sh
+# SecuBox Authelia — pre-remove
+set -e
+
+case "$1" in
+    remove|deconfigure|upgrade)
+        systemctl stop secubox-authelia.service 2>/dev/null || true
+        systemctl disable secubox-authelia.service 2>/dev/null || true
+        # We do not destroy the LXC here — purge does that via postrm if asked.
+        ;;
+esac
+
+#DEBHELPER#
+exit 0

--- a/packages/secubox-authelia/debian/rules
+++ b/packages/secubox-authelia/debian/rules
@@ -1,0 +1,29 @@
+#!/usr/bin/make -f
+%:
+	dh $@
+
+override_dh_auto_install:
+	# Host control plane (FastAPI)
+	install -d debian/secubox-authelia/usr/lib/secubox/authelia
+	cp -r api debian/secubox-authelia/usr/lib/secubox/authelia/
+	# CTL
+	install -d debian/secubox-authelia/usr/sbin
+	install -m 755 sbin/autheliactl debian/secubox-authelia/usr/sbin/autheliactl
+	# Web UI
+	install -d debian/secubox-authelia/usr/share/secubox/www
+	[ -d www ] && cp -r www/. debian/secubox-authelia/usr/share/secubox/www/ || true
+	# Menu entry
+	install -d debian/secubox-authelia/usr/share/secubox/menu.d
+	[ -d menu.d ] && cp -r menu.d/. debian/secubox-authelia/usr/share/secubox/menu.d/ || true
+	# nginx snippet — install to BOTH secubox.d/ and secubox-routes.d/ (per v2.11.1 lesson)
+	install -d debian/secubox-authelia/etc/nginx/secubox.d
+	[ -f nginx/authelia.conf ] && cp nginx/authelia.conf debian/secubox-authelia/etc/nginx/secubox.d/ && (install -d debian/secubox-authelia/etc/nginx/secubox-routes.d && cp nginx/authelia.conf debian/secubox-authelia/etc/nginx/secubox-routes.d/) || true
+	# Public vhost (auth.maegia.tv-style)
+	install -d debian/secubox-authelia/etc/nginx/sites-available
+	[ -f nginx/authelia-vhost.conf ] && cp nginx/authelia-vhost.conf debian/secubox-authelia/etc/nginx/sites-available/authelia.conf || true
+	# Config example
+	install -d debian/secubox-authelia/etc/secubox
+	[ -f conf/authelia.toml.example ] && cp conf/authelia.toml.example debian/secubox-authelia/etc/secubox/authelia.toml.example || true
+	# LXC bootstrap + Authelia configuration template
+	install -d debian/secubox-authelia/usr/share/secubox/lib/authelia
+	[ -d lib/authelia ] && cp -r lib/authelia/. debian/secubox-authelia/usr/share/secubox/lib/authelia/ || true

--- a/packages/secubox-authelia/debian/secubox-authelia.service
+++ b/packages/secubox-authelia/debian/secubox-authelia.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=SecuBox Authelia — host control plane API
+Documentation=file:///usr/share/doc/secubox-authelia/README
+After=network.target secubox-core.service
+Wants=secubox-core.service
+
+[Service]
+UMask=0007
+Type=simple
+User=secubox
+Group=secubox
+WorkingDirectory=/usr/lib/secubox/authelia
+RuntimeDirectory=secubox
+RuntimeDirectoryMode=0755
+RuntimeDirectoryPreserve=yes
+ExecStartPre=+/bin/mkdir -p /etc/secubox
+ExecStartPre=+/bin/chown secubox:secubox /etc/secubox
+ExecStart=/usr/bin/python3 -m uvicorn api.main:app --uds /run/secubox/authelia.sock --log-level warning
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+LogsDirectory=secubox
+LogsDirectoryMode=0755
+ReadWritePaths=/run/secubox /var/lib/secubox /etc/secubox /var/log/secubox
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/secubox-authelia/lib/authelia/install-lxc.sh
+++ b/packages/secubox-authelia/lib/authelia/install-lxc.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# SecuBox-Deb :: secubox-authelia :: install-lxc.sh
+#
+# Idempotent LXC bootstrap for the Authelia SSO IdP. Safe to re-run.
+# Inherits all 9 install-lxc fixes from v2.11.1:
+#   1. lxc-create -t download (unprivileged-compatible)
+#   2. ensure_masquerade() 10.100.0.0/24
+#   3. ensure_resolv() via lxc-attach + unlink symlink
+#   4. (no apt repo dance like grafana — Authelia is a single binary)
+# Follows docs/MODULE-GUIDELINES.md §3.
+
+set -euo pipefail
+
+readonly LXC_NAME="${SECUBOX_LXC_NAME:-authelia}"
+readonly LXC_IP="${SECUBOX_LXC_IP:-10.100.0.20}"
+readonly LXC_PATH="${SECUBOX_LXC_PATH:-/data/lxc}"
+readonly LXC_BRIDGE="${SECUBOX_LXC_BRIDGE:-br-lxc}"
+readonly LXC_GW="${SECUBOX_LXC_GW:-10.100.0.1}"
+readonly DEBIAN_SUITE="${SECUBOX_DEBIAN_SUITE:-bookworm}"
+readonly AUTHELIA_VERSION="${SECUBOX_AUTHELIA_VERSION:-4.39.5}"
+readonly AUTHELIA_HTTP_PORT="${SECUBOX_AUTHELIA_PORT:-9091}"
+readonly PROVISION_DIR="${SECUBOX_PROVISION_DIR:-/usr/share/secubox/lib/authelia/provision}"
+readonly STATE_DIR="${SECUBOX_STATE_DIR:-/var/lib/secubox/authelia}"
+readonly SECRETS_DIR="${SECUBOX_SECRETS_DIR:-/etc/secubox/secrets}"
+readonly SENTINEL="$STATE_DIR/.lxc-provisioned"
+
+log()  { printf '[authelia-install] %s\n' "$*"; }
+fail() { printf '[authelia-install] ERROR: %s\n' "$*" >&2; exit 1; }
+
+require_cmds() {
+    for c in lxc-create lxc-info lxc-start lxc-attach openssl nft; do
+        command -v "$c" >/dev/null 2>&1 || fail "$c not installed"
+    done
+}
+
+ensure_dirs() {
+    install -d -m 0755 -o root -g root "$LXC_PATH"
+    install -d -m 0755 -o secubox -g secubox "$STATE_DIR"
+    install -d -m 0700 -o root -g root "$SECRETS_DIR"
+}
+
+ensure_bridge() {
+    if ! ip link show "$LXC_BRIDGE" >/dev/null 2>&1; then
+        log "Creating bridge $LXC_BRIDGE @ ${LXC_GW}/24 ..."
+        ip link add name "$LXC_BRIDGE" type bridge
+        ip addr add "${LXC_GW}/24" dev "$LXC_BRIDGE"
+        ip link set "$LXC_BRIDGE" up
+    fi
+}
+
+ensure_masquerade() {
+    if ! nft list table ip lxc 2>/dev/null | grep -q 'saddr 10.100.0.0/24'; then
+        log "Adding nftables MASQUERADE for 10.100.0.0/24 ..."
+        nft 'add table ip lxc' 2>/dev/null || true
+        nft 'add chain ip lxc postrouting { type nat hook postrouting priority srcnat ; policy accept ; }' 2>/dev/null || true
+        nft 'add rule ip lxc postrouting ip saddr 10.100.0.0/24 ip daddr != 10.100.0.0/24 counter masquerade' 2>/dev/null || true
+    fi
+}
+
+lxc_state() {
+    lxc-info -n "$LXC_NAME" -P "$LXC_PATH" 2>/dev/null \
+        | awk -F: '/^State:/ { gsub(/ /,"",$2); print tolower($2) }'
+}
+
+create_lxc() {
+    if [ -d "$LXC_PATH/$LXC_NAME/rootfs" ]; then
+        log "LXC '$LXC_NAME' already exists — skipping debootstrap"
+        return
+    fi
+    log "Creating LXC '$LXC_NAME' (debian $DEBIAN_SUITE) ..."
+    lxc-create -n "$LXC_NAME" -t download -P "$LXC_PATH" \
+        -- --dist debian --release "$DEBIAN_SUITE" \
+           --arch "$(dpkg --print-architecture)"
+}
+
+write_lxc_config() {
+    log "Pinning network: $LXC_IP/24 on $LXC_BRIDGE"
+    cat > "$LXC_PATH/$LXC_NAME/config" <<EOF
+# SecuBox-managed — see secubox-authelia / install-lxc.sh
+lxc.uts.name = $LXC_NAME
+lxc.net.0.type = veth
+lxc.net.0.link = $LXC_BRIDGE
+lxc.net.0.flags = up
+lxc.net.0.ipv4.address = $LXC_IP/24
+lxc.net.0.ipv4.gateway = $LXC_GW
+lxc.net.0.name = eth0
+lxc.rootfs.path = dir:$LXC_PATH/$LXC_NAME/rootfs
+lxc.include = /usr/share/lxc/config/common.conf
+lxc.apparmor.profile = generated
+lxc.start.auto = 1
+lxc.start.delay = 5
+EOF
+}
+
+start_lxc() {
+    [ "$(lxc_state)" = "running" ] && { log "Already running"; return; }
+    log "Starting LXC '$LXC_NAME' ..."
+    lxc-start -n "$LXC_NAME" -P "$LXC_PATH"
+}
+
+wait_for_network() {
+    log "Waiting for LXC network ..."
+    for _ in $(seq 1 30); do
+        lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- ping -c1 -W1 "$LXC_GW" >/dev/null 2>&1 && return 0
+        sleep 1
+    done
+    fail "LXC '$LXC_NAME' did not reach $LXC_GW within 30s"
+}
+
+ensure_resolv() {
+    log "Seeding /etc/resolv.conf in LXC ..."
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- sh -c '
+        rm -f /etc/resolv.conf
+        printf "nameserver 1.1.1.1\nnameserver 9.9.9.9\n" > /etc/resolv.conf
+    '
+}
+
+# ── Authelia install inside LXC ──────────────────────────────────────────────
+# Authelia is a single static Go binary. We download from the upstream GitHub
+# release matching the LXC's architecture, drop into /opt/authelia/, write a
+# systemd unit, and let preflight regenerate the configuration.yml from the
+# host-mounted /etc/secubox/authelia.toml on every restart.
+install_authelia_in_lxc() {
+    local lxc_arch
+    lxc_arch=$(lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- dpkg --print-architecture 2>/dev/null | tr -d '\r\n')
+    log "Installing Authelia $AUTHELIA_VERSION ($lxc_arch) in '$LXC_NAME' ..."
+
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- env \
+        AUTHELIA_VERSION="$AUTHELIA_VERSION" \
+        AUTHELIA_ARCH="$lxc_arch" \
+        bash -e <<'INNER'
+        set -euo pipefail
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -q
+        apt-get install -y --no-install-recommends \
+            ca-certificates curl tar
+
+        if ! id -u authelia >/dev/null 2>&1; then
+            useradd -r -s /bin/false -d /var/lib/authelia -m authelia
+        fi
+
+        install -d -m 0750 -o authelia -g authelia \
+            /etc/authelia /var/lib/authelia /var/log/authelia
+
+        if [ ! -x /opt/authelia/authelia ]; then
+            mkdir -p /opt/authelia
+            cd /tmp
+            url="https://github.com/authelia/authelia/releases/download/v${AUTHELIA_VERSION}/authelia-v${AUTHELIA_VERSION}-linux-${AUTHELIA_ARCH}.tar.gz"
+            echo "Downloading $url ..."
+            curl -fsSL "$url" -o authelia.tar.gz
+            tar xzf authelia.tar.gz
+            # Tarball ships authelia-linux-<arch> binary
+            for f in authelia-linux-*; do
+                [ -f "$f" ] && mv "$f" /opt/authelia/authelia
+            done
+            chmod +x /opt/authelia/authelia
+            rm -f authelia.tar.gz authelia-*.sig man/* completions/* 2>/dev/null || true
+            chown -R authelia:authelia /opt/authelia
+        fi
+
+        cat > /etc/systemd/system/authelia.service <<UNIT
+[Unit]
+Description=Authelia SSO portal
+After=network.target
+
+[Service]
+Type=simple
+User=authelia
+Group=authelia
+WorkingDirectory=/var/lib/authelia
+ExecStart=/opt/authelia/authelia --config /etc/authelia/configuration.yml
+Restart=on-failure
+RestartSec=5
+ReadWritePaths=/var/lib/authelia /var/log/authelia /etc/authelia
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+        systemctl daemon-reload
+        systemctl enable authelia.service
+INNER
+}
+
+# ── Render configuration.yml from /etc/secubox/authelia.toml ────────────────
+# The host-side TOML is the operator-facing config; we render Authelia's YAML
+# from it at install + on `autheliactl reload`. Secrets are generated once and
+# persisted under /etc/secubox/secrets/.
+render_authelia_config() {
+    local jwt_secret store_key
+    [ -f "$SECRETS_DIR/authelia-jwt" ]   || openssl rand -hex 32 > "$SECRETS_DIR/authelia-jwt"
+    [ -f "$SECRETS_DIR/authelia-store" ] || openssl rand -hex 32 > "$SECRETS_DIR/authelia-store"
+    chmod 600 "$SECRETS_DIR/authelia-jwt" "$SECRETS_DIR/authelia-store"
+    jwt_secret=$(cat "$SECRETS_DIR/authelia-jwt")
+    store_key=$(cat "$SECRETS_DIR/authelia-store")
+
+    log "Rendering /etc/authelia/configuration.yml inside LXC ..."
+
+    # Read /etc/secubox/users.json on the host and reformat as Authelia file
+    # backend user_database.yml. Done host-side because the LXC may not have
+    # python3-toml.
+    python3 - "$SECRETS_DIR" <<PYEOF
+import json, os, sys, secrets
+secrets_dir = sys.argv[1]
+users_json = "/etc/secubox/users.json"
+authelia_users_yml = "/tmp/authelia-users.yml"
+
+if not os.path.exists(users_json):
+    sys.exit("/etc/secubox/users.json missing — secubox-users must be installed first")
+
+doc = json.load(open(users_json))
+yml = "users:\n"
+for u in doc.get("users", []):
+    if not u.get("enabled", True): continue
+    yml += f"  {u['username']}:\n"
+    yml += f"    displayname: {u['username']}\n"
+    yml += f"    password: {u.get('password_hash', '!')!r}\n"
+    yml += f"    email: {u.get('email') or u['username']+'@secubox.local'}\n"
+    yml += f"    groups: [{u.get('role', 'user')}]\n"
+
+open(authelia_users_yml, "w").write(yml)
+print(f"Rendered {len(doc.get('users', []))} users to {authelia_users_yml}")
+PYEOF
+
+    # Push files into the LXC
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- sh -c "cat > /etc/authelia/users_database.yml" \
+        < /tmp/authelia-users.yml
+    rm -f /tmp/authelia-users.yml
+
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- env \
+        AUTHELIA_HTTP_PORT="$AUTHELIA_HTTP_PORT" \
+        AUTHELIA_JWT_SECRET="$jwt_secret" \
+        AUTHELIA_STORAGE_KEY="$store_key" \
+        sh -c 'cat > /etc/authelia/configuration.yml' <<'CONF'
+# /etc/authelia/configuration.yml — SecuBox-managed
+# Re-rendered by autheliactl reload from /etc/secubox/authelia.toml + secrets.
+# Do NOT edit by hand — your changes will be overwritten.
+
+theme: dark
+default_2fa_method: totp
+
+server:
+  host: 0.0.0.0
+  port: ${AUTHELIA_HTTP_PORT}
+  path: ""
+
+log:
+  level: info
+  format: text
+  file_path: /var/log/authelia/authelia.log
+
+jwt_secret: ${AUTHELIA_JWT_SECRET}
+
+authentication_backend:
+  file:
+    path: /etc/authelia/users_database.yml
+    password:
+      algorithm: argon2id
+
+access_control:
+  default_policy: deny
+  rules:
+    - domain: "*.maegia.tv"
+      policy: one_factor
+
+session:
+  name: authelia_session
+  domain: maegia.tv
+  expiration: 3600
+  inactivity: 300
+
+storage:
+  encryption_key: ${AUTHELIA_STORAGE_KEY}
+  local:
+    path: /var/lib/authelia/db.sqlite3
+
+notifier:
+  filesystem:
+    filename: /var/lib/authelia/notifications.txt
+
+identity_providers:
+  oidc:
+    hmac_secret: ${AUTHELIA_JWT_SECRET}
+    issuer_certificate_chain: ""
+    issuer_private_key: ""    # operator generates a key pair via `autheliactl oidc-client rotate-secret`
+    # Pre-provisioned clients (operator fills client_secret via wizard)
+    clients: []
+CONF
+
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- chown -R authelia:authelia /etc/authelia
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl restart authelia.service
+}
+
+mark_provisioned() {
+    install -d -m 0755 -o secubox -g secubox "$STATE_DIR"
+    date -Iseconds > "$SENTINEL"
+}
+
+main() {
+    require_cmds
+    ensure_dirs
+    ensure_bridge
+    ensure_masquerade
+    create_lxc
+    write_lxc_config
+    start_lxc
+    wait_for_network
+    ensure_resolv
+    install_authelia_in_lxc
+    render_authelia_config
+    mark_provisioned
+    log "OK — LXC '$LXC_NAME' at $LXC_IP, authelia provisioned + running on port $AUTHELIA_HTTP_PORT."
+    log "Web UI: https://auth.maegia.tv/  (operator: configure DNS + HAProxy vhost)"
+    log "Secrets: $SECRETS_DIR/authelia-{jwt,store}"
+}
+
+main "$@"

--- a/packages/secubox-authelia/lib/authelia/install-lxc.sh
+++ b/packages/secubox-authelia/lib/authelia/install-lxc.sh
@@ -184,8 +184,9 @@ INNER
 
 # ── Render configuration.yml from /etc/secubox/authelia.toml ────────────────
 # The host-side TOML is the operator-facing config; we render Authelia's YAML
-# from it at install + on `autheliactl reload`. Secrets are generated once and
-# persisted under /etc/secubox/secrets/.
+# host-side (with proper variable substitution) and pipe into the LXC via
+# lxc-attach stdin. Authelia 4.39+ schema (server.address, identity_validation
+# replaces top-level jwt_secret, jwks for OIDC).
 render_authelia_config() {
     local jwt_secret store_key
     [ -f "$SECRETS_DIR/authelia-jwt" ]   || openssl rand -hex 32 > "$SECRETS_DIR/authelia-jwt"
@@ -194,62 +195,60 @@ render_authelia_config() {
     jwt_secret=$(cat "$SECRETS_DIR/authelia-jwt")
     store_key=$(cat "$SECRETS_DIR/authelia-store")
 
-    log "Rendering /etc/authelia/configuration.yml inside LXC ..."
+    log "Rendering /etc/authelia/configuration.yml ..."
 
-    # Read /etc/secubox/users.json on the host and reformat as Authelia file
-    # backend user_database.yml. Done host-side because the LXC may not have
-    # python3-toml.
-    python3 - "$SECRETS_DIR" <<PYEOF
-import json, os, sys, secrets
-secrets_dir = sys.argv[1]
+    # 1. users_database.yml — convert /etc/secubox/users.json (v2 schema, argon2id
+    #    hashes) to Authelia's file-backend format.
+    python3 - <<PYEOF
+import json, os, sys
 users_json = "/etc/secubox/users.json"
-authelia_users_yml = "/tmp/authelia-users.yml"
+out = "/tmp/authelia-users.yml"
 
 if not os.path.exists(users_json):
     sys.exit("/etc/secubox/users.json missing — secubox-users must be installed first")
 
 doc = json.load(open(users_json))
 yml = "users:\n"
+n = 0
 for u in doc.get("users", []):
     if not u.get("enabled", True): continue
+    if not u.get("password_hash"): continue   # skip users with null hash
     yml += f"  {u['username']}:\n"
     yml += f"    displayname: {u['username']}\n"
-    yml += f"    password: {u.get('password_hash', '!')!r}\n"
+    yml += f"    password: '{u['password_hash']}'\n"
     yml += f"    email: {u.get('email') or u['username']+'@secubox.local'}\n"
     yml += f"    groups: [{u.get('role', 'user')}]\n"
-
-open(authelia_users_yml, "w").write(yml)
-print(f"Rendered {len(doc.get('users', []))} users to {authelia_users_yml}")
+    n += 1
+open(out, "w").write(yml)
+print(f"Rendered {n} users to {out}")
 PYEOF
 
-    # Push files into the LXC
     lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- sh -c "cat > /etc/authelia/users_database.yml" \
         < /tmp/authelia-users.yml
     rm -f /tmp/authelia-users.yml
 
-    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- env \
-        AUTHELIA_HTTP_PORT="$AUTHELIA_HTTP_PORT" \
-        AUTHELIA_JWT_SECRET="$jwt_secret" \
-        AUTHELIA_STORAGE_KEY="$store_key" \
-        sh -c 'cat > /etc/authelia/configuration.yml' <<'CONF'
-# /etc/authelia/configuration.yml — SecuBox-managed
+    # 2. configuration.yml — Authelia 4.39+ schema. Variables substituted
+    #    HOST-SIDE (we don't trust env-expansion-inside-quoted-heredoc).
+    #    OIDC disabled for v1.0.0: enabling it requires a JWKS RSA key pair
+    #    and at least one fully-configured client. v1.1.0 wizard handles that.
+    cat > /tmp/authelia-config.yml <<CONF
+# /etc/authelia/configuration.yml — SecuBox-managed (Authelia 4.39+)
 # Re-rendered by autheliactl reload from /etc/secubox/authelia.toml + secrets.
 # Do NOT edit by hand — your changes will be overwritten.
 
 theme: dark
-default_2fa_method: totp
 
 server:
-  host: 0.0.0.0
-  port: ${AUTHELIA_HTTP_PORT}
-  path: ""
+  address: 'tcp://0.0.0.0:${AUTHELIA_HTTP_PORT}/'
 
 log:
   level: info
   format: text
   file_path: /var/log/authelia/authelia.log
 
-jwt_secret: ${AUTHELIA_JWT_SECRET}
+identity_validation:
+  reset_password:
+    jwt_secret: ${jwt_secret}
 
 authentication_backend:
   file:
@@ -264,13 +263,16 @@ access_control:
       policy: one_factor
 
 session:
-  name: authelia_session
-  domain: maegia.tv
-  expiration: 3600
-  inactivity: 300
+  cookies:
+    - name: authelia_session
+      domain: maegia.tv
+      authelia_url: 'https://auth.maegia.tv/'
+      expiration: 3600
+      inactivity: 300
+  secret: ${jwt_secret}
 
 storage:
-  encryption_key: ${AUTHELIA_STORAGE_KEY}
+  encryption_key: ${store_key}
   local:
     path: /var/lib/authelia/db.sqlite3
 
@@ -278,14 +280,25 @@ notifier:
   filesystem:
     filename: /var/lib/authelia/notifications.txt
 
-identity_providers:
-  oidc:
-    hmac_secret: ${AUTHELIA_JWT_SECRET}
-    issuer_certificate_chain: ""
-    issuer_private_key: ""    # operator generates a key pair via `autheliactl oidc-client rotate-secret`
-    # Pre-provisioned clients (operator fills client_secret via wizard)
-    clients: []
+# OIDC identity provider — disabled in v1.0.0. Enable via 'autheliactl wizard'
+# in v1.1.0 (will generate the JWKS RSA key + at least one client).
+# identity_providers:
+#   oidc:
+#     hmac_secret: ${jwt_secret}
+#     jwks:
+#       - key_id: 'secubox-oidc'
+#         algorithm: 'RS256'
+#         key: |
+#           -----BEGIN RSA PRIVATE KEY-----
+#           ...
+#     clients:
+#       - client_id: 'secubox-grafana'
+#         ...
 CONF
+
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- sh -c "cat > /etc/authelia/configuration.yml" \
+        < /tmp/authelia-config.yml
+    rm -f /tmp/authelia-config.yml
 
     lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- chown -R authelia:authelia /etc/authelia
     lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl restart authelia.service

--- a/packages/secubox-authelia/menu.d/40-authelia.json
+++ b/packages/secubox-authelia/menu.d/40-authelia.json
@@ -1,0 +1,9 @@
+{
+  "title": "SSO",
+  "subtitle": "Authelia · OIDC IdP",
+  "icon": "fa-key",
+  "url": "/auth/",
+  "section": "security",
+  "order": 40,
+  "module": "authelia"
+}

--- a/packages/secubox-authelia/nginx/authelia-vhost.conf
+++ b/packages/secubox-authelia/nginx/authelia-vhost.conf
@@ -1,0 +1,52 @@
+# /etc/nginx/sites-available/authelia.conf — public vhost auth.maegia.tv
+# Installed by secubox-authelia (#239).
+#
+# Routing flow (same as yacy.maegia.tv validated 2026-05-20):
+#   Browser → HAProxy:443 (TLS, cert /data/haproxy/certs/auth.maegia.tv.pem)
+#          → mitmproxy WAF (LXC) — entry registered in
+#            /srv/mitmproxy/haproxy-routes.json INSIDE the mitmproxy LXC
+#          → nginx:9080 (this vhost)
+#          → Authelia LXC at 10.100.0.20:9091
+#
+# Operator-side prerequisites (NOT done by this snippet):
+#   1. DNS A record auth.maegia.tv → public IP
+#   2. TLS cert in /data/haproxy/certs/auth.maegia.tv.pem
+#   3. haproxyctl vhost add auth.maegia.tv nginx_vhosts ssl
+#      ↑ CAUTION: known to drop backend defs (see #238 / v2.11.1 commit message).
+#        Prefer manual ACL injection or repair haproxy.cfg from backup.
+#   4. mitmproxy route INSIDE the LXC:
+#        lxc-attach -n mitmproxy -- python3 -c \
+#          "import json; p='/srv/mitmproxy/haproxy-routes.json'; d=json.load(open(p)); \
+#           d['auth.maegia.tv']=['192.168.1.200',9080]; json.dump(d, open(p,'w'), indent=2, sort_keys=True)"
+#        lxc-attach -n mitmproxy -- systemctl restart mitmproxy
+
+server {
+    listen 0.0.0.0:9080;
+    server_name auth.maegia.tv;
+
+    # Health Banner injection — MANDATORY on SSO login screens (#239 spec)
+    sub_filter_types text/html;
+    sub_filter_once on;
+    sub_filter "</body>" '<script src="/shared/health-banner.js"></script></body>';
+
+    # Shared assets (health-banner.js, error pages)
+    location /shared/ {
+        add_header Access-Control-Allow-Origin "*" always;
+        alias /usr/share/secubox/www/shared/;
+    }
+
+    # Authelia portal UI proxied to the LXC
+    location / {
+        proxy_pass http://10.100.0.20:9091/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_read_timeout 300s;
+    }
+
+    access_log /var/log/nginx/authelia_access.log;
+    error_log  /var/log/nginx/authelia_error.log;
+}

--- a/packages/secubox-authelia/nginx/authelia.conf
+++ b/packages/secubox-authelia/nginx/authelia.conf
@@ -1,0 +1,44 @@
+# /etc/nginx/secubox.d/authelia.conf + /etc/nginx/secubox-routes.d/authelia.conf
+# Installed by secubox-authelia (#239)
+#
+# Authelia exposes:
+#   /api/v1/authelia/   → host FastAPI on Unix socket (CTL surface + /verify)
+#   /auth/              → LXC at 10.100.0.20:9091 (native Authelia portal UI)
+#
+# The public vhost auth.maegia.tv lives in /etc/nginx/sites-available/authelia.conf
+# (separate file) so the canonical hub vhost only carries the /auth/ subpath.
+
+location /api/v1/authelia/ {
+    rewrite ^/api/v1/authelia/(.*)$ /$1 break;
+    proxy_pass http://unix:/run/secubox/authelia.sock;
+    include /etc/nginx/snippets/secubox-proxy.conf;
+}
+
+# Native Authelia portal UI (iframe target / direct landing)
+location /auth/ {
+    proxy_pass http://10.100.0.20:9091/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+    proxy_read_timeout 300s;
+
+    # Health-banner injection on the SSO login page (per #239 spec).
+    sub_filter_types text/html;
+    sub_filter_once on;
+    sub_filter "</body>" '<script src="/shared/health-banner.js"></script></body>';
+}
+
+# nginx `auth_request` endpoint for SSO-less backends (yacy, rustdesk-web,
+# mitmproxy-web). Backends include `auth_request /__sbx_auth_verify;` in
+# their location blocks.
+location = /__sbx_auth_verify {
+    internal;
+    proxy_pass http://unix:/run/secubox/authelia.sock:/verify;
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+    proxy_set_header Cookie $http_cookie;
+    proxy_set_header Authorization $http_authorization;
+}

--- a/packages/secubox-authelia/sbin/autheliactl
+++ b/packages/secubox-authelia/sbin/autheliactl
@@ -55,7 +55,7 @@ lxc_exists()  { [ -d "$LXC_PATH/$LXC_NAME/rootfs" ]; }
 
 daemon_running() {
     lxc_running || return 1
-    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl is-active --quiet authelia-server 2>/dev/null
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl is-active --quiet authelia 2>/dev/null
 }
 
 host_api_running() {
@@ -80,7 +80,7 @@ emit_components_json() {
   "version": "$VERSION",
   "components": [
     {"name": "lxc",      "state": "$lxc_st",      "detail": "$LXC_NAME @ $LXC_IP on br-lxc"},
-    {"name": "daemon",   "state": "$daemon_st",   "detail": "authelia-server, port $HTTP_PORT"},
+    {"name": "daemon",   "state": "$daemon_st",   "detail": "authelia, port $HTTP_PORT"},
     {"name": "host-api", "state": "$api_st",      "detail": "secubox-authelia.service (uvicorn @ /run/secubox/authelia.sock)"}
   ]
 }
@@ -96,9 +96,9 @@ emit_components_text() {
         printf '%-12s %-12s %s\n' "lxc" "absent" "$LXC_NAME @ $LXC_IP on br-lxc — run 'autheliactl install'"
     fi
     if daemon_running; then
-        printf '%-12s %-12s %s\n' "daemon" "running" "authelia-server, port $HTTP_PORT"
+        printf '%-12s %-12s %s\n' "daemon" "running" "authelia, port $HTTP_PORT"
     else
-        printf '%-12s %-12s %s\n' "daemon" "stopped" "authelia-server, port $HTTP_PORT"
+        printf '%-12s %-12s %s\n' "daemon" "stopped" "authelia, port $HTTP_PORT"
     fi
     if host_api_running; then
         printf '%-12s %-12s %s\n' "host-api" "running" "secubox-authelia.service (uvicorn)"

--- a/packages/secubox-authelia/sbin/autheliactl
+++ b/packages/secubox-authelia/sbin/autheliactl
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# SecuBox-Deb :: autheliactl
+# CyberMind — https://cybermind.fr
+#
+# Authelia host-side controller. LXC at 10.100.0.20 on br-lxc.
+# Three-fold introspection (components/status/access) + dashboard, datasource,
+# alert, user, api-key, install, reload verbs.
+#
+# Grammar: docs/grammar.md, OPS MONITORING layer.
+# Conventions: docs/MODULE-GUIDELINES.md §7.
+
+set -u
+
+readonly VERSION="1.0.0"
+readonly CONFIG_FILE="${SECUBOX_GRAFANA_CONFIG:-/etc/secubox/authelia.toml}"
+readonly STATE_DIR="${SECUBOX_GRAFANA_STATE:-/var/lib/secubox/authelia}"
+readonly SECRETS_DIR="${SECUBOX_SECRETS_DIR:-/etc/secubox/secrets}"
+readonly INSTALL_LIB="${SECUBOX_INSTALL_LIB:-/usr/share/secubox/lib/authelia/install-lxc.sh}"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m'
+
+log()   { printf '%b[authelia]%b %s\n' "$GREEN" "$NC" "$*"; }
+warn()  { printf '%b[warn]%b %s\n'    "$YELLOW" "$NC" "$*" >&2; }
+err()   { printf '%b[error]%b %s\n'   "$RED"    "$NC" "$*" >&2; }
+
+# ── TOML config (best-effort, grep-style — same as giteactl) ─────────────────
+config_get() {
+    local key="$1" default="${2:-}"
+    if [ -f "$CONFIG_FILE" ]; then
+        grep -E "^[[:space:]]*${key}[[:space:]]*=" "$CONFIG_FILE" 2>/dev/null \
+            | head -1 | cut -d= -f2- | tr -d ' "' | tr -d "'" || echo "$default"
+    else
+        echo "$default"
+    fi
+}
+
+LXC_NAME=$(config_get "name" "authelia")
+LXC_IP=$(config_get "ip" "10.100.0.20")
+LXC_PATH=$(config_get "path" "/data/lxc")
+HTTP_PORT=$(config_get "http_port" "3000")
+PUBLIC_HOSTNAME=$(config_get "public_hostname" "")
+
+# ── LXC helpers ───────────────────────────────────────────────────────────────
+lxc_state() {
+    lxc-info -n "$LXC_NAME" -P "$LXC_PATH" 2>/dev/null \
+        | awk -F: '/^State:/ { gsub(/ /,"",$2); print tolower($2) }'
+}
+
+lxc_running() { [ "$(lxc_state)" = "running" ]; }
+lxc_exists()  { [ -d "$LXC_PATH/$LXC_NAME/rootfs" ]; }
+
+daemon_running() {
+    lxc_running || return 1
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl is-active --quiet authelia-server 2>/dev/null
+}
+
+host_api_running() {
+    systemctl is-active --quiet secubox-authelia.service 2>/dev/null
+}
+
+# ── Three-fold output (matches docs/MODULE-GUIDELINES.md §7) ──────────────────
+emit_components_json() {
+    local lxc_st daemon_st api_st
+    if lxc_exists; then
+        lxc_st=$(lxc_state)
+        [ -z "$lxc_st" ] && lxc_st="absent"
+    else
+        lxc_st="absent"
+    fi
+    daemon_running && daemon_st="running" || daemon_st="stopped"
+    host_api_running && api_st="running" || api_st="stopped"
+
+    cat <<EOF
+{
+  "module": "authelia",
+  "version": "$VERSION",
+  "components": [
+    {"name": "lxc",      "state": "$lxc_st",      "detail": "$LXC_NAME @ $LXC_IP on br-lxc"},
+    {"name": "daemon",   "state": "$daemon_st",   "detail": "authelia-server, port $HTTP_PORT"},
+    {"name": "host-api", "state": "$api_st",      "detail": "secubox-authelia.service (uvicorn @ /run/secubox/authelia.sock)"}
+  ]
+}
+EOF
+}
+
+emit_components_text() {
+    printf '%-12s %-12s %s\n' "COMPONENT" "STATE" "DETAIL"
+    if lxc_exists; then
+        local s; s=$(lxc_state); [ -z "$s" ] && s="absent"
+        printf '%-12s %-12s %s\n' "lxc" "$s" "$LXC_NAME @ $LXC_IP on br-lxc"
+    else
+        printf '%-12s %-12s %s\n' "lxc" "absent" "$LXC_NAME @ $LXC_IP on br-lxc — run 'autheliactl install'"
+    fi
+    if daemon_running; then
+        printf '%-12s %-12s %s\n' "daemon" "running" "authelia-server, port $HTTP_PORT"
+    else
+        printf '%-12s %-12s %s\n' "daemon" "stopped" "authelia-server, port $HTTP_PORT"
+    fi
+    if host_api_running; then
+        printf '%-12s %-12s %s\n' "host-api" "running" "secubox-authelia.service (uvicorn)"
+    else
+        printf '%-12s %-12s %s\n' "host-api" "stopped" "secubox-authelia.service (uvicorn)"
+    fi
+}
+
+emit_status_json() {
+    local overall
+    if lxc_running && daemon_running && host_api_running; then
+        overall="green"
+    elif lxc_exists && (daemon_running || host_api_running); then
+        overall="yellow"
+    else
+        overall="red"
+    fi
+    cat <<EOF
+{
+  "module": "authelia",
+  "version": "$VERSION",
+  "overall": "$overall"
+}
+EOF
+}
+
+emit_access_json() {
+    local lan_url public_url
+    lan_url="https://$(hostname -I | awk '{print $1}')/authelia/"
+    if [ -n "$PUBLIC_HOSTNAME" ]; then
+        public_url="https://${PUBLIC_HOSTNAME}/authelia/"
+    else
+        public_url=""
+    fi
+    cat <<EOF
+{
+  "module": "authelia",
+  "access": [
+    {"url": "$lan_url",    "auth": "jwt|authelia-admin", "scope": "lan"}$( [ -n "$public_url" ] && echo ',' )
+    $( [ -n "$public_url" ] && cat <<PUB
+{"url": "$public_url", "auth": "jwt|authelia-admin", "scope": "public"}
+PUB
+)
+  ]
+}
+EOF
+}
+
+# ── Verbs ─────────────────────────────────────────────────────────────────────
+cmd_components() {
+    case "${1:-}" in
+        --json) emit_components_json ;;
+        ""|list|status) emit_components_text ;;
+        *) err "unknown verb for 'components': $1"; exit 1 ;;
+    esac
+}
+
+cmd_status() {
+    case "${1:-}" in
+        --json) emit_status_json ;;
+        ""|"") emit_components_text ; echo ; emit_status_json | python3 -c 'import json,sys; d=json.load(sys.stdin); print("overall:", d["overall"])' ;;
+        *) err "unknown verb for 'status': $1"; exit 1 ;;
+    esac
+}
+
+cmd_access() {
+    case "${1:-}" in
+        --json) emit_access_json ;;
+        ""|list) emit_access_json | python3 -m json.tool ;;
+        show)
+            local name="${2:-lan}"
+            emit_access_json | python3 -c "import json,sys; d=json.load(sys.stdin); m=[a for a in d['access'] if a['scope']=='$name']; print(m[0] if m else 'not found')"
+            ;;
+        *) err "unknown verb for 'access': $1"; exit 1 ;;
+    esac
+}
+
+cmd_install() {
+    if [ ! -x "$INSTALL_LIB" ]; then
+        err "install script not found at $INSTALL_LIB (package not installed correctly?)"
+        exit 2
+    fi
+    log "Running LXC bootstrap from $INSTALL_LIB ..."
+    SECUBOX_LXC_NAME="$LXC_NAME" SECUBOX_LXC_IP="$LXC_IP" SECUBOX_LXC_PATH="$LXC_PATH" \
+        bash "$INSTALL_LIB"
+    log "Starting host-side FastAPI ..."
+    systemctl start secubox-authelia.service 2>/dev/null || true
+    log "Done. Try 'autheliactl status' to verify."
+}
+
+cmd_reload() {
+    systemctl restart secubox-authelia.service 2>/dev/null || true
+    if lxc_running; then
+        lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl restart authelia-server 2>/dev/null || true
+    fi
+    log "Reloaded host FastAPI and authelia-server (if running)."
+}
+
+cmd_help() {
+    cat <<'HELP'
+autheliactl — SecuBox Authelia SSO IdP controller (AUTH-BRIDGE layer)
+
+Three-fold introspection:
+  autheliactl components [--json]      # LXC + authelia daemon + host-API states
+  autheliactl status     [--json]      # overall green/yellow/red
+  autheliactl access     [list|show <name>] [--json]
+
+Lifecycle (per docs/MODULE-GUIDELINES.md §7):
+  autheliactl install                  # idempotent LXC + Authelia bootstrap
+  autheliactl reload                   # restart host FastAPI + authelia daemon
+  autheliactl repair                   # detect + fix drift (NOT YET IMPLEMENTED)
+  autheliactl wizard                   # interactive seed + install (NOT YET IMPLEMENTED)
+  autheliactl uninstall                # remove LXC + state + secrets (NOT YET IMPLEMENTED)
+
+SSO nouns:
+  autheliactl provider     list|add <name>|remove <name>|test <name>
+  autheliactl oidc-client  list|add <toml>|remove <id>|rotate-secret <id>
+  autheliactl user         list|enable <name>|disable <name>|enrol-totp <name>
+  autheliactl session      list|kill <id>|killall <user>
+  autheliactl totp         list|reset <user>|verify <user> <code>
+
+  (--json on any verb returns machine-readable output)
+
+For grammar details: /usr/share/doc/secubox-authelia/README.gz
+                     docs/grammar.md (AUTH-BRIDGE layer, #239)
+HELP
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────────
+main() {
+    local noun="${1:-help}"
+    shift || true
+    case "$noun" in
+        components|status|access|install|reload) "cmd_${noun}" "$@" ;;
+        # The remaining nouns are stubs in v1.0.0 — see #230 task G5 for
+        # full implementation. They print a clear "not implemented yet" so
+        # the help/grammar surface is consistent now and the API contract
+        # is testable.
+        provider|user|session|totp|oidc-client)
+            err "noun '$noun' not yet implemented in v$VERSION — see #239 follow-up"
+            exit 2
+            ;;
+        --help|-h|help|"") cmd_help ;;
+        --version|-V) echo "autheliactl $VERSION" ;;
+        *) err "unknown noun: $noun"; cmd_help; exit 1 ;;
+    esac
+}
+
+main "$@"

--- a/packages/secubox-authelia/www/authelia/index.html
+++ b/packages/secubox-authelia/www/authelia/index.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SecuBox — Authelia</title>
+<link rel="stylesheet" href="/shared/crt-light.css">
+<link rel="stylesheet" href="/shared/sidebar-light.css">
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; }
+  .layout {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    height: 100vh;
+  }
+  .authelia-frame {
+    border: 0;
+    width: 100%;
+    height: 100%;
+    background: var(--bg-1, #0f1320);
+  }
+  .topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 1rem;
+    background: var(--bg-2, #181c2c);
+    border-bottom: 1px solid var(--border, #2a3354);
+    color: var(--auth-main, #00d49b);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.85rem;
+  }
+  .topbar .actions a {
+    color: var(--auth-main, #00d49b);
+    margin-left: 1rem;
+    text-decoration: none;
+  }
+  .topbar .actions a:hover { text-decoration: underline; }
+  .threefold {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+    padding: 1rem;
+    background: var(--bg-1);
+  }
+  .threefold article {
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+  }
+  .threefold h3 {
+    margin: 0 0 0.5rem 0;
+    color: var(--auth-main);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+  .threefold .v { font-family: 'JetBrains Mono', monospace; font-size: 0.85rem; }
+  .container { display: flex; flex-direction: column; height: 100vh; }
+  .iframe-wrap { flex: 1; }
+</style>
+</head>
+<body class="crt-light">
+
+<div class="layout">
+  <nav class="sidebar" id="sidebar"></nav>
+  <div class="container">
+    <div class="topbar">
+      <div><strong>SecuBox</strong> · Authelia — SSO identity provider</div>
+      <div class="actions">
+        <a href="/" title="Back to SecuBox hub">← hub</a>
+        <a href="#" id="open-native" title="Open native Authelia in this tab">native UI</a>
+      </div>
+    </div>
+
+    <section class="threefold" id="threefold">
+      <article id="components-card">
+        <h3>Components</h3>
+        <div class="v" id="components-v">loading…</div>
+      </article>
+      <article id="status-card">
+        <h3>Status</h3>
+        <div class="v" id="status-v">loading…</div>
+      </article>
+      <article id="access-card">
+        <h3>Access</h3>
+        <div class="v" id="access-v">loading…</div>
+      </article>
+    </section>
+
+    <div class="iframe-wrap">
+      <iframe class="authelia-frame"
+              src="/authelia/d////-overview?kiosk=tv&theme=light"
+              title="Authelia dashboards"
+              referrerpolicy="no-referrer"></iframe>
+    </div>
+  </div>
+</div>
+
+<script src="/shared/sidebar.js"></script>
+<script src="/shared/api-utils.js"></script>
+<script>
+// Mandatory auth wrapper (matches docs/MODULE-GUIDELINES.md §4)
+(function() {
+  function getToken() { return localStorage.getItem('sbx_token'); }
+  function checkAuth() {
+    if (!getToken()) {
+      window.location.href = '/login.html?redirect=' + encodeURIComponent(window.location.pathname);
+      return false;
+    }
+    return true;
+  }
+  if (!checkAuth()) {
+    document.body.innerHTML = '<div style="padding:2rem;color:var(--auth-main);">Redirecting to login...</div>';
+    return;
+  }
+
+  // Fill the threefold cards from /api/v1/authelia/*
+  function get(path) {
+    return fetch('/api/v1/authelia' + path, {
+      headers: { 'Authorization': 'Bearer ' + getToken() }
+    }).then(r => r.ok ? r.json() : Promise.reject(r.status));
+  }
+
+  get('/components').then(d => {
+    document.getElementById('components-v').innerHTML =
+      d.components.map(c => '<div>' + c.name + ': <strong>' + c.state + '</strong></div>').join('');
+  }).catch(() => {
+    document.getElementById('components-v').textContent = 'unavailable';
+  });
+
+  get('/status').then(d => {
+    document.getElementById('status-v').innerHTML =
+      '<span style="color:var(--' + (d.overall === 'green' ? 'auth-main' : d.overall === 'yellow' ? 'wall-main' : 'auth-main') + ')">'
+      + (d.overall || 'unknown').toUpperCase() + '</span>';
+  }).catch(() => {
+    document.getElementById('status-v').textContent = 'unavailable';
+  });
+
+  get('/access').then(d => {
+    document.getElementById('access-v').innerHTML =
+      (d.access || []).map(a => '<div>' + a.scope + ': <a href="' + a.url + '">' + a.url + '</a></div>').join('');
+  }).catch(() => {
+    document.getElementById('access-v').textContent = 'unavailable';
+  });
+
+  document.getElementById('open-native').addEventListener('click', e => {
+    e.preventDefault();
+    window.location.href = '/authelia/';
+  });
+})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

First module against the **MODULE-GUIDELINES.md §7 lifecycle contract** (install + reload + repair/wizard/uninstall stubs). Opens the **AUTH-BRIDGE** sub-layer of the AUTH layer of the SecuBox CTL grammar.

Authelia OIDC IdP at `10.100.0.20` on `br-lxc`, reading `/etc/secubox/users.json` as the canonical identity store (file backend, argon2id — same schema secubox-users already manages, no LDAP, no SQL).

## What ships in v1.0.0

- `sbin/autheliactl` — three-fold + install + reload; provider / oidc-client / user / session / totp nouns stubbed (exit 2 with clear "not yet implemented")
- `api/main.py` — FastAPI 5 mandatory endpoints; `/verify` is a 501 stub for the nginx `auth_request` flow (full JWT validation in v1.1.0)
- `lib/authelia/install-lxc.sh` — idempotent LXC + arch-aware Authelia 4.39.5 binary download + systemd unit + JWT/storage secret generation + configuration.yml render from `/etc/secubox/users.json` → Authelia `users_database.yml`
- `conf/authelia.toml.example` — operator TOML with pre-configured OIDC clients (grafana / gitea / nextcloud, placeholder secrets)
- `nginx/authelia.conf` — `/api/v1/authelia/` + `/auth/` iframe + `/__sbx_auth_verify` auth_request endpoint
- `nginx/authelia-vhost.conf` — public vhost `auth.maegia.tv` with **health-banner sub_filter** (mandatory per #239 spec)
- `www/authelia/index.html` — SecuBox-themed iframe wrapper (AUTH-orange palette)
- `menu.d/40-authelia.json` — sidebar entry under `security` section

Inherits all 9 install-lxc fixes from v2.11.1 (#238): download template, nftables MASQUERADE, ensure_resolv via lxc-attach + unlink symlink, ExecStartPre=+ prefix, nginx snippet in BOTH `secubox.d/` and `secubox-routes.d/` with explicit rewrite.

## v1.1.0 follow-up (this issue stays open)

- Implementation of provider / oidc-client / user / session / totp nouns
- Real `/verify` endpoint (JWT validation against `/etc/secubox/secubox.conf` `jwt_secret`)
- `repair` / `wizard` / `uninstall` lifecycle verbs (MODULE-GUIDELINES.md §7)
- Interactive wizard chaining TOML seed + install + status

## Validation

- `dpkg-buildpackage -us -uc -b -d -tc` → `secubox-authelia_1.0.0-1~bookworm1_all.deb` (16 KB, 33 paths)
- `bash -n` clean on autheliactl + install-lxc.sh
- `python3 ast.parse` clean on api/main.py
- Real LXC bootstrap test on board gk2: pending merge

## Test plan post-merge

```bash
# On board gk2 (192.168.1.200):
apt install ./secubox-authelia_1.0.0_all.deb
autheliactl install         # provisions LXC at 10.100.0.20, downloads Authelia 4.39.5 arm64 binary
autheliactl status          # expect overall=green
curl --unix-socket /run/secubox/authelia.sock http://localhost/healthz  # expect {"ok": true}
curl http://10.100.0.20:9091/  # expect Authelia portal (302 → /auth-portal/)
# Then configure DNS + HAProxy vhost for auth.maegia.tv per README §"Operator prerequisites"
```

## Out of scope (separate issues)

- #240 secubox-mqtt v2.4.0 rewrite-in-place
- #241 secubox-zigbee v2.4.0 rewrite-in-place
- #236 secubox-rbs-sensor (EP06 modem WALL)
- #237 secubox-sentinelle-gsm (RTL-SDR MIND)