### PR TITLE
fix(secubox-nextcloud): v1.3.1 — split SecuBox config module from public app vhost (closes #282)

### DIFF
--- a/packages/secubox-nextcloud/debian/changelog
+++ b/packages/secubox-nextcloud/debian/changelog
@@ -1,3 +1,25 @@
+secubox-nextcloud (1.3.1-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/nextcloud.conf: revert v1.3.0 over-reach — `/nextcloud/` on the
+    canonical hub vhost is the SecuBox CONFIGURATION MODULE (static UI at
+    /usr/share/secubox/www/nextcloud/ driving the /api/v1/nextcloud/
+    socket), NOT the Nextcloud app. v1.3.0 had reverse-proxied it to the
+    LXC by mistake.
+  * nginx/nextcloud-vhost.conf (new file): public Nextcloud vhost
+    `nc.gk2.secubox.in` — separate server block with reverse-proxy to the
+    LXC Apache at 10.100.0.21:80, Authelia SSO gating (auth_request +
+    error_page 401 = @sbx_auth_login), X-Original-URL forwarding (#274
+    pattern). Operator enables with `ln -s ../sites-available/nextcloud.conf
+    /etc/nginx/sites-enabled/` + DNS + HAProxy SNI + mitmproxy route +
+    ACME cert (CLAUDE.md WAF rule).
+  * debian/rules: install nginx/nextcloud.conf to both
+    /etc/nginx/secubox.d/ AND /etc/nginx/secubox-routes.d/ (matches
+    secubox-authelia convention); install nginx/nextcloud-vhost.conf to
+    /etc/nginx/sites-available/nextcloud.conf.
+  * Closes #282.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 08:10:00 +0000
+
 secubox-nextcloud (1.3.0-1~bookworm1) bookworm; urgency=medium
 
   * nginx/nextcloud.conf: /nextcloud/ is now a reverse-proxy to the

--- a/packages/secubox-nextcloud/debian/rules
+++ b/packages/secubox-nextcloud/debian/rules
@@ -12,6 +12,15 @@ override_dh_auto_install:
 	install -d debian/secubox-nextcloud/usr/sbin
 	[ -d sbin ] && install -m 755 sbin/* debian/secubox-nextcloud/usr/sbin/ || true
 
-	# Install nginx config
+	# nginx canonical-hub snippet (SecuBox config module + API). Installed to
+	# both secubox.d/ and secubox-routes.d/ (the canonical hub vhost includes
+	# both via /etc/nginx/snippets/secubox-routes.conf — same convention as
+	# secubox-authelia v1.0.5+).
 	install -d $(CURDIR)/debian/secubox-nextcloud/etc/nginx/secubox.d
 	install -m 644 nginx/nextcloud.conf $(CURDIR)/debian/secubox-nextcloud/etc/nginx/secubox.d/nextcloud.conf
+	install -d $(CURDIR)/debian/secubox-nextcloud/etc/nginx/secubox-routes.d
+	install -m 644 nginx/nextcloud.conf $(CURDIR)/debian/secubox-nextcloud/etc/nginx/secubox-routes.d/nextcloud.conf
+	# Public Nextcloud vhost (nc.gk2.secubox.in). Operator enables with
+	# ln -s ../sites-available/nextcloud.conf /etc/nginx/sites-enabled/
+	install -d $(CURDIR)/debian/secubox-nextcloud/etc/nginx/sites-available
+	install -m 644 nginx/nextcloud-vhost.conf $(CURDIR)/debian/secubox-nextcloud/etc/nginx/sites-available/nextcloud.conf

--- a/packages/secubox-nextcloud/nginx/nextcloud-vhost.conf
+++ b/packages/secubox-nextcloud/nginx/nextcloud-vhost.conf
@@ -1,0 +1,95 @@
+# /etc/nginx/sites-available/nextcloud.conf — Nextcloud public vhost
+# Installed by secubox-nextcloud (#282). Operator enables with:
+#   ln -s ../sites-available/nextcloud.conf /etc/nginx/sites-enabled/
+#   systemctl reload nginx
+#
+# Public chain: Browser → HAProxy:443 (cert) → mitmproxy WAF → nginx:9080
+#               (nc.gk2.secubox.in) → LXC Apache (10.100.0.21:80).
+# Operator wires the HAProxy SNI ACL, the mitmproxy haproxy-routes.json
+# entry, and the ACME cert separately (CLAUDE.md WAF rule).
+#
+# Nextcloud uses absolute asset paths (/core/img/…, /apps/…, /index.php/…)
+# so it MUST live at vhost root — never proxy under a subpath without an
+# elaborate sub_filter rewrite.
+
+server {
+    listen 9080;
+    listen [::]:9080;
+    server_name nc.gk2.secubox.in;
+
+    # ACME HTTP-01 challenge — outside SSO so renewals work from the
+    # public internet. MUST come before the catch-all proxy.
+    location ^~ /.well-known/acme-challenge/ {
+        root /usr/share/secubox/www;
+        try_files $uri =404;
+    }
+
+    # Health Banner injection (consistent with sibling vhosts).
+    sub_filter_types text/html;
+    sub_filter_once on;
+    sub_filter "</body>" '<script src="/shared/health-banner.js"></script></body>';
+
+    # Shared assets — banner JS, error pages (LAN-only).
+    location /shared/ {
+        allow 127.0.0.1;
+        allow 10.0.0.0/8;
+        allow 172.16.0.0/12;
+        allow 192.168.0.0/16;
+        deny all;
+
+        add_header Access-Control-Allow-Origin "*" always;
+        alias /usr/share/secubox/www/shared/;
+    }
+
+    # Nextcloud Apache proxied to the LXC at root. Gated by Authelia SSO
+    # via secubox-authelia's /verify socket. 401 → 302 to /auth/ on the
+    # canonical hub vhost (admin.gk2.secubox.in).
+    location / {
+        auth_request /__sbx_auth_verify;
+        error_page 401 = @sbx_auth_login;
+
+        auth_request_set $sbx_user   $upstream_http_remote_user;
+        auth_request_set $sbx_groups $upstream_http_remote_groups;
+
+        proxy_pass http://10.100.0.21:80/;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host  $host;
+        proxy_set_header X-Forwarded-User  $sbx_user;
+        proxy_set_header X-Forwarded-Groups $sbx_groups;
+        proxy_read_timeout 300s;
+        client_max_body_size 0;        # large Nextcloud uploads
+        proxy_request_buffering off;
+    }
+
+    # 401 → 302 to Authelia portal at admin.gk2.secubox.in/auth/. Same
+    # parent .gk2.secubox.in → authelia_session cookie is shared with
+    # the portal vhost (session.cookies[] per #272).
+    location @sbx_auth_login {
+        return 302 https://admin.gk2.secubox.in/auth/?rd=https://$host$request_uri;
+    }
+
+    # Internal auth_request target — re-declared per server-block scope.
+    # Forwards X-Original-URL + X-Forwarded-* so Authelia picks the
+    # correct session.cookies[] entry (#274 pattern).
+    location = /__sbx_auth_verify {
+        internal;
+        proxy_pass http://unix:/run/secubox/authelia.sock:/verify;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header Authorization $http_authorization;
+        proxy_set_header X-Original-URL https://$host$request_uri;
+        proxy_set_header X-Forwarded-Method $request_method;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Uri $request_uri;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    access_log /var/log/nginx/nextcloud_access.log;
+    error_log  /var/log/nginx/nextcloud_error.log;
+}

--- a/packages/secubox-nextcloud/nginx/nextcloud.conf
+++ b/packages/secubox-nextcloud/nginx/nextcloud.conf
@@ -9,26 +9,11 @@ location /api/v1/nextcloud/ {
     proxy_read_timeout 60s;
 }
 
-# Nextcloud web frontend — reverse-proxies to the LXC Apache at 10.100.0.21:80
-# and is SSO-gated by secubox-authelia. /__sbx_auth_verify and
-# @sbx_auth_login come from /etc/nginx/secubox.d/authelia.conf.
+# SecuBox configuration module for Nextcloud — start/stop the LXC, status,
+# storage config. The static UI drives /api/v1/nextcloud/ (FastAPI socket).
+# The actual Nextcloud app lives on its own vhost: nc.gk2.secubox.in
+# (see /etc/nginx/sites-available/nextcloud.conf).
 location /nextcloud/ {
-    auth_request /__sbx_auth_verify;
-    error_page 401 = @sbx_auth_login;
-
-    auth_request_set $sbx_user   $upstream_http_remote_user;
-    auth_request_set $sbx_groups $upstream_http_remote_groups;
-
-    proxy_pass http://10.100.0.21:80/;
-    proxy_http_version 1.1;
-    proxy_set_header Host              $host;
-    proxy_set_header X-Real-IP         $remote_addr;
-    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto https;
-    proxy_set_header X-Forwarded-Host  $host;
-    proxy_set_header X-Forwarded-User  $sbx_user;
-    proxy_set_header X-Forwarded-Groups $sbx_groups;
-    proxy_read_timeout 300s;
-    client_max_body_size 0;            # large Nextcloud uploads
-    proxy_request_buffering off;
+    alias /usr/share/secubox/www/nextcloud/;
+    try_files $uri $uri/ /nextcloud/index.html;
 }


### PR DESCRIPTION
## Summary

v1.3.0 over-reached: `/nextcloud/` on the canonical hub vhost is the **SecuBox configuration module** (static UI + `/api/v1/nextcloud/`), not the Nextcloud app. The Nextcloud app now lives on its own public vhost `nc.gk2.secubox.in`.

- `nginx/nextcloud.conf` — `/nextcloud/` reverted to the static alias (config UI). `/api/v1/nextcloud/` socket proxy unchanged.
- `nginx/nextcloud-vhost.conf` (new) — `nc.gk2.secubox.in` reverse-proxies to `10.100.0.21:80`. Authelia SSO via `auth_request /__sbx_auth_verify` (full X-Original-URL + X-Forwarded-* per #274 pattern, server-block scope). `@sbx_auth_login` redirects to `https://admin.gk2.secubox.in/auth/` — session.cookies on `.gk2.secubox.in` (#272) cover both vhosts.
- `debian/rules` — installs `nginx/nextcloud.conf` to BOTH `secubox.d/` AND `secubox-routes.d/` (matches secubox-authelia convention); installs `nginx/nextcloud-vhost.conf` to `sites-available/`.

Closes #282.

## Deploy follow-up (operator)
1. DNS: `nc.gk2.secubox.in` → board public IP
2. HAProxy SNI ACL `nc.gk2.secubox.in` → mitmproxy → `127.0.0.1:9080`
3. mitmproxy: add `nc.gk2.secubox.in` to `/srv/mitmproxy{,-in}/haproxy-routes.json` (per CLAUDE.md WAF rule)
4. ACME cert for `nc.gk2.secubox.in`
5. `ln -s ../sites-available/nextcloud.conf /etc/nginx/sites-enabled/` + `systemctl reload nginx`
6. Nextcloud `trusted_domains`: add `nc.gk2.secubox.in`

## Test plan
- [ ] `curl -kI https://admin.gk2.secubox.in/nextcloud/` returns 200 with the SecuBox config UI (no redirect to Authelia)
- [ ] After operator wires DNS+HAProxy+vhost-enable: `curl -kI https://nc.gk2.secubox.in/` returns 302 → /auth/?rd=…
- [ ] After login, `nc.gk2.secubox.in/` lands on Nextcloud