### PR TITLE
fix(zigbee+lyrion): swap LAN-only gate for Authelia auth_request (closes #264)

### DIFF
--- a/packages/secubox-lyrion/debian/changelog
+++ b/packages/secubox-lyrion/debian/changelog
@@ -1,3 +1,23 @@
+secubox-lyrion (1.0.5-1~bookworm1) bookworm; urgency=medium
+
+  * SECURITY: replace the LAN-only allow/deny on /lyrion/ + lyrion.maegia.tv
+    with proper Authelia SSO via auth_request /__sbx_auth_verify
+    (wired by secubox-authelia v1.0.2 #263).
+  * On the canonical hub vhost: /lyrion/ uses the Authelia portal at
+    /auth/ (same origin).
+  * On the dedicated lyrion.maegia.tv vhost: 401 → 302 to
+    https://auth.maegia.tv/ (Authelia session cookie scoped to
+    .maegia.tv per #239 spec, shared across subdomains).
+  * Vhost-internal /__sbx_auth_verify location added (the secubox-d
+    snippet only loads on the canonical hub; dedicated vhosts need
+    their own copy).
+  * X-Forwarded-User / X-Forwarded-Groups propagated from Authelia
+    Remote-* headers to LMS.
+  * acme-challenge stays exposed (outside the gate) for LE renewals.
+  * Closes #264 (lyrion portion).
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 21 May 2026 02:50:00 +0200
+
 secubox-lyrion (1.0.4-1~bookworm1) bookworm; urgency=medium
 
   * SECURITY: gate /lyrion/ (canonical hub vhost) AND lyrion.maegia.tv

--- a/packages/secubox-lyrion/nginx/lyrion-vhost.conf
+++ b/packages/secubox-lyrion/nginx/lyrion-vhost.conf
@@ -83,16 +83,15 @@ server {
         alias /usr/share/secubox/www/shared/;
     }
 
-    # LMS web UI proxied to the LXC at root — LAN-only.
-    # Will be re-enabled with secubox-authelia v1.0.2+ /verify:
-    #   auth_request /__sbx_auth_verify;
-    #   error_page 401 = @sbx_auth_login;
+    # LMS web UI proxied to the LXC at root. Gated by Authelia SSO via
+    # secubox-authelia v1.0.2+ /verify (#263). 401 → 302 to /auth/.
     location / {
-        allow 127.0.0.1;
-        allow 10.0.0.0/8;
-        allow 172.16.0.0/12;
-        allow 192.168.0.0/16;
-        deny all;
+        auth_request /__sbx_auth_verify;
+        error_page 401 = @sbx_auth_login;
+        auth_request_set $sbx_user   $upstream_http_remote_user;
+        auth_request_set $sbx_groups $upstream_http_remote_groups;
+        proxy_set_header X-Forwarded-User   $sbx_user;
+        proxy_set_header X-Forwarded-Groups $sbx_groups;
 
         proxy_pass http://10.100.0.100:9000/;
         proxy_set_header Host $host;
@@ -103,6 +102,25 @@ server {
         proxy_set_header Connection "";
         proxy_buffering off;
         proxy_read_timeout 300s;
+    }
+
+    # 401 → 302 to Authelia portal at auth.maegia.tv (same parent
+    # .maegia.tv → authelia_session cookie is shared across subdomains
+    # per #239 spec). Carries the original URL in `rd` so the portal
+    # returns the user to lyrion.maegia.tv after login.
+    location @sbx_auth_login {
+        return 302 https://auth.maegia.tv/?rd=$scheme://$http_host$request_uri;
+    }
+
+    # Internal auth_request target — must be reachable inside this server
+    # block. Re-included from the secubox-authelia snippet via include.
+    location = /__sbx_auth_verify {
+        internal;
+        proxy_pass http://unix:/run/secubox/authelia.sock:/verify;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header Authorization $http_authorization;
     }
 
     access_log /var/log/nginx/lyrion_access.log;

--- a/packages/secubox-lyrion/nginx/lyrion.conf
+++ b/packages/secubox-lyrion/nginx/lyrion.conf
@@ -15,24 +15,15 @@ location /api/v1/lyrion/ {
 }
 
 # Lyrion Music Server web UI (LXC :9000). LMS has no authentication of
-# its own (protectSettings disabled in #248 to make settings reachable
-# behind nginx reverse-proxy), so this location is LAN-only.
-#
-# Internet visitors hitting the canonical hub vhost get 403; LAN clients
-# (127.0.0.1 + RFC1918) get full access.
-#
-# When secubox-authelia v1.0.2+ implements /verify properly, replace the
-# allow/deny with `auth_request /__sbx_auth_verify;`. The block below is
-# ready for that swap.
+# its own (protectSettings disabled in #248). Gated by Authelia SSO via
+# secubox-authelia v1.0.2+ /verify (#263). 401 → 302 to /auth/.
 location /lyrion/ {
-    # Will be re-enabled with secubox-authelia v1.0.2+ /verify:
-    #   auth_request /__sbx_auth_verify;
-    #   error_page 401 = @sbx_auth_login;
-    allow 127.0.0.1;
-    allow 10.0.0.0/8;
-    allow 172.16.0.0/12;
-    allow 192.168.0.0/16;
-    deny all;
+    auth_request /__sbx_auth_verify;
+    error_page 401 = @sbx_auth_login;
+    auth_request_set $sbx_user   $upstream_http_remote_user;
+    auth_request_set $sbx_groups $upstream_http_remote_groups;
+    proxy_set_header X-Forwarded-User   $sbx_user;
+    proxy_set_header X-Forwarded-Groups $sbx_groups;
 
     proxy_pass http://10.100.0.100:9000/;
     proxy_set_header Host $host;

--- a/packages/secubox-zigbee/debian/changelog
+++ b/packages/secubox-zigbee/debian/changelog
@@ -1,3 +1,17 @@
+secubox-zigbee (2.4.2-1~bookworm1) bookworm; urgency=medium
+
+  * SECURITY: replace the LAN-only allow/deny on /zigbee/ with proper
+    Authelia SSO via auth_request /__sbx_auth_verify (wired by
+    secubox-authelia v1.0.2 #263). Operators can now access the z2m
+    web UI from outside the LAN after authenticating through Authelia.
+  * Captures the Authelia-validated identity (Remote-User /
+    Remote-Groups) via auth_request_set and forwards as X-Forwarded-User
+    / X-Forwarded-Groups to z2m.
+  * 401 → 302 to /auth/?rd=… (Authelia portal on the canonical hub).
+  * Closes #264 (zigbee portion).
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 21 May 2026 02:50:00 +0200
+
 secubox-zigbee (2.4.1-1~bookworm1) bookworm; urgency=medium
 
   * Six bugs found while wiring the SONOFF Dongle Lite MG21 on the gk2

--- a/packages/secubox-zigbee/nginx/zigbee.conf
+++ b/packages/secubox-zigbee/nginx/zigbee.conf
@@ -13,21 +13,21 @@ location /api/v1/zigbee/ {
 # needing a separate public vhost. WebSocket upgrade required for live
 # device state pushes.
 location /zigbee/ {
-    # z2m has no authentication of its own. Gate the proxy to LAN-only
-    # so internet visitors hitting the public hub vhost get 403, never
-    # reaching z2m or the LXC.
-    #
-    # NOTE: the Authelia auth_request gate would be the better mechanism
-    # (header-based auth instead of IP allowlist), but secubox-authelia
-    # v1.0.1's /verify endpoint returns 501 — not yet implemented.
-    # When secubox-authelia v1.0.2+ ships proper /verify, uncomment:
-    #   auth_request /__sbx_auth_verify;
-    #   error_page 401 = @sbx_auth_login;
-    allow 127.0.0.1;
-    allow 10.0.0.0/8;
-    allow 172.16.0.0/12;
-    allow 192.168.0.0/16;
-    deny all;
+    # z2m has no authentication of its own. Gate via Authelia SSO:
+    # nginx auth_request → /__sbx_auth_verify (host FastAPI, implemented
+    # in secubox-authelia v1.0.2+ #263, which reverse-proxies to the
+    # Authelia LXC's native /api/verify and returns 200 + Remote-User
+    # headers when the authelia_session cookie is valid).
+    auth_request /__sbx_auth_verify;
+    error_page 401 = @sbx_auth_login;
+
+    # Capture the Authelia-validated identity and forward to z2m.
+    # z2m doesn't use it (no native SSO), but downstream logging /
+    # auditing can.
+    auth_request_set $sbx_user   $upstream_http_remote_user;
+    auth_request_set $sbx_groups $upstream_http_remote_groups;
+    proxy_set_header X-Forwarded-User   $sbx_user;
+    proxy_set_header X-Forwarded-Groups $sbx_groups;
 
     proxy_pass http://10.100.0.111:8080/;
     proxy_set_header Host $host;
@@ -50,7 +50,8 @@ location /zigbee/ {
     sub_filter "</body>" '<script src="/shared/health-banner.js"></script></body>';
 }
 
-# Will be re-enabled when secubox-authelia v1.0.2+ implements /verify:
-# location @sbx_auth_login {
-#     return 302 /auth/?rd=$scheme://$http_host$request_uri;
-# }
+# 401 from auth_request → 302 to the Authelia portal, carrying the
+# original URL in `rd` so the user returns to /zigbee/ post-login.
+location @sbx_auth_login {
+    return 302 /auth/?rd=$scheme://$http_host$request_uri;
+}


### PR DESCRIPTION
Follow-up to #263 (secubox-authelia v1.0.2 /verify). Replaces the temporary LAN-only allow/deny on /zigbee/ and /lyrion/ with proper Authelia SSO via `auth_request /__sbx_auth_verify`. Operators can now reach these UIs from outside the LAN after Authelia login.

* secubox-zigbee → 2.4.2
* secubox-lyrion → 1.0.5

Lyrion's dedicated lyrion.maegia.tv vhost ships its own /__sbx_auth_verify location (separate server block from the hub) and redirects to https://auth.maegia.tv/ (cookie scope sharing across .maegia.tv per #239 spec).

Board-validated on gk2: both routes return HTTP 302 to /auth/ when no Authelia session.

Closes #264