### PR TITLE
feat(secubox-nextcloud): v1.3.2 — ship /etc/secubox/nextcloud.toml.example (closes #284)

### DIFF
--- a/packages/secubox-nextcloud/conf/nextcloud.toml.example
+++ b/packages/secubox-nextcloud/conf/nextcloud.toml.example
@@ -1,0 +1,30 @@
+# /etc/secubox/nextcloud.toml — SecuBox Nextcloud module
+# Copy this file to /etc/secubox/nextcloud.toml and adjust as needed.
+# Both the FastAPI control plane (/api/v1/nextcloud/) and `nextcloudctl`
+# read flat (un-sectioned) keys from this file.
+#
+# Restart `secubox-nextcloud.service` after editing for changes to take
+# effect on the FastAPI side.
+
+# ── LXC ──────────────────────────────────────────────────────────────
+container_name = "nextcloud"
+# v2.11.1 canonical layout — match secubox-authelia and siblings.
+lxc_path  = "/data/lxc"
+data_path = "/data/volumes/nextcloud"
+
+# ── Public app URL ───────────────────────────────────────────────────
+# Used by /api/v1/nextcloud/connections to build WebDAV/CalDAV/CardDAV
+# URLs displayed in the SecuBox config UI.
+#
+# When ssl_enabled = true, the UI shows https://${ssl_domain}/…
+# Otherwise it shows http://localhost:${http_port}/… (dev fallback).
+ssl_enabled = true
+ssl_domain  = "nc.gk2.secubox.in"
+http_port   = 80
+
+# ── Nextcloud install knobs (used by `nextcloudctl install`) ─────────
+domain     = "nc.gk2.secubox.in"
+admin_user = "ncadmin"
+# Storage backend for Nextcloud's metadata DB. "sqlite" is the simple
+# default; switch to "mariadb" or "pgsql" for multi-user deployments.
+db_type    = "sqlite"

--- a/packages/secubox-nextcloud/debian/changelog
+++ b/packages/secubox-nextcloud/debian/changelog
@@ -1,3 +1,18 @@
+secubox-nextcloud (1.3.2-1~bookworm1) bookworm; urgency=medium
+
+  * conf/nextcloud.toml.example (new): operator-facing config template
+    documenting every key both api/main.py and nextcloudctl consume
+    (container_name, lxc_path, data_path, http_port, ssl_enabled,
+    ssl_domain, domain, admin_user, db_type). Without this file
+    operators had to read the source to find the right key names —
+    the symptom was the Connection URLs panel showing
+    http://localhost:8080 (default fallback) even with the new
+    nc.gk2.secubox.in vhost live.
+  * debian/rules: ships the file as /etc/secubox/nextcloud.toml.example.
+  * Closes #284.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 08:30:00 +0000
+
 secubox-nextcloud (1.3.1-1~bookworm1) bookworm; urgency=medium
 
   * nginx/nextcloud.conf: revert v1.3.0 over-reach — `/nextcloud/` on the

--- a/packages/secubox-nextcloud/debian/rules
+++ b/packages/secubox-nextcloud/debian/rules
@@ -24,3 +24,8 @@ override_dh_auto_install:
 	# ln -s ../sites-available/nextcloud.conf /etc/nginx/sites-enabled/
 	install -d $(CURDIR)/debian/secubox-nextcloud/etc/nginx/sites-available
 	install -m 644 nginx/nextcloud-vhost.conf $(CURDIR)/debian/secubox-nextcloud/etc/nginx/sites-available/nextcloud.conf
+
+	# Operator config example. Shipped to /etc/secubox/ so operators can
+	# `cp nextcloud.toml.example nextcloud.toml` without hunting for keys.
+	install -d $(CURDIR)/debian/secubox-nextcloud/etc/secubox
+	install -m 644 conf/nextcloud.toml.example $(CURDIR)/debian/secubox-nextcloud/etc/secubox/nextcloud.toml.example


### PR DESCRIPTION
Operator-facing config template. Without it the Connection URLs panel falls back to http://localhost:8080. Pure config addition.