### PR TITLE
fix(secubox-zigbee): v2.4.1 — six SONOFF MG21 fixes + LAN-only /zigbee/ gate (ref #241)

### DIFF
--- a/packages/secubox-zigbee/debian/changelog
+++ b/packages/secubox-zigbee/debian/changelog
@@ -1,3 +1,70 @@
+secubox-zigbee (2.4.1-1~bookworm1) bookworm; urgency=medium
+
+  * Six bugs found while wiring the SONOFF Dongle Lite MG21 on the gk2
+    board; all folded into this point release. After deploy the broker
+    bridge state goes ONLINE and the z2m web UI is reachable.
+  *
+  * 1. systemd Environment=Z2M_DATA → ZIGBEE2MQTT_DATA. z2m reads the
+    latter; the v2.4.0 unit set the wrong var, so z2m silently fell
+    back to /opt/zigbee2mqtt/node_modules/zigbee2mqtt/data/ and never
+    read our configuration.yaml. discoverAdapter() received
+    adapter=undefined, path=undefined and threw "No valid USB adapter
+    found". The Z2M_* prefix is for v2.x onboarding flags (see #4 below).
+  *
+  * 2. Environment=Z2M_ONBOARD_NO_SERVER=1 added. z2m 2.x ships a
+    first-run web wizard that intercepts BEFORE adapter init when
+    settings.onboarding is unset. With a complete configuration.yaml
+    we don't need it; this env var skips it so the daemon proceeds
+    directly to the adapter.
+  *
+  * 3. SONOFF Dongle Lite MG21 udev rule. The MG21 enumerates as
+    `10c4:ea60` (CP210x USB-UART bridge) — same VID/PID as a bare
+    CP210x serial bridge. The v2.4.0 rule put `10c4:ea60` on the
+    secondary symlink `/dev/secubox-zgb-alt`. v2.4.1 adds an explicit
+    `ATTRS{product}=="SONOFF Dongle Lite MG21"` match BEFORE the
+    generic CP210x fallback, so the MG21 lands on the primary
+    `/dev/secubox-zgb` symlink.
+  *
+  * 4. /dev/serial/by-id bind-mounted into the LXC. z2m 2.x adapter
+    discovery matches by manufacturer regex against the resolved path
+    (e.g. ".*sonoff.*lite.*mg21.*"), so the configuration.yaml `port:`
+    must be the canonical /dev/serial/by-id/usb-SONOFF_*_MG21_*-if00*
+    path inside the LXC.
+  *
+  * 5. Adapter auto-detection. install-lxc.sh now lsusb-greps for the
+    SONOFF MG21 and writes `adapter: ember` + the matching by-id path
+    into configuration.yaml. Falls back to `adapter: zstack` +
+    /dev/secubox-zgb for the original CC2652P pattern.
+  *
+  * 6. z2m web UI exposed at /zigbee/ on the canonical hub vhost
+    (proxied from the LXC at 10.100.0.111:8080 with WebSocket upgrade
+    + health-banner injection). Matches the sibling pattern of
+    /yacy/, /lyrion/, /auth/.
+    .
+    SECURITY: zigbee2mqtt itself has no authentication, so the /zigbee/
+    proxy is gated to LAN-only via nginx allow/deny (127.0.0.1 + RFC1918
+    ranges; everything else gets 403). Internet visitors hitting the
+    canonical hub vhost cannot reach the z2m UI nor the upstream LXC.
+    .
+    The Authelia auth_request gate (auth_request /__sbx_auth_verify)
+    would be the better mechanism (header-based auth instead of IP
+    allowlist), but secubox-authelia v1.0.1's /verify endpoint
+    currently returns HTTP 501 — not yet implemented in that module's
+    FastAPI. The nginx config carries a commented-out auth_request
+    block ready to enable once secubox-authelia v1.0.2+ wires /verify.
+  *
+  * Board-validated on gk2:
+  *   - SONOFF Dongle Lite MG21 detected as /dev/secubox-zgb
+  *   - zigbee2mqtt bridge state = "online"
+  *   - zigbeectl status: overall: green
+  *   - Frontend HTTP 200 at http://10.100.0.111:8080/
+  *   - Migration notes 1→2 through 4→5 ran cleanly
+  *   - One pre-existing Zigbee light visible in bridge/devices
+  *
+  * Closes the "device: absent → green" gap from #241.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 21 May 2026 01:00:00 +0200
+
 secubox-zigbee (2.4.0-1~bookworm1) bookworm; urgency=medium
 
   * v2.4.0 rewrite-in-place: move zigbee2mqtt into a dedicated LXC at

--- a/packages/secubox-zigbee/lib/zigbee/install-lxc.sh
+++ b/packages/secubox-zigbee/lib/zigbee/install-lxc.sh
@@ -115,6 +115,11 @@ lxc.apparmor.profile = generated
 lxc.start.auto = 1
 lxc.start.delay = 5
 lxc.mount.entry = /dev/secubox-zgb dev/secubox-zgb none bind,create=file,optional 0 0
+# Also bind /dev/serial/by-id so z2m's adapter auto-discovery can match the
+# manufacturer regex (e.g. ".*sonoff.*lite.*mg21.*" for the SONOFF MG21).
+# Without this, the configuration.yaml port: must be the bare /dev/secubox-zgb
+# AND z2m must match by USB VID/PID alone — which v2.10+ doesn't always do.
+lxc.mount.entry = /dev/serial/by-id dev/serial/by-id none bind,create=dir,optional 0 0
 lxc.cgroup2.devices.allow = c 188:* rwm
 lxc.cgroup2.devices.allow = c 166:* rwm
 EOF
@@ -207,6 +212,15 @@ install_zigbee2mqtt_in_lxc() {
         runuser -u zigbee2mqtt -- bash -c \
             "cd /opt/zigbee2mqtt && npm install --omit=dev --no-audit --no-fund zigbee2mqtt@${Z2M_VERSION}" 2>&1 | tail -5
 
+        # NOTE: the env var z2m actually reads is ZIGBEE2MQTT_DATA — NOT Z2M_DATA.
+        # The Z2M_* prefix is reserved for v2.x onboarding-related flags
+        # (e.g. Z2M_ONBOARD_NO_SERVER). v2.4.0 set the wrong var, so z2m fell
+        # back to its module-default data dir at
+        # /opt/zigbee2mqtt/node_modules/zigbee2mqtt/data and never read our
+        # configuration.yaml. Fixed in v2.4.1.
+        #
+        # Z2M_ONBOARD_NO_SERVER=1 skips the first-run web wizard so adapter
+        # init proceeds directly when configuration.yaml is complete.
         cat > /etc/systemd/system/zigbee2mqtt.service <<UNIT
 [Unit]
 Description=zigbee2mqtt
@@ -217,7 +231,8 @@ StartLimitIntervalSec=0
 Type=simple
 User=zigbee2mqtt
 WorkingDirectory=/opt/zigbee2mqtt/node_modules/zigbee2mqtt
-Environment=Z2M_DATA=/opt/zigbee2mqtt/data
+Environment=ZIGBEE2MQTT_DATA=/opt/zigbee2mqtt/data
+Environment=Z2M_ONBOARD_NO_SERVER=1
 StandardOutput=journal
 StandardError=journal
 Restart=always
@@ -249,6 +264,25 @@ configure_zigbee2mqtt() {
     [ -f "$z2m_pw_file" ] || fail "missing $z2m_pw_file — install secubox-mqtt first and run 'mqttctl install'"
     local z2m_pw; z2m_pw=$(cat "$z2m_pw_file")
 
+    # Detect the connected adapter type by USB VID/PID. We auto-pick the
+    # adapter + port to write into configuration.yaml so the operator
+    # doesn't have to touch YAML for the common dongles. If nothing's
+    # plugged in yet, default to zstack/CC2652P (most common) and let z2m
+    # re-detect on next restart once the dongle appears.
+    local detected_adapter="zstack"
+    local detected_port="/dev/secubox-zgb"
+    # SONOFF Dongle Lite MG21 (10c4:ea60, Silicon Labs EFR32MG21)
+    if lsusb 2>/dev/null | grep -qE "10c4:ea60.*Silicon Labs|SONOFF.*MG21"; then
+        detected_adapter="ember"
+        # z2m 2.x adapter discovery matches by manufacturer regex
+        # ".*sonoff.*lite.*mg21.*" against the path — use the canonical
+        # /dev/serial/by-id symlink which contains the SONOFF descriptor.
+        local byid
+        byid=$(ls /dev/serial/by-id/usb-SONOFF_*MG21* 2>/dev/null | head -1)
+        [ -n "$byid" ] && detected_port="$byid"
+    fi
+    log "  · detected adapter: $detected_adapter ($detected_port)"
+
     local stage=/tmp/zigbee2mqtt-config.$$
     cat > "$stage" <<YAML
 # /opt/zigbee2mqtt/data/configuration.yaml
@@ -264,8 +298,8 @@ mqtt:
   password: '${z2m_pw}'
   keepalive: 60
 serial:
-  port: /dev/secubox-zgb
-  adapter: zstack
+  port: ${detected_port}
+  adapter: ${detected_adapter}
 advanced:
   network_key: GENERATE
   pan_id: GENERATE
@@ -302,7 +336,15 @@ install_udev_rule() {
     log "Installing udev rule for Zigbee dongles ..."
     cat > "$rule_file" <<'UDEV'
 # /etc/udev/rules.d/99-secubox-zigbee.rules
-# Installed by secubox-zigbee (#241)
+# Installed by secubox-zigbee (#241, updated v2.4.1 for SONOFF MG21).
+# Order matters: ATTRS{product} filter MUST come before the generic CP210x
+# rule below, otherwise the SONOFF MG21 would land as -alt and z2m's adapter
+# discovery wouldn't pick it up.
+
+# SONOFF Dongle Lite MG21 (Silicon Labs EFR32MG21 behind a CP210x bridge)
+SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", \
+    ATTRS{product}=="SONOFF Dongle Lite MG21", \
+    SYMLINK+="secubox-zgb", MODE="0660", GROUP="dialout"
 
 # Sonoff Zigbee 3.0 USB Plus (CC2652P)
 SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="55d4", \
@@ -312,7 +354,7 @@ SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="55d4", \
 SUBSYSTEM=="tty", ATTRS{idVendor}=="1cf1", ATTRS{idProduct}=="0030", \
     SYMLINK+="secubox-zgb", MODE="0660", GROUP="dialout"
 
-# Generic CP210x (alt — ConBee III, Slaesh's CC2652RB)
+# Generic CP210x without the SONOFF descriptor — secondary symlink only
 SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", \
     SYMLINK+="secubox-zgb-alt", MODE="0660", GROUP="dialout"
 UDEV

--- a/packages/secubox-zigbee/nginx/zigbee.conf
+++ b/packages/secubox-zigbee/nginx/zigbee.conf
@@ -1,12 +1,56 @@
 # /etc/nginx/secubox.d/zigbee.conf + /etc/nginx/secubox-routes.d/zigbee.conf
-# Installed by secubox-zigbee (#241).
-#
-# Host control-plane API only. The native zigbee2mqtt frontend (LXC :8080)
-# is reachable on the LAN directly — operator opts in via a separate
-# vhost or by exposing it via the IoT Hub WebUI (separate effort).
+# Installed by secubox-zigbee (#241, v2.4.1 adds the z2m frontend proxy).
 
+# Host control-plane API
 location /api/v1/zigbee/ {
     rewrite ^/api/v1/zigbee/(.*)$ /$1 break;
     proxy_pass http://unix:/run/secubox/zigbee.sock;
     include /etc/nginx/snippets/secubox-proxy.conf;
 }
+
+# Native zigbee2mqtt frontend (LXC :8080) — proxied at /zigbee/ on the
+# canonical hub vhost so it shows up inside the SecuBox WebUI without
+# needing a separate public vhost. WebSocket upgrade required for live
+# device state pushes.
+location /zigbee/ {
+    # z2m has no authentication of its own. Gate the proxy to LAN-only
+    # so internet visitors hitting the public hub vhost get 403, never
+    # reaching z2m or the LXC.
+    #
+    # NOTE: the Authelia auth_request gate would be the better mechanism
+    # (header-based auth instead of IP allowlist), but secubox-authelia
+    # v1.0.1's /verify endpoint returns 501 — not yet implemented.
+    # When secubox-authelia v1.0.2+ ships proper /verify, uncomment:
+    #   auth_request /__sbx_auth_verify;
+    #   error_page 401 = @sbx_auth_login;
+    allow 127.0.0.1;
+    allow 10.0.0.0/8;
+    allow 172.16.0.0/12;
+    allow 192.168.0.0/16;
+    deny all;
+
+    proxy_pass http://10.100.0.111:8080/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # z2m frontend uses WebSocket — must upgrade.
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+    proxy_buffering off;
+    proxy_read_timeout 86400;
+
+    # Health-banner injection (consistent with sibling iframe targets like
+    # /yacy/, /lyrion/, /auth/).
+    sub_filter_types text/html;
+    sub_filter_once on;
+    sub_filter "</body>" '<script src="/shared/health-banner.js"></script></body>';
+}
+
+# Will be re-enabled when secubox-authelia v1.0.2+ implements /verify:
+# location @sbx_auth_login {
+#     return 302 /auth/?rd=$scheme://$http_host$request_uri;
+# }


### PR DESCRIPTION
## Summary

Six bugs found wiring the SONOFF Dongle Lite MG21 on the gk2 board, plus a security gate. After deploy: bridge `{"state":"online"}`, z2m UI reachable at `https://admin.gk2.secubox.in/zigbee/` (LAN-only).

### v2.4.0 → v2.4.1 fixes

1. `Environment=Z2M_DATA=` → `ZIGBEE2MQTT_DATA=`. v2.4.0 used the wrong env var name; z2m read its module-default data dir instead of ours and `discoverAdapter()` got `adapter=undefined path=undefined` → "No valid USB adapter found".
2. `Environment=Z2M_ONBOARD_NO_SERVER=1` added. z2m 2.x ships a first-run web wizard that blocks adapter init when settings.onboarding is unset.
3. SONOFF Dongle Lite MG21 udev rule. The MG21 enumerates as `10c4:ea60` (CP210x bridge), same VID/PID as generic CP210x. Added `ATTRS{product}=="SONOFF Dongle Lite MG21"` filter BEFORE the generic fallback so MG21 lands on the primary `/dev/secubox-zgb`.
4. `/dev/serial/by-id` bind-mounted into the LXC. z2m 2.x adapter discovery matches by manufacturer regex against the resolved path.
5. Adapter auto-detection in `install-lxc.sh`. Picks `adapter: ember` + by-id path when SONOFF MG21 detected; falls back to `adapter: zstack` + `/dev/secubox-zgb` for the CC2652P pattern.
6. z2m web UI exposed at `/zigbee/` on the canonical hub vhost with WebSocket upgrade + health-banner injection.

### Security gate (new in this PR)

`/zigbee/` is LAN-only via nginx `allow 127.0.0.1; allow 10.0.0.0/8; allow 172.16.0.0/12; allow 192.168.0.0/16; deny all;`. Internet visitors get 403, LAN users get full access. z2m has no auth of its own; this is required.

Tried `auth_request /__sbx_auth_verify` first (matches the SSO bridge spec pattern), but secubox-authelia v1.0.1's `/verify` returns HTTP 501 — endpoint scaffolded but not wired. Commented-out auth_request block is left in the config ready for v1.0.2+.

## Board validation (gk2)

```
$ mosquitto_sub -t zigbee2mqtt/bridge/state -C 1
{"state":"online"}

$ zigbeectl status
device present | daemon running | bridge online | host-api running
overall: green

$ curl -sIk -H 'Host: admin.gk2.secubox.in' https://192.168.1.200:9443/zigbee/
HTTP/1.1 200 OK    # from LAN
```

Closes part of #241 (the bring-up). The auth_request follow-up tracks against secubox-authelia /verify implementation.