### PR TITLE
fix(secubox-zigbee+lyrion): strip internal :9080 port from auth redirects (closes #273)

### DIFF
--- a/packages/secubox-lyrion/debian/changelog
+++ b/packages/secubox-lyrion/debian/changelog
@@ -1,3 +1,15 @@
+secubox-lyrion (1.0.7-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/lyrion-vhost.conf: replace $scheme://$http_host with
+    https://$host in the rd= target of @sbx_auth_login. $scheme is
+    "http" behind HAProxy TLS termination and $http_host may carry an
+    internal port (:9080), so the previous form let the SSO portal
+    return the user to http://...:9080/... — never a valid public URL.
+    Hardcode https + $host (hostname only).
+  * Closes #273.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Wed, 20 May 2026 18:30:00 +0000
+
 secubox-lyrion (1.0.6-1~bookworm1) bookworm; urgency=medium
 
   * nginx/lyrion.conf + nginx/lyrion-vhost.conf: fix the 401 → portal

--- a/packages/secubox-lyrion/nginx/lyrion-vhost.conf
+++ b/packages/secubox-lyrion/nginx/lyrion-vhost.conf
@@ -108,8 +108,12 @@ server {
     # .maegia.tv → authelia_session cookie is shared across subdomains
     # per #239 spec). Carries the original URL in `rd` so the portal
     # returns the user to lyrion.maegia.tv after login.
+    # Use https://$host (hostname only) for the rd= target. $scheme is "http"
+    # behind HAProxy TLS termination, and $http_host carries any port in the
+    # Host header (e.g. :9080 from a LAN-direct hit) — both would leak into
+    # the redirect URL. Public traffic is always on :443 over TLS.
     location @sbx_auth_login {
-        return 302 https://auth.maegia.tv/?rd=$scheme://$http_host$request_uri;
+        return 302 https://auth.maegia.tv/?rd=https://$host$request_uri;
     }
 
     # Internal auth_request target — must be reachable inside this server

--- a/packages/secubox-zigbee/debian/changelog
+++ b/packages/secubox-zigbee/debian/changelog
@@ -1,3 +1,15 @@
+secubox-zigbee (2.4.4-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/zigbee.conf: replace $http_host with $host in the 401 →
+    Authelia portal redirect (@sbx_auth_login). The Host header may
+    carry an internal port (e.g. :9080 from a LAN-direct request),
+    which must never appear in a public redirect URL. Symptom: browser
+    landed on https://admin.gk2.secubox.in:9080/auth/?rd=...:9080/zigbee/
+    instead of the public :443 URL. $host returns the hostname only.
+  * Closes #273.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Wed, 20 May 2026 18:30:00 +0000
+
 secubox-zigbee (2.4.3-1~bookworm1) bookworm; urgency=medium
 
   * nginx/zigbee.conf: fix the 401 → portal redirect scheme. v2.4.2

--- a/packages/secubox-zigbee/nginx/zigbee.conf
+++ b/packages/secubox-zigbee/nginx/zigbee.conf
@@ -52,6 +52,10 @@ location /zigbee/ {
 
 # 401 from auth_request → 302 to the Authelia portal, carrying the
 # original URL in `rd` so the user returns to /zigbee/ post-login.
+# Use $host (hostname only) instead of $http_host (Host header verbatim):
+# the Host header may carry an internal port (e.g. :9080 from a LAN-direct
+# request) which must never appear in a public redirect. Public traffic is
+# always TLS-terminated on :443 by HAProxy.
 location @sbx_auth_login {
-    return 302 https://$http_host/auth/?rd=https://$http_host$request_uri;
+    return 302 https://$host/auth/?rd=https://$host$request_uri;
 }


### PR DESCRIPTION
## Summary

- `secubox-zigbee` v2.4.4 — `zigbee.conf:56`: `\$http_host` → `\$host` in `@sbx_auth_login`.
- `secubox-lyrion` v1.0.7 — `lyrion-vhost.conf:112`: `\$scheme://\$http_host` → `https://\$host` in `@sbx_auth_login`.

The Host header may carry the internal `:9080` nginx port (LAN-direct, HAProxy passthrough); `\$host` returns hostname only. Public SecuBox is always TLS on :443. Symptom was browser landing on `https://admin.gk2.secubox.in:9080/auth/?rd=…:9080/zigbee/`.

Closes #273.

## Test plan
- [ ] `curl -kI https://admin.gk2.secubox.in/zigbee/` returns 302 to `https://admin.gk2.secubox.in/auth/?rd=https://admin.gk2.secubox.in/zigbee/` (no `:9080`)
- [ ] Same check for `https://lyrion.maegia.tv/`