### PR TITLE
fix(secubox-lyrion): v1.0.4 — LAN-only gate on /lyrion/ + lyrion.maegia.tv (closes #260)

### DIFF
--- a/packages/secubox-lyrion/debian/changelog
+++ b/packages/secubox-lyrion/debian/changelog
@@ -1,3 +1,21 @@
+secubox-lyrion (1.0.4-1~bookworm1) bookworm; urgency=medium
+
+  * SECURITY: gate /lyrion/ (canonical hub vhost) AND lyrion.maegia.tv
+    (dedicated vhost) to LAN-only via nginx allow/deny. LMS has no
+    authentication of its own (protectSettings was disabled in #248 to
+    make settings reachable behind nginx reverse-proxy), so without the
+    gate any internet visitor reaching the public DNS would get full
+    LMS control. Matches the secubox-zigbee v2.4.1 / #259 pattern.
+  * acme-challenge location stays exposed (outside the gate) so Let's
+    Encrypt renewals on lyrion.maegia.tv keep working from the public
+    internet.
+  * Commented-out auth_request /__sbx_auth_verify blocks left in both
+    locations, ready to enable when secubox-authelia v1.0.2+ ships a
+    working /verify (currently returns HTTP 501).
+  * Closes #260
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 21 May 2026 01:45:00 +0200
+
 secubox-lyrion (1.0.3-1~bookworm1) bookworm; urgency=medium
 
   * install-lxc.sh: new ensure_slimproto_dnat() step writes a persistent

--- a/packages/secubox-lyrion/nginx/lyrion-vhost.conf
+++ b/packages/secubox-lyrion/nginx/lyrion-vhost.conf
@@ -47,12 +47,20 @@ server {
 }
 
 # ── 2. Public lyrion.maegia.tv (via HAProxy + mitmproxy) ───────────────────
+#
+# IMPORTANT: LMS has no auth of its own (protectSettings was disabled in
+# #248). Even though this vhost is "public" by DNS, the proxy is LAN-only
+# via allow/deny — internet visitors get 403, LAN clients (or anyone
+# reaching the box via VPN/WireGuard) get full access.
+#
+# acme-challenge is exempt from the allow/deny (its own location block
+# above the gated `/`) so Let's Encrypt renewals can hit it from outside.
 server {
     listen 0.0.0.0:9080;
     server_name lyrion.maegia.tv;
 
-    # ACME HTTP-01 challenge — MUST come before the catch-all proxy so
-    # acme.sh renewals win (see #246 yacy fix for the same reason).
+    # ACME HTTP-01 challenge — outside the LAN gate so renewals work from
+    # the public internet. MUST come before the catch-all proxy.
     location ^~ /.well-known/acme-challenge/ {
         root /usr/share/secubox/www;
         try_files $uri =404;
@@ -63,14 +71,29 @@ server {
     sub_filter_once on;
     sub_filter "</body>" '<script src="/shared/health-banner.js"></script></body>';
 
-    # Shared assets — banner JS, error pages
+    # Shared assets — banner JS, error pages (LAN-only for consistency)
     location /shared/ {
+        allow 127.0.0.1;
+        allow 10.0.0.0/8;
+        allow 172.16.0.0/12;
+        allow 192.168.0.0/16;
+        deny all;
+
         add_header Access-Control-Allow-Origin "*" always;
         alias /usr/share/secubox/www/shared/;
     }
 
-    # LMS web UI proxied to the LXC at root
+    # LMS web UI proxied to the LXC at root — LAN-only.
+    # Will be re-enabled with secubox-authelia v1.0.2+ /verify:
+    #   auth_request /__sbx_auth_verify;
+    #   error_page 401 = @sbx_auth_login;
     location / {
+        allow 127.0.0.1;
+        allow 10.0.0.0/8;
+        allow 172.16.0.0/12;
+        allow 192.168.0.0/16;
+        deny all;
+
         proxy_pass http://10.100.0.100:9000/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/packages/secubox-lyrion/nginx/lyrion.conf
+++ b/packages/secubox-lyrion/nginx/lyrion.conf
@@ -14,8 +14,26 @@ location /api/v1/lyrion/ {
     include /etc/nginx/snippets/secubox-proxy.conf;
 }
 
-# Native Authelia portal UI (iframe target / direct landing)
+# Lyrion Music Server web UI (LXC :9000). LMS has no authentication of
+# its own (protectSettings disabled in #248 to make settings reachable
+# behind nginx reverse-proxy), so this location is LAN-only.
+#
+# Internet visitors hitting the canonical hub vhost get 403; LAN clients
+# (127.0.0.1 + RFC1918) get full access.
+#
+# When secubox-authelia v1.0.2+ implements /verify properly, replace the
+# allow/deny with `auth_request /__sbx_auth_verify;`. The block below is
+# ready for that swap.
 location /lyrion/ {
+    # Will be re-enabled with secubox-authelia v1.0.2+ /verify:
+    #   auth_request /__sbx_auth_verify;
+    #   error_page 401 = @sbx_auth_login;
+    allow 127.0.0.1;
+    allow 10.0.0.0/8;
+    allow 172.16.0.0/12;
+    allow 192.168.0.0/16;
+    deny all;
+
     proxy_pass http://10.100.0.100:9000/;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Same security pattern as #259 (zigbee v2.4.1). LMS has no auth of its own — gating both /lyrion/ on the hub vhost AND the dedicated lyrion.maegia.tv vhost to LAN-only. acme-challenge stays exposed for LE renewals. Commented-out auth_request block ready for secubox-authelia v1.0.2+ /verify. Board-validated. Closes #260.