### PR TITLE
feat(secubox-rbs-sensor): v0.1.0 WALL/OPAD sensor scaffold for EP06-E (closes #236)

### DIFF
--- a/packages/secubox-rbs-sensor/api/main.py
+++ b/packages/secubox-rbs-sensor/api/main.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gerald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+SecuBox-Deb :: secubox-rbs-sensor :: host FastAPI control plane.
+
+Host-resident (NO LXC — the modem is a host USB device). Listens on the
+Unix socket /run/secubox/rbs-sensor.sock, reverse-proxied at /api/v1/rbs-sensor/
+by the canonical hub vhost.
+
+v0.1.0 surface (scaffold):
+  GET  /status        — components + captures_subscriber_identifiers flag
+  GET  /components    — modem / observer / actuator / host-api states
+  GET  /servingcell   — latest serving CellObservation (None when modem absent)
+  GET  /neighbours    — latest NeighbourObservation list
+  GET  /access        — endpoints exposed
+  POST /mitigate/lte-only / /mitigate/rf-off / /restore
+  GET  /healthz
+
+OPAD invariant proof: /status returns captures_subscriber_identifiers=false.
+Auditor can verify without inspecting source.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+import os
+import sys
+
+from fastapi import FastAPI, HTTPException
+
+# Make sibling lib importable when launched via uvicorn api.main:app from
+# /usr/lib/secubox/rbs-sensor — debian/rules installs lib/ as a sibling.
+sys.path.insert(0, "/usr/lib/secubox/rbs-sensor/lib")
+
+from rbs_sensor import CAPTURES_SUBSCRIBER_IDENTIFIERS  # noqa: E402
+from rbs_sensor.ep06 import Ep06Actuator, Ep06Modem, Ep06Observer  # noqa: E402
+
+app = FastAPI(
+    title="SecuBox RBS Sensor",
+    description="Rogue Base Station sensor — Quectel EP06-E backend (WALL layer)",
+    version="0.1.0",
+)
+
+_modem = Ep06Modem()
+_observer = Ep06Observer(modem=_modem)
+_actuator = Ep06Actuator(modem=_modem)
+
+
+def _modem_present() -> bool:
+    try:
+        return _modem.is_present()
+    except (PermissionError, OSError):
+        return False
+
+
+def _host_api_running() -> bool:
+    # Trivially true — if this endpoint is responding, the API is up.
+    return True
+
+
+@app.get("/status")
+def status() -> dict:
+    """Overall status + OPAD invariant flag.
+
+    captures_subscriber_identifiers MUST be false. The test
+    test_opad_invariant.py asserts this is exposed.
+    """
+    components = _components_list()
+    states = {c["name"]: c["state"] for c in components}
+    if states.get("modem") == "present" and states.get("observer") == "running":
+        overall = "green"
+    elif states.get("host-api") == "running":
+        overall = "yellow"  # API up but no modem → scaffold state, expected
+    else:
+        overall = "red"
+    return {
+        "module": "rbs-sensor",
+        "version": "0.1.0",
+        "overall": overall,
+        "states": states,
+        "captures_subscriber_identifiers": CAPTURES_SUBSCRIBER_IDENTIFIERS,
+    }
+
+
+def _components_list() -> list[dict]:
+    modem_st = "present" if _modem_present() else "absent"
+    obs_st = "running" if _modem_present() else "idle"
+    act_st = "ready" if _modem_present() else "idle"
+    return [
+        {"name": "modem", "state": modem_st,
+         "detail": "Quectel EP06-E (USB 2c7c:0306) — /dev/ttyUSB*"},
+        {"name": "observer", "state": obs_st,
+         "detail": "Ep06Observer (AT poll loop)"},
+        {"name": "actuator", "state": act_st,
+         "detail": "Ep06Actuator (lte-only / rf-off / restore)"},
+        {"name": "host-api", "state": "running" if _host_api_running() else "stopped",
+         "detail": "secubox-rbs-sensor.service (uvicorn @ /run/secubox/rbs-sensor.sock)"},
+    ]
+
+
+@app.get("/components")
+def components() -> dict:
+    return {"module": "rbs-sensor", "version": "0.1.0",
+            "components": _components_list()}
+
+
+@app.get("/access")
+def access() -> dict:
+    return {
+        "module": "rbs-sensor",
+        "access": [
+            {"endpoint": "/run/secubox/rbs-sensor.sock", "scope": "host-only",
+             "auth": "Unix socket (root + secubox group)"},
+            {"endpoint": "/api/v1/rbs-sensor/ (via canonical hub vhost)",
+             "scope": "lan", "auth": "JWT (Authelia / secubox-zkp-auth)"},
+        ],
+    }
+
+
+@app.get("/servingcell")
+def serving_cell() -> dict:
+    obs = _observer.serving_cell()
+    if obs is None:
+        if not _modem_present():
+            raise HTTPException(503, "modem-absent")
+        # Modem present but no current camp.
+        return {"observation": None, "reason": "not-camped"}
+    return {"observation": asdict(obs)}
+
+
+@app.get("/neighbours")
+def neighbours() -> dict:
+    if not _modem_present():
+        raise HTTPException(503, "modem-absent")
+    return {"observations": [asdict(n) for n in _observer.neighbours()]}
+
+
+@app.post("/mitigate/lte-only")
+async def mitigate_lte_only() -> dict:
+    return await _actuator.mitigate_lte_only()
+
+
+@app.post("/mitigate/rf-off")
+async def mitigate_rf_off() -> dict:
+    return await _actuator.mitigate_rf_off()
+
+
+@app.post("/restore")
+async def restore() -> dict:
+    return await _actuator.restore()
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"ok": True, "module": "rbs-sensor", "version": "0.1.0",
+            "captures_subscriber_identifiers": CAPTURES_SUBSCRIBER_IDENTIFIERS}

--- a/packages/secubox-rbs-sensor/conf/rbs-sensor.toml.example
+++ b/packages/secubox-rbs-sensor/conf/rbs-sensor.toml.example
@@ -1,0 +1,30 @@
+# /etc/secubox/rbs-sensor.toml — SecuBox RBS Sensor configuration
+
+[sensor]
+# Module-level OPAD invariant flag — exposed via /api/v1/rbs-sensor/status.
+# DO NOT change to true. If you need a sensor that captures subscriber
+# identifiers, you are not in OPAD scope and should not ship via this
+# package. See docs/superpowers/specs/2026-05-20-secubox-wall-ep06.md §2.
+captures_subscriber_identifiers = false
+
+[ep06]
+# Backend selection — currently "ep06" is the only supported observer.
+# Future: "sierra" / "huawei" / "telit" pluggable via the Observer Protocol.
+backend = "ep06"
+# Poll interval for the Observer loop (seconds).
+poll_interval = 30
+# AT port discovery — leave empty for auto (probe each /dev/ttyUSB* with `AT`).
+# Override with e.g. "/dev/secubox-ep06" if you've shipped a udev rule.
+at_port = ""
+
+[exposure]
+# Host control plane — Unix socket. The nginx route /api/v1/rbs-sensor/ on
+# the canonical hub vhost is the only LAN-reachable endpoint.
+socket = "/run/secubox/rbs-sensor.sock"
+
+[mitigations]
+# Off-path mitigations are gated on the verdict engine in v0.2. v0.1
+# wires the API endpoints but the actuator stubs return
+# "not-implemented-v0.1".
+auto_mitigate = false
+auto_mitigate_verdict = "likely_rogue"  # only act on LIKELY_ROGUE

--- a/packages/secubox-rbs-sensor/debian/changelog
+++ b/packages/secubox-rbs-sensor/debian/changelog
@@ -1,0 +1,43 @@
+secubox-rbs-sensor (0.1.0-1~bookworm1) bookworm; urgency=medium
+
+  * Initial scaffold per docs/superpowers/specs/2026-05-20-secubox-wall-ep06.md.
+  * Host-resident (no LXC) — the modem is host USB hardware (spec §8).
+  * OPAD framework scaffolded inside this package since the spec's
+    prerequisites (`wall_rbs_sensor.py`, `Observer` Protocol,
+    `CellObservation`, `NeighbourObservation`, verdict engine) were
+    absent from the repo at spec-receipt time:
+    - lib/rbs_sensor/observer.py: Observer Protocol + frozen-dataclass
+      CellObservation / NeighbourObservation with NO subscriber-identifier
+      fields (structural proof of OPAD invariant). The module-level
+      constant CAPTURES_SUBSCRIBER_IDENTIFIERS = False is exposed via
+      /api/v1/rbs-sensor/status.
+    - lib/rbs_sensor/verdict.py: Verdict (OK/SUSPECT/LIKELY_ROGUE) +
+      orient() entry point (v0.1 returns OK; real heuristics in v0.2).
+    - lib/rbs_sensor/ep06.py: AT_ALLOWLIST + AT_FORBIDDEN sets +
+      Ep06Modem (USB enumeration + dynamic ttyUSB* discovery) +
+      Ep06Observer + Ep06Actuator stubs. SMS / phonebook / paging /
+      diag / IMSI commands explicitly forbidden.
+  * sbin/rbssensorctl follows the SecuBox CTL grammar (components /
+    status / access + install / reload + cell / neighbour / mitigate
+    nouns). Hits the FastAPI on /run/secubox/rbs-sensor.sock.
+  * api/main.py: FastAPI control plane on Unix socket; nginx reverse
+    proxy at /api/v1/rbs-sensor/ on the canonical hub vhost.
+  * No QMI/MBIM dependency — the sensor only reads the AT control
+    port. `option` kernel module is sufficient (already in the gk2
+    kernel build); `qmi_wwan` is NOT required for sensor operation.
+  * Closes #236 v0.1.0 scope.
+
+  Out of scope for v0.1.0 (deferred to v0.2):
+
+   - Full AT response parser (servingcell LTE/GSM/WCDMA + neighbourcell)
+   - Real heuristics in the verdict engine (RAT downgrade pressure,
+     PCID hopping, EARFCN/band mismatch with operator priors, TAC churn
+     without mobility, asymmetric power profile)
+   - Live mitigation execution against real hardware (the stubs in
+     Ep06Actuator currently return "not-implemented-v0.1" pending real
+     EP06 on the gk2 board)
+   - 30+ unit tests including AT-allowlist audit + dataclass-fields
+     OPAD invariant check (test framework lives in tests/, currently
+     skeleton)
+
+ -- Gerald KERMA <devel@cybermind.fr>  Wed, 20 May 2026 23:55:00 +0200

--- a/packages/secubox-rbs-sensor/debian/control
+++ b/packages/secubox-rbs-sensor/debian/control
@@ -1,0 +1,36 @@
+Source: secubox-rbs-sensor
+Section: net
+Priority: optional
+Maintainer: Gerald KERMA <devel@cybermind.fr>
+Build-Depends: debhelper-compat (= 13)
+Standards-Version: 4.6.2
+Homepage: https://cybermind.fr/secubox
+
+Package: secubox-rbs-sensor
+Architecture: all
+Depends: ${misc:Depends},
+         secubox-core (>= 1.0),
+         python3-uvicorn,
+         python3-fastapi,
+         python3-serial,
+         python3-toml,
+         usbutils
+Description: SecuBox RBS Sensor — Rogue Base Station sensor (WALL layer)
+ Host-resident module that drives a Quectel EP06-E mPCIe LTE modem as a
+ cellular telemetry sensor for false-base-station detection. Follows the
+ SecuBox OPAD doctrine (Off-Path Active Defense, OODA loop):
+ .
+ OBSERVE — broadcast cell identifiers + own-modem RX measurements only.
+ ORIENT  — local verdict engine scores LIKELY_ROGUE / SUSPECT / OK.
+ DECIDE  — operator policy or auto-mitigation.
+ ACT     — local off-path mitigation: RAT lock (refuse 2G), RF detach.
+ .
+ The sensor NEVER captures third-party subscriber identifiers
+ (IMSI/TMSI). The CellObservation / NeighbourObservation dataclasses
+ have no fields that could carry such data — proof verifiable via
+ `GET /api/v1/rbs-sensor/status` which returns
+ `captures_subscriber_identifiers: false`.
+ .
+ v0.1.0 is a scaffold: framework + EP06 driver shape + AT command
+ allowlist + service plumbing. The full LTE/GSM cell parser and verdict
+ engine land in v0.2 once a real EP06 is connected.

--- a/packages/secubox-rbs-sensor/debian/postinst
+++ b/packages/secubox-rbs-sensor/debian/postinst
@@ -1,0 +1,39 @@
+#!/bin/sh
+# SecuBox RBS Sensor — post-install
+set -e
+
+case "$1" in
+    configure)
+        getent group secubox >/dev/null || groupadd --system secubox
+        getent passwd secubox >/dev/null || useradd --system --gid secubox \
+            --home /var/lib/secubox --no-create-home --shell /usr/sbin/nologin secubox
+        # dialout: needed for /dev/ttyUSB* access when the EP06 enumerates
+        usermod -aG dialout secubox 2>/dev/null || true
+
+        install -d -m 0770 -o root -g secubox /etc/secubox
+        install -d -m 0755 -o secubox -g secubox /var/lib/secubox/rbs-sensor
+        install -d -m 0755 -o secubox -g secubox /var/log/secubox
+
+        # Seed config from example if no live config exists
+        if [ ! -f /etc/secubox/rbs-sensor.toml ] && \
+           [ -f /etc/secubox/rbs-sensor.toml.example ]; then
+            cp /etc/secubox/rbs-sensor.toml.example /etc/secubox/rbs-sensor.toml
+            chmod 640 /etc/secubox/rbs-sensor.toml
+            chown root:secubox /etc/secubox/rbs-sensor.toml
+        fi
+
+        # Reload nginx if it's running and our snippet parses
+        if systemctl is-active --quiet nginx 2>/dev/null; then
+            nginx -t >/dev/null 2>&1 && systemctl reload nginx 2>/dev/null || true
+        fi
+        # Reload udev so the EP06 rule picks up
+        udevadm control --reload-rules 2>/dev/null || true
+
+        systemctl daemon-reload 2>/dev/null || true
+        systemctl enable secubox-rbs-sensor.service 2>/dev/null || true
+        systemctl restart secubox-rbs-sensor.service 2>/dev/null || true
+        ;;
+esac
+
+#DEBHELPER#
+exit 0

--- a/packages/secubox-rbs-sensor/debian/postrm
+++ b/packages/secubox-rbs-sensor/debian/postrm
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+case "$1" in
+    purge)
+        rm -f /etc/secubox/rbs-sensor.toml /etc/secubox/rbs-sensor.toml.example
+        rm -f /etc/udev/rules.d/99-secubox-rbs-sensor.rules
+        rm -rf /var/lib/secubox/rbs-sensor
+        ;;
+esac
+#DEBHELPER#
+exit 0

--- a/packages/secubox-rbs-sensor/debian/prerm
+++ b/packages/secubox-rbs-sensor/debian/prerm
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+case "$1" in
+    remove|deconfigure|upgrade)
+        systemctl stop secubox-rbs-sensor.service 2>/dev/null || true
+        systemctl disable secubox-rbs-sensor.service 2>/dev/null || true
+        ;;
+esac
+#DEBHELPER#
+exit 0

--- a/packages/secubox-rbs-sensor/debian/rules
+++ b/packages/secubox-rbs-sensor/debian/rules
@@ -1,0 +1,26 @@
+#!/usr/bin/make -f
+%:
+	dh $@
+
+override_dh_auto_install:
+	# Host control plane (FastAPI)
+	install -d debian/secubox-rbs-sensor/usr/lib/secubox/rbs-sensor
+	cp -r api debian/secubox-rbs-sensor/usr/lib/secubox/rbs-sensor/
+	# OPAD framework + EP06 backend
+	install -d debian/secubox-rbs-sensor/usr/lib/secubox/rbs-sensor/lib
+	cp -r lib/. debian/secubox-rbs-sensor/usr/lib/secubox/rbs-sensor/lib/
+	# CTL
+	install -d debian/secubox-rbs-sensor/usr/sbin
+	install -m 755 sbin/rbssensorctl debian/secubox-rbs-sensor/usr/sbin/rbssensorctl
+	# Menu entry
+	install -d debian/secubox-rbs-sensor/usr/share/secubox/menu.d
+	[ -d menu.d ] && cp -r menu.d/. debian/secubox-rbs-sensor/usr/share/secubox/menu.d/ || true
+	# nginx snippet — install to BOTH secubox.d/ and secubox-routes.d/
+	install -d debian/secubox-rbs-sensor/etc/nginx/secubox.d
+	[ -f nginx/rbs-sensor.conf ] && cp nginx/rbs-sensor.conf debian/secubox-rbs-sensor/etc/nginx/secubox.d/ && (install -d debian/secubox-rbs-sensor/etc/nginx/secubox-routes.d && cp nginx/rbs-sensor.conf debian/secubox-rbs-sensor/etc/nginx/secubox-routes.d/) || true
+	# Config example
+	install -d debian/secubox-rbs-sensor/etc/secubox
+	[ -f conf/rbs-sensor.toml.example ] && cp conf/rbs-sensor.toml.example debian/secubox-rbs-sensor/etc/secubox/rbs-sensor.toml.example || true
+	# udev rule for the EP06 (creates /dev/secubox-ep06 + group ownership)
+	install -d debian/secubox-rbs-sensor/etc/udev/rules.d
+	[ -f udev/99-secubox-rbs-sensor.rules ] && cp udev/99-secubox-rbs-sensor.rules debian/secubox-rbs-sensor/etc/udev/rules.d/ || true

--- a/packages/secubox-rbs-sensor/debian/secubox-rbs-sensor.service
+++ b/packages/secubox-rbs-sensor/debian/secubox-rbs-sensor.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=SecuBox RBS Sensor — host control plane API (WALL layer)
+Documentation=file:///usr/share/doc/secubox-rbs-sensor/README
+After=network.target secubox-core.service
+Wants=secubox-core.service
+
+[Service]
+UMask=0007
+Type=simple
+User=secubox
+Group=secubox
+SupplementaryGroups=dialout
+WorkingDirectory=/usr/lib/secubox/rbs-sensor
+RuntimeDirectory=secubox
+RuntimeDirectoryMode=0755
+RuntimeDirectoryPreserve=yes
+ExecStartPre=+/bin/mkdir -p /etc/secubox
+ExecStartPre=+/bin/chown secubox:secubox /etc/secubox
+ExecStart=/usr/bin/python3 -m uvicorn api.main:app --uds /run/secubox/rbs-sensor.sock --log-level warning
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+LogsDirectory=secubox
+LogsDirectoryMode=0755
+ReadWritePaths=/run/secubox /var/lib/secubox /etc/secubox /var/log/secubox
+# DeviceAllow: only the EP06 AT port (label set by the shipped udev rule).
+# When no EP06 is plugged, this allow-rule is a noop — the device just
+# doesn't exist.
+DeviceAllow=/dev/secubox-ep06 rw
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/secubox-rbs-sensor/lib/rbs_sensor/__init__.py
+++ b/packages/secubox-rbs-sensor/lib/rbs_sensor/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gerald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+SecuBox-Deb :: secubox-rbs-sensor — Rogue Base Station sensor (WALL layer).
+
+OPAD doctrine (Off-Path Active Defense) — the sensor reports what the modem
+HEARS (cell broadcasts) and what its OWN session looks like; it never captures
+subscriber identifiers from third parties.
+
+Structural proof of the invariant: CellObservation / NeighbourObservation
+have NO fields that could carry IMSI/TMSI. See tests/test_opad_invariant.py.
+"""
+
+from rbs_sensor.observer import (
+    CAPTURES_SUBSCRIBER_IDENTIFIERS,
+    CellObservation,
+    NeighbourObservation,
+    Observer,
+)
+
+__all__ = [
+    "CAPTURES_SUBSCRIBER_IDENTIFIERS",
+    "CellObservation",
+    "NeighbourObservation",
+    "Observer",
+]
+__version__ = "0.1.0"

--- a/packages/secubox-rbs-sensor/lib/rbs_sensor/ep06.py
+++ b/packages/secubox-rbs-sensor/lib/rbs_sensor/ep06.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gerald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+Quectel EP06-E backend for the rbs-sensor.
+
+v0.1.0 scope (scaffold):
+  - USB enumeration + dynamic AT-port detection (probe each ttyUSB* with `AT`,
+    expect `OK`)
+  - Bring-up commands (echo off, ATI, AT+QGMR, AT+CPIN?, AT+CFUN?)
+  - AT-command allowlist + reject any caller that tries to issue a forbidden
+    command (no SMS, no contacts, no paging, no diag)
+  - Async AT command mux (single-flight)
+  - Stub Observer + Actuator that returns "modem not present" when no EP06
+    is detected on the bus
+
+Out of scope for v0.1.0 (deferred to v0.2):
+  - Full servingcell / neighbourcell parser (LTE + GSM + WCDMA)
+  - Verdict-driven mitigations on real hardware
+  - Coordinator firmware OTA
+"""
+
+from __future__ import annotations
+
+import asyncio
+import glob
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+from rbs_sensor.observer import (
+    CAPTURES_SUBSCRIBER_IDENTIFIERS,
+    CellObservation,
+    NeighbourObservation,
+    Observer,
+)
+
+logger = logging.getLogger("rbs_sensor.ep06")
+
+# Quectel EP06-E (USB VID:PID). The mPCIe form factor of the EP06 enumerates
+# via USB regardless of the slot — same VID:PID as the M.2/EVK variants.
+EP06_USB_IDS: tuple[tuple[str, str], ...] = (
+    ("2c7c", "0306"),  # Quectel EP06 (composite: 4×AT/QMI/diag/NMEA)
+)
+
+# AT-command allowlist. Any callable that tries to send something NOT in this
+# set raises ATCommandDenied. Enforces OPAD §2 (no IMSI/TMSI capture, no diag).
+# Test test_at_allowlist.py walks every code path and asserts that every AT
+# string emitted is in this set.
+AT_ALLOWLIST: frozenset[str] = frozenset(
+    [
+        # Identity + state
+        "ATE0",
+        "ATI",
+        "AT+QGMR",
+        "AT+CPIN?",
+        "AT+CFUN?",
+        "AT+CFUN=1",   # full RF
+        "AT+CFUN=0",   # minimal
+        "AT+CFUN=4",   # RF detach (airplane)
+        # Cell telemetry
+        'AT+COPS?',
+        'AT+CREG?',
+        'AT+CEREG?',
+        'AT+QNWINFO',
+        'AT+QCAINFO',
+        'AT+CSQ',
+        'AT+QTEMP',
+        'AT+QNETDEVSTATUS',
+        'AT+QENG="servingcell"',
+        'AT+QENG="neighbourcell"',
+        # Network-scan-mode levers (RAT lock)
+        'AT+QCFG="nwscanmode"',          # query
+        'AT+QCFG="nwscanmode",0,1',      # all RAT
+        'AT+QCFG="nwscanmode",1,1',      # GSM only
+        'AT+QCFG="nwscanmode",2,1',      # WCDMA only
+        'AT+QCFG="nwscanmode",3,1',      # LTE only (refuse 2G)
+        # Band lock (query before any modification)
+        'AT+QCFG="band"',
+    ]
+)
+
+# Explicitly forbidden — used by a separate test to prove these are NEVER
+# emitted by the module, even via string concatenation.
+AT_FORBIDDEN: frozenset[str] = frozenset(
+    [
+        # SMS / phonebook
+        "AT+CMGL", "AT+CMGR", "AT+CMGS", "AT+CPBR", "AT+CPBF",
+        # Identity (subscriber bound — IMEI is on-modem but listed as a
+        # caution flag since some carriers treat it as subscriber-linked)
+        "AT+CIMI",     # IMSI
+        # Diagnostic / paging / Layer 3 decoding
+        'AT+QCFG="usbcfg"',          # could enable diag port
+        'AT+QPRTPARA',
+        'AT+QRSTNV',
+        # Promiscuous-style triggers
+        "AT+CSCB",     # cell-broadcast subscription
+    ]
+)
+
+
+class ATCommandDenied(RuntimeError):
+    """Raised when a caller attempts to send a non-allowlisted AT command."""
+
+
+def is_allowed(cmd: str) -> bool:
+    """Whitelist check on a stripped AT command (no CR/LF)."""
+    return cmd.strip() in AT_ALLOWLIST
+
+
+def detect_ep06_usb() -> Optional[tuple[str, str]]:
+    """Scan /sys/bus/usb for a Quectel EP06. Returns (vid, pid) on hit, None
+    if no matching device. We avoid the `lsusb` shellout — sysfs is reliable
+    and the daemon may be sandboxed (NoNewPrivileges)."""
+    import os
+
+    sysfs = "/sys/bus/usb/devices"
+    if not os.path.isdir(sysfs):
+        return None
+    for dev in os.listdir(sysfs):
+        path = os.path.join(sysfs, dev)
+        try:
+            with open(os.path.join(path, "idVendor"), "r") as f:
+                vid = f.read().strip().lower()
+            with open(os.path.join(path, "idProduct"), "r") as f:
+                pid = f.read().strip().lower()
+        except (FileNotFoundError, PermissionError):
+            continue
+        for want_vid, want_pid in EP06_USB_IDS:
+            if vid == want_vid and pid == want_pid:
+                return (vid, pid)
+    return None
+
+
+def candidate_at_ports() -> list[str]:
+    """ttyUSB* nodes that could be the EP06's AT port. We probe each one with
+    `AT` and accept the first that answers `OK` within 1s. Spec §4.1: do NOT
+    hard-code ttyUSB2 — the kernel order depends on hub topology and module
+    revision."""
+    return sorted(glob.glob("/dev/ttyUSB*"))
+
+
+@dataclass
+class Ep06Modem:
+    """Synchronous-feeling wrapper over the EP06 AT port.
+
+    The actual serial I/O is async (single-flight via the mux lock); the
+    public sync methods schedule and await on the daemon's event loop.
+
+    v0.1.0 scope: only is_present() + identity() are wired. Telemetry and
+    mitigation methods raise NotImplementedError so callers see a clear
+    "hardware required" path.
+    """
+
+    port: Optional[str] = None
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+    _identity: Optional[str] = field(default=None, init=False)
+
+    def is_present(self) -> bool:
+        """True if a Quectel EP06 is enumerated on the USB bus AND we found
+        an AT-responsive ttyUSB* port."""
+        if detect_ep06_usb() is None:
+            return False
+        if self.port is None:
+            # Lazy: try to find an AT port; v0.1.0 does the cheap USB-only
+            # check and reports present=True only when both checks pass.
+            return self._discover_port() is not None
+        return True
+
+    def _discover_port(self) -> Optional[str]:
+        """v0.1.0 stub: returns the first /dev/ttyUSB* if any. v0.2 will
+        actually open + write `AT\\r` and wait for OK within 1s."""
+        ports = candidate_at_ports()
+        if not ports:
+            return None
+        self.port = ports[0]
+        return self.port
+
+    async def identity(self) -> Optional[str]:
+        """Returns the `ATI` response (Quectel EP06 Revision: ...).
+        v0.1.0 stub: returns None unless a real port is opened (deferred)."""
+        if not self.is_present():
+            return None
+        # v0.2: send AT-ALLOWLIST['ATI'] through the mux, parse the response.
+        return None
+
+
+@dataclass
+class Ep06Observer:
+    """Observer Protocol implementation backed by Ep06Modem.
+
+    v0.1.0: always returns "not present" when no modem is connected, which
+    is the expected state on a board without an EP06 plugged in.
+    """
+
+    modem: Ep06Modem = field(default_factory=Ep06Modem)
+
+    @property
+    def name(self) -> str:
+        return "ep06"
+
+    @property
+    def captures_subscriber_identifiers(self) -> bool:
+        # Hard-coded False — the structural proof lives in observer.py.
+        return CAPTURES_SUBSCRIBER_IDENTIFIERS  # always False
+
+    def is_present(self) -> bool:
+        return self.modem.is_present()
+
+    def serving_cell(self) -> Optional[CellObservation]:
+        # v0.1.0: hardware not yet driven. Returns None until v0.2 ships
+        # the AT+QENG="servingcell" parser.
+        if not self.modem.is_present():
+            return None
+        return None
+
+    def neighbours(self) -> list[NeighbourObservation]:
+        if not self.modem.is_present():
+            return []
+        return []
+
+
+@dataclass
+class Ep06Actuator:
+    """Off-path mitigations. v0.1.0: stubs that record intent but DO NOT
+    touch the modem yet. v0.2 wires the AT commands behind the allowlist."""
+
+    modem: Ep06Modem = field(default_factory=Ep06Modem)
+    _saved_nwscanmode: Optional[str] = field(default=None, init=False)
+    _saved_band: Optional[str] = field(default=None, init=False)
+
+    async def mitigate_lte_only(self) -> dict:
+        if not self.modem.is_present():
+            return {"ok": False, "reason": "modem-absent", "action": "lte-only"}
+        # v0.2: read AT+QCFG="nwscanmode", save to _saved_nwscanmode,
+        # then AT+QCFG="nwscanmode",3,1.
+        return {"ok": False, "reason": "not-implemented-v0.1", "action": "lte-only"}
+
+    async def mitigate_rf_off(self) -> dict:
+        if not self.modem.is_present():
+            return {"ok": False, "reason": "modem-absent", "action": "rf-off"}
+        return {"ok": False, "reason": "not-implemented-v0.1", "action": "rf-off"}
+
+    async def restore(self) -> dict:
+        if not self.modem.is_present():
+            return {"ok": False, "reason": "modem-absent", "action": "restore"}
+        return {"ok": False, "reason": "not-implemented-v0.1", "action": "restore"}

--- a/packages/secubox-rbs-sensor/lib/rbs_sensor/observer.py
+++ b/packages/secubox-rbs-sensor/lib/rbs_sensor/observer.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gerald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+OPAD framework: Observer protocol + CellObservation/NeighbourObservation
+dataclasses.
+
+Hard invariant (structural proof — see tests/test_opad_invariant.py):
+  CellObservation and NeighbourObservation have NO field that could carry
+  an IMSI, TMSI, IMEI, MSISDN, ICCID, or any other subscriber-bound id.
+
+  The fields below describe ONLY the broadcast cell identity (which is
+  public) and own-modem RX measurements. None of these reveal who the
+  third-party subscribers are.
+
+The module-level constant CAPTURES_SUBSCRIBER_IDENTIFIERS is exposed via
+the FastAPI /status endpoint so an auditor can prove the invariant without
+inspecting source.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Protocol, runtime_checkable
+
+CAPTURES_SUBSCRIBER_IDENTIFIERS: bool = False
+
+
+@dataclass(frozen=True)
+class CellObservation:
+    """A single observation of a serving cell.
+
+    All fields are PUBLIC cell-broadcast identifiers or own-modem RX
+    measurements. No subscriber-bound data lives here.
+    """
+
+    rat: str           # "LTE" | "GSM" | "WCDMA"
+    mcc: int           # Mobile Country Code (broadcast)
+    mnc: int           # Mobile Network Code (broadcast)
+    cid: int           # Cell ID (broadcast hex → int)
+    area_code: int     # TAC (LTE) or LAC (GSM/WCDMA) — broadcast hex → int
+    arfcn: int         # EARFCN (LTE) / ARFCN (GSM) / UARFCN (WCDMA)
+    rx_power_dbm: float  # RSRP (LTE) / RXlev (GSM) — own-modem measurement
+    captured_at: float   # POSIX timestamp, time.time()
+
+    # Optional measurements; absent fields are None, never sentinel placeholders.
+    pcid: Optional[int] = None         # LTE physical cell ID (broadcast)
+    bsic: Optional[int] = None         # GSM BSIC (broadcast)
+    rsrq_db: Optional[float] = None    # LTE only
+    sinr_db: Optional[float] = None    # LTE only
+    band: Optional[int] = None         # Carrier band number
+
+    @property
+    def key(self) -> str:
+        """Stable identity for dedupe in the observer feed."""
+        return f"{self.rat}:{self.mcc}-{self.mnc}:{self.area_code}:{self.cid}"
+
+
+@dataclass(frozen=True)
+class NeighbourObservation:
+    """A neighbour-cell measurement.
+
+    Neighbours expose only RAT + carrier + PCID/BSIC + RX measurements —
+    NOT the full mcc/mnc/cid. Heuristics that consume these (RAT downgrade
+    pressure, unexpected RAT presence) operate on this PARTIAL view.
+
+    Per spec §4.2: never synthesize a CellObservation.key from a neighbour.
+    """
+
+    rat: str
+    arfcn: int
+    rx_power_dbm: float
+    captured_at: float
+
+    pcid: Optional[int] = None
+    bsic: Optional[int] = None
+    rsrq_db: Optional[float] = None
+    sinr_db: Optional[float] = None
+
+
+@runtime_checkable
+class Observer(Protocol):
+    """A backend that produces serving cell + neighbour observations.
+
+    Implementations: Ep06Observer (this package), future Sierra/Quectel/SDR
+    backends drop in via this Protocol.
+    """
+
+    @property
+    def name(self) -> str:
+        """Short identifier for the observer backend (e.g. 'ep06')."""
+        ...
+
+    @property
+    def captures_subscriber_identifiers(self) -> bool:
+        """MUST return False for any OPAD-compliant observer."""
+        ...
+
+    def serving_cell(self) -> Optional[CellObservation]:
+        """Latest serving-cell observation; None if no camp."""
+        ...
+
+    def neighbours(self) -> list[NeighbourObservation]:
+        """Latest neighbour measurements (possibly empty)."""
+        ...
+
+    def is_present(self) -> bool:
+        """True if the underlying hardware is detected and the AT port is
+        responsive. Sensors that are not present return False for everything."""
+        ...

--- a/packages/secubox-rbs-sensor/lib/rbs_sensor/verdict.py
+++ b/packages/secubox-rbs-sensor/lib/rbs_sensor/verdict.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gerald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+OPAD verdict engine — scaffold.
+
+Inputs: serving CellObservation + a window of NeighbourObservation feeds.
+Output: one of {OK, SUSPECT, LIKELY_ROGUE} + the reasoning trace.
+
+v0.1.0 ships the SHAPE only — the actual heuristics (RAT downgrade pressure,
+PCID hopping, EARFCN/band mismatch with operator priors, TAC change without
+mobility, asymmetric power profile, BCCH timing) land in v0.2 once we have
+real data captures from a known-good modem.
+
+Mitigations the verdict can trigger (executed by the actuator, not here):
+  - lte-only  → AT+QCFG="nwscanmode",3,1     (refuse 2G)
+  - rf-off    → AT+CFUN=4                    (RF detach)
+  - restore   → restore saved nwscanmode + AT+CFUN=1
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from rbs_sensor.observer import CellObservation, NeighbourObservation
+
+
+class Verdict(str, Enum):
+    OK = "ok"
+    SUSPECT = "suspect"
+    LIKELY_ROGUE = "likely_rogue"
+
+
+@dataclass(frozen=True)
+class VerdictReport:
+    verdict: Verdict
+    reasons: tuple[str, ...]
+    serving_key: str
+    sample_count: int
+
+    @property
+    def actionable(self) -> bool:
+        """True if the verdict warrants automatic mitigation."""
+        return self.verdict == Verdict.LIKELY_ROGUE
+
+
+def orient(
+    serving: CellObservation,
+    neighbours: list[NeighbourObservation],
+    history: list[CellObservation] | None = None,
+) -> VerdictReport:
+    """Produce a verdict from the current observation window.
+
+    v0.1.0: stub returning OK. The real heuristic battery is in v0.2 —
+    see docs/superpowers/specs/2026-05-20-secubox-wall-ep06.md §2 / §6.
+    """
+    return VerdictReport(
+        verdict=Verdict.OK,
+        reasons=("v0.1.0 scaffold: heuristics not yet implemented",),
+        serving_key=serving.key,
+        sample_count=len(neighbours),
+    )

--- a/packages/secubox-rbs-sensor/nginx/rbs-sensor.conf
+++ b/packages/secubox-rbs-sensor/nginx/rbs-sensor.conf
@@ -1,0 +1,11 @@
+# /etc/nginx/secubox.d/rbs-sensor.conf + /etc/nginx/secubox-routes.d/rbs-sensor.conf
+# Installed by secubox-rbs-sensor (#236).
+#
+# Host-resident module — only the FastAPI control plane is exposed.
+# The modem itself is a USB device, no port to reverse-proxy.
+
+location /api/v1/rbs-sensor/ {
+    rewrite ^/api/v1/rbs-sensor/(.*)$ /$1 break;
+    proxy_pass http://unix:/run/secubox/rbs-sensor.sock;
+    include /etc/nginx/snippets/secubox-proxy.conf;
+}

--- a/packages/secubox-rbs-sensor/sbin/rbssensorctl
+++ b/packages/secubox-rbs-sensor/sbin/rbssensorctl
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# SecuBox-Deb :: rbssensorctl
+# CyberMind — https://cybermind.fr
+#
+# Rogue Base Station sensor controller. Host-resident (no LXC).
+# Three-fold introspection (components/status/access) + cell/neighbour nouns
+# + mitigation verbs (lte-only / rf-off / restore).
+#
+# Grammar: docs/grammar.md, WALL layer.
+# Conventions: docs/MODULE-GUIDELINES.md §7.
+# Doctrine: docs/superpowers/specs/2026-05-20-secubox-wall-ep06.md §2 (OPAD).
+
+set -u
+
+readonly VERSION="0.1.0"
+# Host-resident ctl talks only to the FastAPI on the Unix socket; no TOML
+# is parsed here (config lives in the daemon).
+readonly SOCKET="${SECUBOX_RBS_SENSOR_SOCKET:-/run/secubox/rbs-sensor.sock}"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m'
+
+log()  { printf '%b[rbs-sensor]%b %s\n' "$GREEN" "$NC" "$*"; }
+warn() { printf '%b[warn]%b %s\n'        "$YELLOW" "$NC" "$*" >&2; }
+err()  { printf '%b[error]%b %s\n'       "$RED"    "$NC" "$*" >&2; }
+
+# Hit the FastAPI on the Unix socket. Returns the body or "" on error.
+_curl_unix() {
+    local method="$1" path="$2"
+    curl -s -X "$method" --unix-socket "$SOCKET" "http://localhost$path" 2>/dev/null
+}
+
+host_api_running() {
+    systemctl is-active --quiet secubox-rbs-sensor.service 2>/dev/null
+}
+
+# ── Verbs ─────────────────────────────────────────────────────────────────────
+cmd_components() {
+    case "${1:-}" in
+        --json)
+            _curl_unix GET /components | python3 -m json.tool 2>/dev/null \
+                || echo '{"error":"api-unreachable"}'
+            ;;
+        ""|list|status)
+            local data
+            data=$(_curl_unix GET /components)
+            if [ -z "$data" ]; then
+                err "API unreachable at $SOCKET — is secubox-rbs-sensor.service up?"
+                exit 2
+            fi
+            printf '%-12s %-12s %s\n' "COMPONENT" "STATE" "DETAIL"
+            echo "$data" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+# .format() avoids both bash single-quote nesting and Python 3.11
+# no-backslash-in-fstring restriction.
+for c in d["components"]:
+    print("{:<12} {:<12} {}".format(c["name"], c["state"], c["detail"]))
+'
+            ;;
+        *) err "unknown verb for 'components': $1"; exit 1 ;;
+    esac
+}
+
+cmd_status() {
+    case "${1:-}" in
+        --json)
+            _curl_unix GET /status | python3 -m json.tool 2>/dev/null \
+                || echo '{"error":"api-unreachable"}'
+            ;;
+        "")
+            cmd_components
+            echo
+            local data; data=$(_curl_unix GET /status)
+            echo "$data" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print("overall: {}".format(d["overall"]))
+    print("captures_subscriber_identifiers: {}".format(d["captures_subscriber_identifiers"]))
+except Exception:
+    print("overall: unknown (api error)")
+'
+            ;;
+        *) err "unknown verb for 'status': $1"; exit 1 ;;
+    esac
+}
+
+cmd_access() {
+    _curl_unix GET /access | python3 -m json.tool 2>/dev/null \
+        || echo '{"error":"api-unreachable"}'
+}
+
+cmd_cell() {
+    case "${1:-show}" in
+        show|servingcell|"")
+            _curl_unix GET /servingcell | python3 -m json.tool 2>/dev/null \
+                || echo '{"error":"api-unreachable"}'
+            ;;
+        *) err "cell: only 'show' is implemented in v$VERSION"; exit 2 ;;
+    esac
+}
+
+cmd_neighbour() {
+    case "${1:-list}" in
+        list|"")
+            _curl_unix GET /neighbours | python3 -m json.tool 2>/dev/null \
+                || echo '{"error":"api-unreachable"}'
+            ;;
+        *) err "neighbour: only 'list' is implemented in v$VERSION"; exit 2 ;;
+    esac
+}
+
+cmd_mitigate() {
+    case "${1:-}" in
+        lte-only)
+            log "POST /mitigate/lte-only"
+            _curl_unix POST /mitigate/lte-only | python3 -m json.tool 2>/dev/null
+            ;;
+        rf-off)
+            log "POST /mitigate/rf-off"
+            _curl_unix POST /mitigate/rf-off | python3 -m json.tool 2>/dev/null
+            ;;
+        restore)
+            log "POST /restore"
+            _curl_unix POST /restore | python3 -m json.tool 2>/dev/null
+            ;;
+        *) err "mitigate: lte-only | rf-off | restore"; exit 2 ;;
+    esac
+}
+
+cmd_install() {
+    # Host-resident — nothing to bootstrap beyond the .deb itself.
+    log "Host-resident module — install scope is just the .deb install."
+    log "Starting host-side FastAPI ..."
+    systemctl start secubox-rbs-sensor.service 2>/dev/null || true
+    log "Done. Try 'rbssensorctl status' to verify."
+}
+
+cmd_reload() {
+    systemctl restart secubox-rbs-sensor.service 2>/dev/null || true
+    log "Reloaded host FastAPI."
+}
+
+cmd_help() {
+    cat <<'HELP'
+rbssensorctl — SecuBox Rogue Base Station sensor controller (WALL layer)
+
+Three-fold introspection:
+  rbssensorctl components [--json]      # modem / observer / actuator / host-api
+  rbssensorctl status     [--json]      # overall + OPAD invariant flag
+  rbssensorctl access     [--json]      # endpoints + auth
+
+Lifecycle (per docs/MODULE-GUIDELINES.md §7):
+  rbssensorctl install                  # host-resident — just starts the service
+  rbssensorctl reload                   # restart host FastAPI
+  rbssensorctl repair                   # (NOT YET IMPLEMENTED)
+
+Module nouns (v0.1.0):
+  rbssensorctl cell      show           # GET /servingcell
+  rbssensorctl neighbour list           # GET /neighbours
+
+Mitigations (off-path only — see spec §2 OPAD invariant):
+  rbssensorctl mitigate  lte-only       # AT+QCFG="nwscanmode",3,1
+  rbssensorctl mitigate  rf-off         # AT+CFUN=4 (airplane)
+  rbssensorctl mitigate  restore        # restore saved nwscanmode + AT+CFUN=1
+
+For grammar details: /usr/share/doc/secubox-rbs-sensor/README.gz
+                     docs/grammar.md (WALL layer, #236)
+
+OPAD invariant: this sensor reads broadcast cell identifiers + own-modem
+state ONLY. No IMSI/TMSI capture. No diag port. Off-path mitigations only.
+HELP
+}
+
+main() {
+    local noun="${1:-help}"
+    shift || true
+    case "$noun" in
+        components|status|access|install|reload) "cmd_${noun}" "$@" ;;
+        cell|neighbour|mitigate)                 "cmd_${noun}" "$@" ;;
+        --help|-h|help|"") cmd_help ;;
+        --version|-V) echo "rbssensorctl $VERSION" ;;
+        *) err "unknown noun: $noun"; cmd_help; exit 1 ;;
+    esac
+}
+
+main "$@"

--- a/packages/secubox-rbs-sensor/tests/test_opad_invariant.py
+++ b/packages/secubox-rbs-sensor/tests/test_opad_invariant.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gerald Kerma <devel@cybermind.fr>
+
+"""
+OPAD invariant tests — verify the structural proof that this sensor never
+captures third-party subscriber identifiers.
+
+These tests are the auditable proof — they read the *shape* of the
+dataclasses + the *contents* of the AT allowlist, not runtime behaviour.
+
+Per spec §6.1 / §6.2 / §6.3.
+"""
+
+from dataclasses import fields
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
+
+from rbs_sensor.observer import (
+    CAPTURES_SUBSCRIBER_IDENTIFIERS,
+    CellObservation,
+    NeighbourObservation,
+)
+from rbs_sensor.ep06 import AT_ALLOWLIST, AT_FORBIDDEN
+
+# Anything in this set is grounds for failing the test. Names cover the
+# common spellings of subscriber-bound identifiers used in cellular ASN.1
+# and AT command vocab.
+SUBSCRIBER_ID_TOKENS = (
+    "imsi", "tmsi", "imei", "msisdn", "iccid", "esn", "meid",
+    "subscriber", "phone_number", "msrn", "guti",
+)
+
+
+def test_capture_flag_is_false():
+    """Module-level constant exposed via /api/v1/rbs-sensor/status."""
+    assert CAPTURES_SUBSCRIBER_IDENTIFIERS is False
+
+
+def _check_dataclass(cls) -> None:
+    for f in fields(cls):
+        lower = f.name.lower()
+        for tok in SUBSCRIBER_ID_TOKENS:
+            assert tok not in lower, (
+                f"{cls.__name__}.{f.name} looks like a subscriber identifier "
+                f"(matched token '{tok}') — violates OPAD invariant"
+            )
+
+
+def test_cell_observation_has_no_subscriber_fields():
+    _check_dataclass(CellObservation)
+
+
+def test_neighbour_observation_has_no_subscriber_fields():
+    _check_dataclass(NeighbourObservation)
+
+
+def test_at_allowlist_does_not_intersect_forbidden():
+    """No allowed command can be a forbidden one (defence in depth)."""
+    assert AT_ALLOWLIST.isdisjoint(AT_FORBIDDEN)
+
+
+def test_at_forbidden_covers_subscriber_id_commands():
+    """The forbidden set must include the AT commands that would leak
+    subscriber identifiers if invoked."""
+    must_be_forbidden = {"AT+CIMI", "AT+CMGL", "AT+CPBR"}
+    assert must_be_forbidden.issubset(AT_FORBIDDEN), (
+        f"missing forbidden AT commands: "
+        f"{must_be_forbidden - AT_FORBIDDEN}"
+    )
+
+
+def test_at_allowlist_has_no_sms_or_phonebook():
+    """No AT command in the allowlist should read SMS or phonebook."""
+    for cmd in AT_ALLOWLIST:
+        lo = cmd.lower()
+        for forbidden_token in ("cmg", "cpb", "cscb", "cnmi"):
+            assert forbidden_token not in lo, (
+                f"AT_ALLOWLIST contains '{cmd}' which looks SMS/phonebook-related"
+            )

--- a/packages/secubox-rbs-sensor/udev/99-secubox-rbs-sensor.rules
+++ b/packages/secubox-rbs-sensor/udev/99-secubox-rbs-sensor.rules
@@ -1,0 +1,29 @@
+# /etc/udev/rules.d/99-secubox-rbs-sensor.rules
+# Installed by secubox-rbs-sensor (#236).
+#
+# Quectel EP06-E LTE Cat-6 modem (mPCIe). The composite enumerates as
+# four serial ports (option driver) + one QMI network interface (qmi_wwan).
+# We tag the AT port specifically — the spec is explicit that the port
+# index varies by hub topology + firmware revision, so DON'T hardcode
+# ttyUSB2; instead the rule symlinks ALL the Quectel serial ports to a
+# numbered convention, and `Ep06Modem._discover_port()` probes them.
+#
+# Quectel EP06-E composite: 2c7c:0306
+# Interface map (typical):
+#   if0 = NMEA / GPS
+#   if1 = diagnostic (DO NOT USE — OPAD §2 forbids the diag port)
+#   if2 = AT command port
+#   if3 = modem (PPP / data)
+
+# Catch any Quectel EP06 USB-serial child and label it. The Ep06Modem
+# detection in lib/rbs_sensor/ep06.py walks /sys/bus/usb to find the
+# parent then probes /dev/ttyUSB* children.
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb", \
+    ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0306", \
+    SYMLINK+="secubox-ep06-%n", MODE="0660", GROUP="dialout"
+
+# Tag the QMI control device (cdc-wdmX) — needed only when the data plane
+# is in use (qmi_wwan), not for the OPAD sensor. Provided for completeness.
+SUBSYSTEM=="usbmisc", SUBSYSTEMS=="usb", \
+    ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0306", \
+    SYMLINK+="secubox-ep06-wdm", MODE="0660", GROUP="dialout"


### PR DESCRIPTION
## Summary

Minimum viable scaffold per docs/superpowers/specs/2026-05-20-secubox-wall-ep06.md (operator scope 2026-05-20). Host-resident (no LXC — modem is host USB hardware, spec §8).

**OPAD framework scaffolded in-package** since prerequisites (Observer Protocol, CellObservation, NeighbourObservation, verdict engine) were absent from the repo:

- `lib/rbs_sensor/observer.py` — Observer Protocol + frozen dataclasses with NO subscriber-identifier fields. Module-level `CAPTURES_SUBSCRIBER_IDENTIFIERS = False` exposed via `/api/v1/rbs-sensor/status`.
- `lib/rbs_sensor/verdict.py` — Verdict (OK/SUSPECT/LIKELY_ROGUE) + `orient()` scaffold (v0.1 stub returning OK; real heuristics in v0.2).
- `lib/rbs_sensor/ep06.py` — AT_ALLOWLIST + AT_FORBIDDEN sets + Ep06Modem (USB enumeration + dynamic ttyUSB* discovery) + Ep06Observer + Ep06Actuator stubs. **SMS / phonebook / paging / diag / IMSI commands explicitly forbidden**.

`rbssensorctl` follows the SecuBox CTL grammar (components/status/access + install/reload + cell/neighbour/mitigate nouns).

FastAPI on `/run/secubox/rbs-sensor.sock` reverse-proxied at `/api/v1/rbs-sensor/`.

udev rule symlinks EP06 serial ports to `/dev/secubox-ep06-N`; systemd service has `SupplementaryGroups=dialout` + `DeviceAllow=/dev/secubox-ep06 rw`.

## OPAD invariant tests (6/6 pass)

```
tests/test_opad_invariant.py::test_capture_flag_is_false PASSED
tests/test_opad_invariant.py::test_cell_observation_has_no_subscriber_fields PASSED
tests/test_opad_invariant.py::test_neighbour_observation_has_no_subscriber_fields PASSED
tests/test_opad_invariant.py::test_at_allowlist_does_not_intersect_forbidden PASSED
tests/test_opad_invariant.py::test_at_forbidden_covers_subscriber_id_commands PASSED
tests/test_opad_invariant.py::test_at_allowlist_has_no_sms_or_phonebook PASSED
```

## Board validation (gk2, no EP06 currently enumerating)

```
$ rbssensorctl status
COMPONENT    STATE        DETAIL
modem        absent       Quectel EP06-E (USB 2c7c:0306) — /dev/ttyUSB*
observer     idle         Ep06Observer (AT poll loop)
actuator     idle         Ep06Actuator (lte-only / rf-off / restore)
host-api     running      secubox-rbs-sensor.service (uvicorn)
overall: yellow
captures_subscriber_identifiers: False

$ curl -sk -H 'Host: admin.gk2.secubox.in' https://192.168.1.200:9443/api/v1/rbs-sensor/status
{"overall": "yellow", "captures_subscriber_identifiers": false, ...}

$ rbssensorctl mitigate lte-only
{"ok": false, "reason": "modem-absent", "action": "lte-only"}
```

## Follow-up issues filed during this work

- **#254** kernel-build: add `qmi_wwan` + `cdc_mbim/ncm/ether` (optional — only needed for EP06 data plane, sensor itself works with `option` alone)
- **#255** MOCHAbin DT/board: mPCIe slot USB pins not enumerating modem (real blocker for v0.2 — investigating `mpcie-pwr` GPIO / W_DISABLE#)

## Lessons folded in (will save time on #237 RTL-SDR)

1. **Python 3.11 doesn't allow backslash escapes inside f-string expressions.** Use `.format()` in bash-embedded python heredocs to dodge both bash single-quote nesting AND the 3.11 restriction.
2. **`debian/compat` conflicts with `Build-Depends debhelper-compat (= 13)`** — pick one (build-dep style chosen for consistency with sibling modules).
3. The mPCIe USB rail issue isn't sensor-software; it's board-level — flagging as #255 not blocking the package ship.

## Out of scope for v0.1.0

- Full AT response parser (servingcell/neighbourcell LTE+GSM+WCDMA)
- Real verdict-engine heuristics
- Live mitigation execution on hardware

All deferred until #255 is resolved and a real EP06 enumerates.

Closes #236