### PR TITLE
refactor(secubox-authelia+zigbee): own @sbx_auth_login in authelia.conf (closes #278)

### DIFF
--- a/packages/secubox-authelia/api/main.py
+++ b/packages/secubox-authelia/api/main.py
@@ -26,7 +26,7 @@ from typing import Any, Dict
 
 from fastapi import FastAPI, HTTPException, Header, Request, Response
 
-VERSION = "1.0.7"
+VERSION = "1.0.8"
 CTL = shutil.which("autheliactl") or "/usr/sbin/autheliactl"
 
 # Authelia LXC (provisioned by install-lxc.sh at 10.100.0.20:9091). Override

--- a/packages/secubox-authelia/debian/changelog
+++ b/packages/secubox-authelia/debian/changelog
@@ -1,3 +1,16 @@
+secubox-authelia (1.0.8-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/authelia.conf: own the `@sbx_auth_login` named location.
+    Previously defined in secubox-zigbee, meaning lyrion (and any other
+    SSO-gated app) silently broke if zigbee was uninstalled. The handler
+    logically belongs to the SSO module — moved verbatim from
+    zigbee.conf v2.4.5 (no functional change; named-location lookup
+    happens within the same canonical hub server block via
+    `include /etc/nginx/secubox.d/*`).
+  * Closes #278.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 07:30:00 +0000
+
 secubox-authelia (1.0.7-1~bookworm1) bookworm; urgency=medium
 
   * nginx/authelia.conf (`location = /__sbx_auth_verify`): forward

--- a/packages/secubox-authelia/nginx/authelia.conf
+++ b/packages/secubox-authelia/nginx/authelia.conf
@@ -67,3 +67,16 @@ location = /__sbx_auth_verify {
     proxy_set_header X-Forwarded-Uri $request_uri;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
+
+# Named location consumed by every SSO-gated backend on the canonical hub
+# vhost (zigbee, lyrion, future apps) via `error_page 401 = @sbx_auth_login;`.
+# 401 from auth_request → 302 to the Authelia portal, carrying the original
+# URL in `rd` so the user lands back where they started post-login.
+#
+# $host (hostname only) and hardcoded `https://` strip both the internal
+# :9080 port that the Host header may carry (LAN-direct hit, HAProxy
+# passthrough) and the http scheme nginx sees behind TLS termination —
+# neither must appear in a public redirect.
+location @sbx_auth_login {
+    return 302 https://$host/auth/?rd=https://$host$request_uri;
+}

--- a/packages/secubox-zigbee/debian/changelog
+++ b/packages/secubox-zigbee/debian/changelog
@@ -1,3 +1,14 @@
+secubox-zigbee (2.4.5-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/zigbee.conf: stop defining the `@sbx_auth_login` named location.
+    Ownership moved to secubox-authelia v1.0.8 (same canonical hub server
+    block, same named-location lookup — no functional change for zigbee).
+    Lets lyrion (and any other SSO-gated app) stop transitively depending
+    on secubox-zigbee being installed.
+  * Closes #278.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 07:30:00 +0000
+
 secubox-zigbee (2.4.4-1~bookworm1) bookworm; urgency=medium
 
   * nginx/zigbee.conf: replace $http_host with $host in the 401 →

--- a/packages/secubox-zigbee/nginx/zigbee.conf
+++ b/packages/secubox-zigbee/nginx/zigbee.conf
@@ -50,12 +50,7 @@ location /zigbee/ {
     sub_filter "</body>" '<script src="/shared/health-banner.js"></script></body>';
 }
 
-# 401 from auth_request → 302 to the Authelia portal, carrying the
-# original URL in `rd` so the user returns to /zigbee/ post-login.
-# Use $host (hostname only) instead of $http_host (Host header verbatim):
-# the Host header may carry an internal port (e.g. :9080 from a LAN-direct
-# request) which must never appear in a public redirect. Public traffic is
-# always TLS-terminated on :443 by HAProxy.
-location @sbx_auth_login {
-    return 302 https://$host/auth/?rd=https://$host$request_uri;
-}
+# The `@sbx_auth_login` named location used by `error_page 401 = …;` above
+# is owned by secubox-authelia (see /etc/nginx/secubox.d/authelia.conf).
+# Defining it here would make this package the unintentional provider for
+# every other SSO-gated app on the canonical hub vhost.


### PR DESCRIPTION
## Summary

Move the `@sbx_auth_login` named nginx location (handles 401 from `auth_request`) from `secubox-zigbee` to `secubox-authelia` — the natural owner since it redirects to the SSO portal.

- `secubox-authelia v1.0.8` — `nginx/authelia.conf` now defines `location @sbx_auth_login`.
- `secubox-zigbee v2.4.5` — `nginx/zigbee.conf` drops the local definition; in-source comment points to authelia.conf.

Zero functional change at runtime (same canonical hub server block via `include /etc/nginx/secubox.d/*` → same named-location lookup). Decouples lyrion (and any future SSO-gated app) from a transitive `secubox-zigbee` install.

Closes #278.

## Test plan
- [ ] `nginx -t` clean
- [ ] `curl -kI https://admin.gk2.secubox.in/zigbee/` returns 302 → /auth/?rd=… (unchanged)
- [ ] `curl -kI https://admin.gk2.secubox.in/lyrion/` returns 302 → /auth/?rd=… (still works without zigbee defining the handler)