### PR TITLE
fix(secubox-authelia): v1.0.5 — suppress inherited server-level banner sub_filter on /auth/ (closes #270)

### DIFF
--- a/packages/secubox-authelia/debian/changelog
+++ b/packages/secubox-authelia/debian/changelog
@@ -1,3 +1,21 @@
+secubox-authelia (1.0.5-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/authelia.conf: add `sub_filter "__SBX_BANNER_OFF" "";` inside
+    the /auth/ location to suppress the inherited server-level banner
+    injection from webui.conf. Per nginx docs, sub_filter inherits
+    from the parent server block when no child-level directive exists;
+    just deleting our location-level sub_filter in v1.0.3 left the
+    server-level injection still active. Authelia's strict CSP
+    (default-src 'self'; style-src 'self' 'nonce-...'; base-uri 'self')
+    then rejected the injected script-src + caused
+    base-uri / style-src-elem violations + an AxiosError 403 because
+    the SPA's API calls couldn't fire.
+    The never-match pattern replaces the inherited sub_filter with a
+    noop → response passes through unmodified.
+  * Closes #270.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 21 May 2026 04:10:00 +0200
+
 secubox-authelia (1.0.4-1~bookworm1) bookworm; urgency=medium
 
   * nginx/authelia.conf + nginx/authelia-vhost.conf: hardcode

--- a/packages/secubox-authelia/nginx/authelia.conf
+++ b/packages/secubox-authelia/nginx/authelia.conf
@@ -16,13 +16,17 @@ location /api/v1/authelia/ {
 
 # Native Authelia portal UI. NO trailing slash on proxy_pass — Authelia
 # 4.39+ is path-aware (server.address: tcp://0.0.0.0:9091/auth), so the
-# /auth/ prefix MUST be forwarded as-is. With the trailing slash nginx
-# would strip /auth/ and Authelia would 404 its own React routes.
+# /auth/ prefix MUST be forwarded as-is.
 #
-# Banner injection REMOVED: Authelia ships a strict CSP (default-src
-# 'self'; style-src 'self' 'nonce-...'; base-uri 'self') that rejects
-# our sub_filter <script src="/shared/health-banner.js"></script>
-# injection. Leaving the portal CSP-clean lets the React UI work.
+# Banner injection MUST be suppressed here: Authelia ships a strict CSP
+# (default-src 'self'; style-src 'self' 'nonce-...'; base-uri 'self')
+# that rejects the <script src="/shared/health-banner.js"></script>
+# the canonical hub vhost (webui.conf) injects at the server level.
+#
+# Just NOT declaring sub_filter here isn't enough — per nginx docs,
+# sub_filter inherits from the parent server block unless overridden.
+# We declare a never-match sub_filter pattern inside this location to
+# replace the inherited one with a noop.
 location /auth/ {
     proxy_pass http://10.100.0.20:9091;
     proxy_set_header Host $host;
@@ -32,6 +36,11 @@ location /auth/ {
     proxy_http_version 1.1;
     proxy_set_header Connection "";
     proxy_read_timeout 300s;
+
+    # Suppress the inherited server-level banner injection — never-match
+    # pattern replaces the parent's sub_filter so the response passes
+    # through unmodified.
+    sub_filter "__SBX_BANNER_OFF" "";
 }
 
 # nginx `auth_request` endpoint for SSO-less backends (yacy, rustdesk-web,


### PR DESCRIPTION
v1.0.3 location-level removal wasn't enough — nginx inherits sub_filter from the parent server block (webui.conf) when child has no override. Add a never-match sub_filter inside /auth/ to replace the inherited banner injection with a noop. Authelia CSP now passes. Closes #270.