### PR TITLE
fix(authelia+zigbee+lyrion): browser-flow fixes — path prefix, banner CSP, redirect scheme (closes #266)

### DIFF
--- a/packages/secubox-authelia/api/main.py
+++ b/packages/secubox-authelia/api/main.py
@@ -26,7 +26,7 @@ from typing import Any, Dict
 
 from fastapi import FastAPI, HTTPException, Header, Request, Response
 
-VERSION = "1.0.2"
+VERSION = "1.0.3"
 CTL = shutil.which("autheliactl") or "/usr/sbin/autheliactl"
 
 # Authelia LXC (provisioned by install-lxc.sh at 10.100.0.20:9091). Override
@@ -113,7 +113,10 @@ def verify(
     # Pass through Cookie + Authorization headers to Authelia. nginx already
     # stripped the request body (proxy_pass_request_body off) so we're just
     # forwarding metadata.
-    upstream = f"{AUTHELIA_URL.rstrip('/')}/api/verify"
+    # Authelia 4.39+ is path-prefixed at /auth (server.address). The verify
+    # endpoint is therefore at /auth/api/verify (both /api/verify legacy
+    # and the prefixed path respond, but prefix is the canonical one).
+    upstream = f"{AUTHELIA_URL.rstrip('/')}/auth/api/verify"
     headers = {}
     if cookie:
         headers["Cookie"] = cookie

--- a/packages/secubox-authelia/debian/changelog
+++ b/packages/secubox-authelia/debian/changelog
@@ -1,3 +1,21 @@
+secubox-authelia (1.0.3-1~bookworm1) bookworm; urgency=medium
+
+  * install-lxc.sh: set Authelia server.address path prefix /auth
+    (NO trailing slash — 4.39+ validator rejects it). Without this,
+    the React SPA's API calls 404'd → browser AxiosError ERR_BAD_REQUEST.
+  * nginx/authelia.conf: drop trailing / on proxy_pass to preserve the
+    /auth/ prefix expected by Authelia 4.39+. Remove the health-banner
+    sub_filter — Authelia's strict CSP (default-src 'self';
+    style-src 'self' 'nonce-...'; base-uri 'self') rejects the injection.
+  * nginx/authelia-vhost.conf (auth.maegia.tv): same proxy_pass /
+    banner fixes + add `location = /` → 302 to /auth/ so the portal
+    URL is consistent across canonical hub + public vhost.
+  * api/main.py: /verify now reverse-proxies to /auth/api/verify
+    (matches the path-prefixed Authelia layout).
+  * Closes #266 (authelia portion).
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 21 May 2026 03:30:00 +0200
+
 secubox-authelia (1.0.2-1~bookworm1) bookworm; urgency=medium
 
   * api/main.py: implement /verify properly. v1.0.1 returned HTTP 501

--- a/packages/secubox-authelia/lib/authelia/install-lxc.sh
+++ b/packages/secubox-authelia/lib/authelia/install-lxc.sh
@@ -239,7 +239,11 @@ PYEOF
 theme: dark
 
 server:
-  address: 'tcp://0.0.0.0:${AUTHELIA_HTTP_PORT}/'
+  # Path prefix /auth (NO trailing slash — Authelia 4.39+ rejects it).
+  # Tells Authelia the React UI lives under /auth/ on the canonical hub
+  # vhost. Without this, the SPA makes API calls to /api/state etc.
+  # which 404 because nginx only routes /auth/ → the LXC.
+  address: 'tcp://0.0.0.0:${AUTHELIA_HTTP_PORT}/auth'
 
 log:
   level: info

--- a/packages/secubox-authelia/nginx/authelia-vhost.conf
+++ b/packages/secubox-authelia/nginx/authelia-vhost.conf
@@ -24,20 +24,26 @@ server {
     listen 0.0.0.0:9080;
     server_name auth.maegia.tv;
 
-    # Health Banner injection — MANDATORY on SSO login screens (#239 spec)
-    sub_filter_types text/html;
-    sub_filter_once on;
-    sub_filter "</body>" '<script src="/shared/health-banner.js"></script></body>';
+    # Banner injection REMOVED here too: Authelia ships a strict CSP
+    # that rejects the sub_filter <script src="/shared/health-banner.js">.
 
-    # Shared assets (health-banner.js, error pages)
+    # Shared assets (banner JS, error pages)
     location /shared/ {
         add_header Access-Control-Allow-Origin "*" always;
         alias /usr/share/secubox/www/shared/;
     }
 
-    # Authelia portal UI proxied to the LXC
-    location / {
-        proxy_pass http://10.100.0.20:9091/;
+    # Redirect root → /auth/ so the SPA lives at the same path on this
+    # public vhost as on the canonical hub. Authelia is path-aware at
+    # /auth/ (server.address: tcp://0.0.0.0:9091/auth).
+    location = / {
+        return 302 https://$host/auth/;
+    }
+
+    # Authelia portal UI — proxy_pass with NO trailing slash to preserve
+    # the /auth/ prefix expected by Authelia 4.39+.
+    location /auth/ {
+        proxy_pass http://10.100.0.20:9091;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/packages/secubox-authelia/nginx/authelia.conf
+++ b/packages/secubox-authelia/nginx/authelia.conf
@@ -14,9 +14,17 @@ location /api/v1/authelia/ {
     include /etc/nginx/snippets/secubox-proxy.conf;
 }
 
-# Native Authelia portal UI (iframe target / direct landing)
+# Native Authelia portal UI. NO trailing slash on proxy_pass — Authelia
+# 4.39+ is path-aware (server.address: tcp://0.0.0.0:9091/auth), so the
+# /auth/ prefix MUST be forwarded as-is. With the trailing slash nginx
+# would strip /auth/ and Authelia would 404 its own React routes.
+#
+# Banner injection REMOVED: Authelia ships a strict CSP (default-src
+# 'self'; style-src 'self' 'nonce-...'; base-uri 'self') that rejects
+# our sub_filter <script src="/shared/health-banner.js"></script>
+# injection. Leaving the portal CSP-clean lets the React UI work.
 location /auth/ {
-    proxy_pass http://10.100.0.20:9091/;
+    proxy_pass http://10.100.0.20:9091;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -24,11 +32,6 @@ location /auth/ {
     proxy_http_version 1.1;
     proxy_set_header Connection "";
     proxy_read_timeout 300s;
-
-    # Health-banner injection on the SSO login page (per #239 spec).
-    sub_filter_types text/html;
-    sub_filter_once on;
-    sub_filter "</body>" '<script src="/shared/health-banner.js"></script></body>';
 }
 
 # nginx `auth_request` endpoint for SSO-less backends (yacy, rustdesk-web,

--- a/packages/secubox-lyrion/debian/changelog
+++ b/packages/secubox-lyrion/debian/changelog
@@ -1,3 +1,14 @@
+secubox-lyrion (1.0.6-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/lyrion.conf + nginx/lyrion-vhost.conf: fix the 401 → portal
+    redirect scheme. v1.0.5 used `$scheme://$http_host` which resolves
+    to `http://...:9080` because nginx is plain HTTP behind HAProxy.
+    Now hardcoded to `https://$http_host` matching the public-facing
+    URL.
+  * Closes #266 (lyrion portion).
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 21 May 2026 03:35:00 +0200
+
 secubox-lyrion (1.0.5-1~bookworm1) bookworm; urgency=medium
 
   * SECURITY: replace the LAN-only allow/deny on /lyrion/ + lyrion.maegia.tv

--- a/packages/secubox-zigbee/debian/changelog
+++ b/packages/secubox-zigbee/debian/changelog
@@ -1,3 +1,14 @@
+secubox-zigbee (2.4.3-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/zigbee.conf: fix the 401 → portal redirect scheme. v2.4.2
+    used `$scheme://$http_host` which resolves to `http://...:9080`
+    because nginx itself is plain HTTP (TLS terminates at HAProxy).
+    Now hardcoded to `https://$http_host` matching the public-facing
+    URL the browser actually uses.
+  * Closes #266 (zigbee portion).
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 21 May 2026 03:35:00 +0200
+
 secubox-zigbee (2.4.2-1~bookworm1) bookworm; urgency=medium
 
   * SECURITY: replace the LAN-only allow/deny on /zigbee/ with proper

--- a/packages/secubox-zigbee/nginx/zigbee.conf
+++ b/packages/secubox-zigbee/nginx/zigbee.conf
@@ -53,5 +53,5 @@ location /zigbee/ {
 # 401 from auth_request → 302 to the Authelia portal, carrying the
 # original URL in `rd` so the user returns to /zigbee/ post-login.
 location @sbx_auth_login {
-    return 302 /auth/?rd=$scheme://$http_host$request_uri;
+    return 302 https://$http_host/auth/?rd=https://$http_host$request_uri;
 }


### PR DESCRIPTION
First real browser login after #265 surfaced four issues, all fixed:

1. **Authelia path prefix /auth** (`server.address: tcp://0.0.0.0:9091/auth` — no trailing slash, 4.39+ rejects it). Without this, the React SPA's API calls 404'd → browser AxiosError.
2. **nginx proxy_pass no-trailing-slash** to preserve the /auth/ prefix.
3. **Banner sub_filter removed** from /auth/ (canonical hub + auth.maegia.tv vhost) — Authelia's strict CSP rejects script-src + style-src-elem injection.
4. **Redirect scheme** — hardcoded https://$http_host (was $scheme://$http_host:9080 because nginx is plain HTTP behind HAProxy).

Bonus: `location = /` on auth.maegia.tv → 302 to /auth/, and api/main.py /verify upstream URL updated to /auth/api/verify (the path-prefixed canonical).

* secubox-authelia → 1.0.3
* secubox-zigbee → 2.4.3
* secubox-lyrion → 1.0.6

Board-validated end-to-end. Closes #266