### PR TITLE
fix(secubox-authelia): v1.0.7 — forward X-Original-URL + X-Forwarded-* to /api/verify (closes #274)

### DIFF
--- a/packages/secubox-authelia/api/main.py
+++ b/packages/secubox-authelia/api/main.py
@@ -26,7 +26,7 @@ from typing import Any, Dict
 
 from fastapi import FastAPI, HTTPException, Header, Request, Response
 
-VERSION = "1.0.6"
+VERSION = "1.0.7"
 CTL = shutil.which("autheliactl") or "/usr/sbin/autheliactl"
 
 # Authelia LXC (provisioned by install-lxc.sh at 10.100.0.20:9091). Override
@@ -122,6 +122,23 @@ def verify(
         headers["Cookie"] = cookie
     if authorization:
         headers["Authorization"] = authorization
+    # Authelia 4.39+ needs the original URL/host so it can (a) match the
+    # right session.cookies[].domain entry — multi-cookie deployments have
+    # several — and (b) apply access_control rules. nginx sets these in
+    # `location = /__sbx_auth_verify`; we forward verbatim. Without them
+    # Authelia falls back to the first cookies[] entry, doesn't find the
+    # session, returns 401 → infinite redirect loop.
+    for h in (
+        "X-Original-URL",
+        "X-Forwarded-Method",
+        "X-Forwarded-Proto",
+        "X-Forwarded-Host",
+        "X-Forwarded-Uri",
+        "X-Forwarded-For",
+    ):
+        v = request.headers.get(h)
+        if v is not None:
+            headers[h] = v
 
     req = urllib.request.Request(upstream, method="GET", headers=headers)
     try:

--- a/packages/secubox-authelia/debian/changelog
+++ b/packages/secubox-authelia/debian/changelog
@@ -1,3 +1,19 @@
+secubox-authelia (1.0.7-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/authelia.conf (`location = /__sbx_auth_verify`): forward
+    X-Original-URL + X-Forwarded-{Method,Proto,Host,Uri,For} to the
+    FastAPI /verify socket. Authelia's /api/verify needs the original
+    URL to (a) match the right session.cookies[].domain entry —
+    multi-cookie deployments have several — and (b) apply access_control
+    rules. Without these headers Authelia defaults to the first cookies[]
+    entry (maegia.tv), the gk2.secubox.in session isn't found, /verify
+    returns 401 even after successful login → infinite redirect loop.
+  * api/main.py (`/verify`): forward the same X-Original-URL +
+    X-Forwarded-* headers verbatim to the Authelia LXC upstream.
+  * Closes #274.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Wed, 20 May 2026 19:00:00 +0000
+
 secubox-authelia (1.0.6-1~bookworm1) bookworm; urgency=medium
 
   * lib/authelia/install-lxc.sh: render session.cookies[] with TWO entries

--- a/packages/secubox-authelia/nginx/authelia.conf
+++ b/packages/secubox-authelia/nginx/authelia.conf
@@ -46,6 +46,13 @@ location /auth/ {
 # nginx `auth_request` endpoint for SSO-less backends (yacy, rustdesk-web,
 # mitmproxy-web). Backends include `auth_request /__sbx_auth_verify;` in
 # their location blocks.
+#
+# Authelia's /api/verify needs the original URL/host to (a) pick the right
+# session.cookies[] entry for session lookup (Authelia is multi-cookie:
+# maegia.tv + the SecuBox hub domain) and (b) apply access_control rules.
+# Without X-Original-URL the verify call defaults to the first cookies[]
+# entry — the session created under the second domain is not found and
+# Authelia returns 401 → infinite redirect loop with /auth/?rd=…
 location = /__sbx_auth_verify {
     internal;
     proxy_pass http://unix:/run/secubox/authelia.sock:/verify;
@@ -53,4 +60,10 @@ location = /__sbx_auth_verify {
     proxy_set_header Content-Length "";
     proxy_set_header Cookie $http_cookie;
     proxy_set_header Authorization $http_authorization;
+    proxy_set_header X-Original-URL https://$host$request_uri;
+    proxy_set_header X-Forwarded-Method $request_method;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Uri $request_uri;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }


### PR DESCRIPTION
## Summary

- `nginx/authelia.conf` (`location = /__sbx_auth_verify`): now sets `X-Original-URL https://\$host\$request_uri` + `X-Forwarded-{Method,Proto,Host,Uri,For}`.
- `api/main.py` (`/verify`): forwards those headers verbatim to the Authelia LXC.

Without these headers Authelia's `/api/verify` falls back to the first `session.cookies[]` entry (`maegia.tv`), the `gk2.secubox.in` session is not found, returns 401 → **infinite redirect loop** between `/auth/?rd=…` and the protected URL after a successful login.

Builds on #272 (multi-cookie session config). Closes #274.

## Test plan
- [ ] After login on `https://admin.gk2.secubox.in/auth/`, navigating to `/zigbee/` lands on the Z2M UI (no loop)
- [ ] `journalctl -u secubox-authelia -f` shows /verify → 200 with Remote-User header