### PR TITLE
fix(secubox-authelia): v1.0.6 — session.cookies[] per top-level domain (closes #272)

### DIFF
--- a/packages/secubox-authelia/api/main.py
+++ b/packages/secubox-authelia/api/main.py
@@ -26,7 +26,7 @@ from typing import Any, Dict
 
 from fastapi import FastAPI, HTTPException, Header, Request, Response
 
-VERSION = "1.0.3"
+VERSION = "1.0.6"
 CTL = shutil.which("autheliactl") or "/usr/sbin/autheliactl"
 
 # Authelia LXC (provisioned by install-lxc.sh at 10.100.0.20:9091). Override

--- a/packages/secubox-authelia/debian/changelog
+++ b/packages/secubox-authelia/debian/changelog
@@ -1,3 +1,25 @@
+secubox-authelia (1.0.6-1~bookworm1) bookworm; urgency=medium
+
+  * lib/authelia/install-lxc.sh: render session.cookies[] with TWO entries
+    — one per top-level domain where the SSO portal is consumed:
+    `maegia.tv` (auth.maegia.tv) and `${SECUBOX_HUB_DOMAIN}` (default:
+    gk2.secubox.in, override via env). Without the second entry, Authelia
+    rejects /auth/api/state with 403 ERR_BAD_REQUEST when the SPA is
+    loaded on admin.gk2.secubox.in/auth/ because no cookies[].domain
+    matched the request Host. Symptom in browser: AxiosError 403 inside
+    index.Bzd5GHAP.js after the page paints.
+  * lib/authelia/install-lxc.sh: add matching access_control rules
+    for `${SECUBOX_HUB_DOMAIN}` and `*.${SECUBOX_HUB_DOMAIN}`
+    (one_factor) so nginx auth_request → /auth/api/verify resolves
+    cleanly for the canonical hub vhost and every sibling app vhost
+    (lyrion., zigbee., grafana., etc.).
+  * lib/authelia/install-lxc.sh: new readonly SECUBOX_HUB_DOMAIN env
+    knob (default gk2.secubox.in) — operators on other hubs override
+    it before running `autheliactl install`.
+  * Closes #272.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Wed, 20 May 2026 18:00:00 +0000
+
 secubox-authelia (1.0.5-1~bookworm1) bookworm; urgency=medium
 
   * nginx/authelia.conf: add `sub_filter "__SBX_BANNER_OFF" "";` inside

--- a/packages/secubox-authelia/lib/authelia/install-lxc.sh
+++ b/packages/secubox-authelia/lib/authelia/install-lxc.sh
@@ -20,6 +20,11 @@ readonly LXC_GW="${SECUBOX_LXC_GW:-10.100.0.1}"
 readonly DEBIAN_SUITE="${SECUBOX_DEBIAN_SUITE:-bookworm}"
 readonly AUTHELIA_VERSION="${SECUBOX_AUTHELIA_VERSION:-4.39.5}"
 readonly AUTHELIA_HTTP_PORT="${SECUBOX_AUTHELIA_PORT:-9091}"
+# Hub domain — the canonical SecuBox WebUI vhost where the SSO portal is
+# mounted under /auth/. Authelia REQUIRES a session.cookies[] entry per
+# top-level domain it serves, otherwise the SPA gets 403 on /auth/api/state.
+# Override via env when deploying on a non-default hub (gk2.secubox.in etc.).
+readonly SECUBOX_HUB_DOMAIN="${SECUBOX_HUB_DOMAIN:-gk2.secubox.in}"
 readonly PROVISION_DIR="${SECUBOX_PROVISION_DIR:-/usr/share/secubox/lib/authelia/provision}"
 readonly STATE_DIR="${SECUBOX_STATE_DIR:-/var/lib/secubox/authelia}"
 readonly SECRETS_DIR="${SECUBOX_SECRETS_DIR:-/etc/secubox/secrets}"
@@ -265,12 +270,25 @@ access_control:
   rules:
     - domain: "*.maegia.tv"
       policy: one_factor
+    # SecuBox hub vhost (admin.<hub>, lyrion.<hub>, zigbee.<hub>, etc.)
+    - domain: "${SECUBOX_HUB_DOMAIN}"
+      policy: one_factor
+    - domain: "*.${SECUBOX_HUB_DOMAIN}"
+      policy: one_factor
 
 session:
+  # One cookie entry per top-level domain. Authelia returns 403 on /auth/api/*
+  # if the request's Host header doesn't match any cookies[].domain — that's
+  # the symptom we saw on admin.${SECUBOX_HUB_DOMAIN} before this entry existed.
   cookies:
     - name: authelia_session
       domain: maegia.tv
       authelia_url: 'https://auth.maegia.tv/'
+      expiration: 3600
+      inactivity: 300
+    - name: authelia_session
+      domain: ${SECUBOX_HUB_DOMAIN}
+      authelia_url: 'https://admin.${SECUBOX_HUB_DOMAIN}/auth/'
       expiration: 3600
       inactivity: 300
   secret: ${jwt_secret}


### PR DESCRIPTION
## Summary

- `install-lxc.sh` now renders TWO `session.cookies[]` entries — `maegia.tv` (auth.maegia.tv) AND `${SECUBOX_HUB_DOMAIN}` (default `gk2.secubox.in`, override via env at install time).
- Matching `access_control` rules for `${SECUBOX_HUB_DOMAIN}` and `*.${SECUBOX_HUB_DOMAIN}` (one_factor) so nginx `auth_request` → `/api/verify` cleanly authorises every sibling app vhost.
- New `readonly SECUBOX_HUB_DOMAIN` env knob.

Without the second entry Authelia returned 403 on `/auth/api/state` for the SPA loaded under admin.gk2.secubox.in (no cookies[].domain match).

Closes #272.

## Test plan
- [ ] `autheliactl install` on gk2 is idempotent (re-run doesn't break running Authelia)
- [ ] `curl -sk -H "Host: admin.gk2.secubox.in" https://192.168.1.200:9443/auth/api/state` returns 200