### PR TITLE
feat(secubox-nextcloud): v1.3.0 — reverse-proxy + SSO gating + move to 10.100.0.21 (closes #280)

### DIFF
--- a/packages/secubox-nextcloud/debian/changelog
+++ b/packages/secubox-nextcloud/debian/changelog
@@ -1,3 +1,28 @@
+secubox-nextcloud (1.3.0-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/nextcloud.conf: /nextcloud/ is now a reverse-proxy to the
+    Nextcloud LXC at 10.100.0.21:80 (was an unused static-stub alias).
+    Adds Apache-friendly headers (Host, X-Forwarded-{For,Proto,Host}),
+    bumps proxy_read_timeout to 300s and disables request buffering /
+    body-size limits for large uploads (WebDAV / mobile-app sync).
+  * nginx/nextcloud.conf: SSO-gated via auth_request /__sbx_auth_verify;
+    error_page 401 = @sbx_auth_login; — handler now owned by
+    secubox-authelia v1.0.8 (#278). User identity propagated to Apache
+    via X-Forwarded-{User,Groups}.
+  * sbin/nextcloudctl: LXC config template moved from lxc.net.0.type=none
+    (host-mode) to veth + br-lxc + 10.100.0.21/24. Default IP changed
+    to 10.100.0.21 to free 10.100.0.20 for secubox-authelia (#280).
+    Operators with an existing LXC at .20 must rebind manually (see
+    issue #280 for the migration recipe) — install-lxc.sh modernization
+    follows in v1.4.0.
+  * sbin/nextcloudctl: LXC_PATH now defaults to /data/lxc (v2.11.1
+    canonical path), DATA_PATH to /data/volumes/nextcloud. New env
+    knobs: SECUBOX_LXC_PATH, SECUBOX_NEXTCLOUD_DATA, SECUBOX_LXC_NAME,
+    SECUBOX_LXC_BRIDGE, SECUBOX_LXC_IP, SECUBOX_LXC_GW.
+  * Closes #280.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 07:50:00 +0000
+
 secubox-nextcloud (1.2.0-1~bookworm1) bookworm; urgency=medium
 
   * Fix default port to 9080 (avoid CrowdSec conflict)

--- a/packages/secubox-nextcloud/nginx/nextcloud.conf
+++ b/packages/secubox-nextcloud/nginx/nextcloud.conf
@@ -1,4 +1,4 @@
-# SecuBox Nextcloud API proxy
+# SecuBox Nextcloud API proxy (host-side FastAPI control plane).
 location /api/v1/nextcloud/ {
     proxy_pass http://unix:/run/secubox/nextcloud.sock:/;
     proxy_http_version 1.1;
@@ -9,8 +9,26 @@ location /api/v1/nextcloud/ {
     proxy_read_timeout 60s;
 }
 
-# Nextcloud web frontend
+# Nextcloud web frontend — reverse-proxies to the LXC Apache at 10.100.0.21:80
+# and is SSO-gated by secubox-authelia. /__sbx_auth_verify and
+# @sbx_auth_login come from /etc/nginx/secubox.d/authelia.conf.
 location /nextcloud/ {
-    alias /usr/share/secubox/www/nextcloud/;
-    try_files $uri $uri/ /nextcloud/index.html;
+    auth_request /__sbx_auth_verify;
+    error_page 401 = @sbx_auth_login;
+
+    auth_request_set $sbx_user   $upstream_http_remote_user;
+    auth_request_set $sbx_groups $upstream_http_remote_groups;
+
+    proxy_pass http://10.100.0.21:80/;
+    proxy_http_version 1.1;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Host  $host;
+    proxy_set_header X-Forwarded-User  $sbx_user;
+    proxy_set_header X-Forwarded-Groups $sbx_groups;
+    proxy_read_timeout 300s;
+    client_max_body_size 0;            # large Nextcloud uploads
+    proxy_request_buffering off;
 }

--- a/packages/secubox-nextcloud/sbin/nextcloudctl
+++ b/packages/secubox-nextcloud/sbin/nextcloudctl
@@ -3,11 +3,16 @@
 # File sync in Debian LXC for Debian
 # Three-fold architecture: Components, Status, Access
 
-VERSION="1.2.0"
+VERSION="1.3.0"
 CONFIG_FILE="/etc/secubox/nextcloud.toml"
-LXC_PATH="/srv/lxc"
-DATA_PATH="/srv/nextcloud"
-CONTAINER="nextcloud"
+# v2.11.1 modernization: /data/lxc is the canonical LXC path on SecuBox
+# boards (matches authelia/grafana/etc). Override via SECUBOX_LXC_PATH for tests.
+LXC_PATH="${SECUBOX_LXC_PATH:-/data/lxc}"
+DATA_PATH="${SECUBOX_NEXTCLOUD_DATA:-/data/volumes/nextcloud}"
+CONTAINER="${SECUBOX_LXC_NAME:-nextcloud}"
+LXC_BRIDGE="${SECUBOX_LXC_BRIDGE:-br-lxc}"
+LXC_IP="${SECUBOX_LXC_IP:-10.100.0.21}"
+LXC_GW="${SECUBOX_LXC_GW:-10.100.0.1}"
 NC_VERSION="30.0.4"
 
 RED='\033[0;31m'
@@ -88,23 +93,31 @@ create_lxc_config() {
     cat > "$LXC_PATH/$CONTAINER/config" << EOF
 lxc.uts.name = nextcloud
 lxc.rootfs.path = dir:${LXC_PATH}/${CONTAINER}/rootfs
+lxc.include = /usr/share/lxc/config/common.conf
+lxc.apparmor.profile = generated
 
-# Host networking (no bridge required)
-lxc.net.0.type = none
+# Bridged networking on br-lxc (10.100.0.0/24). Pinned to 10.100.0.21 to
+# avoid the legacy collision with secubox-authelia at 10.100.0.20 (see #280).
+lxc.net.0.type = veth
+lxc.net.0.link = ${LXC_BRIDGE:-br-lxc}
+lxc.net.0.flags = up
+lxc.net.0.name = eth0
+lxc.net.0.ipv4.address = ${LXC_IP:-10.100.0.21}/24
+lxc.net.0.ipv4.gateway = ${LXC_GW:-10.100.0.1}
 
-lxc.mount.auto = proc:mixed sys:ro cgroup:mixed
-lxc.cap.drop = sys_module mac_admin mac_override sys_time
-lxc.autodev = 1
-lxc.tty.max = 4
-lxc.pty.max = 256
-lxc.cgroup2.memory.max = 1G
+# Unprivileged uid mapping
+lxc.idmap = u 0 100000 65536
+lxc.idmap = g 0 100000 65536
+
+lxc.cgroup2.memory.max = 2G
 lxc.init.cmd = /sbin/init
+lxc.start.auto = 1
 
-# Bind mounts for persistent data
+# Bind mounts for persistent data (host paths must be owned by mapped uid 100000)
 lxc.mount.entry = ${DATA_PATH}/data var/www/nextcloud/data none bind,create=dir 0 0
 lxc.mount.entry = ${DATA_PATH}/config var/www/nextcloud/config none bind,create=dir 0 0
 EOF
-    log "LXC config created"
+    log "LXC config created (veth on ${LXC_BRIDGE:-br-lxc}, ip ${LXC_IP:-10.100.0.21})"
 }
 
 create_install_init() {


### PR DESCRIPTION
## Summary

- `nginx/nextcloud.conf` — `/nextcloud/` is now a reverse-proxy to the Nextcloud LXC at `10.100.0.21:80` (was an unused static-stub alias). Apache-friendly headers, 300s `proxy_read_timeout`, request-buffering off, no body-size cap (WebDAV / mobile sync).
- `nginx/nextcloud.conf` — SSO-gated via `auth_request /__sbx_auth_verify` + `error_page 401 = @sbx_auth_login;` (handler owned by `secubox-authelia v1.0.8` per #278). User identity forwarded to Apache via `X-Forwarded-{User,Groups}`.
- `sbin/nextcloudctl` — LXC template moves from `lxc.net.0.type=none` (host-mode) to `veth + br-lxc + 10.100.0.21/24`. Frees `10.100.0.20` for `secubox-authelia` (was colliding). Defaults aligned with v2.11.1: `LXC_PATH=/data/lxc`, `DATA_PATH=/data/volumes/nextcloud`. Env overrides per MODULE-GUIDELINES §3.

Closes #280.

## Deploy notes

Source-side IP change does **not** move a running LXC. Operators on gk2-style boards need to manually rebind:

```bash
lxc-stop -n nextcloud
sed -i 's@10\.100\.0\.20@10.100.0.21@' /data/lxc/nextcloud/config
lxc-start -n nextcloud
nginx -t && systemctl reload nginx
```

## Test plan
- [ ] `nginx -t` clean post-deploy
- [ ] `curl -kI https://admin.gk2.secubox.in/nextcloud/` returns 302 → /auth/?rd=…/nextcloud/
- [ ] After login, /nextcloud/ proxies through to Apache (Nextcloud setup/login page)
- [ ] LXCs `authelia` (10.100.0.20) and `nextcloud` (10.100.0.21) both reachable, no IP conflict