### PR TITLE
refactor(secubox-lyrion+yacy): move public vhosts to *.gk2.secubox.in (closes #287)

### DIFF
--- a/packages/secubox-lyrion/debian/changelog
+++ b/packages/secubox-lyrion/debian/changelog
@@ -1,3 +1,24 @@
+secubox-lyrion (1.0.8-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/lyrion-vhost.conf: move public vhost from lyrion.maegia.tv to
+    lyrion.gk2.secubox.in. Consolidates SSO under one portal
+    (admin.gk2.secubox.in/auth/) and one cookie scope (.gk2.secubox.in)
+    instead of a separate auth.maegia.tv portal + .maegia.tv cookie.
+  * nginx/lyrion-vhost.conf: re-declare /__sbx_auth_verify with full
+    X-Original-URL + X-Forwarded-{Method,Proto,Host,Uri,For} forwarding
+    (#274 pattern) so Authelia picks the correct session.cookies[] entry.
+  * Closes #287.
+
+  Deploy-side follow-up (operator):
+   - mitmproxy haproxy-routes.json: drop lyrion.maegia.tv entry, fix
+     lyrion.gk2.secubox.in to [192.168.1.200, 9080] (was [..., 8000]).
+   - HAProxy: remove lyrion_maegia_tv vhost if any; lyrion_gk2_secubox_in
+     is already present (or routes via default_backend).
+   - Wildcard *.gk2.secubox.in.pem already covers the new vhost — no
+     new cert needed.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 08:50:00 +0000
+
 secubox-lyrion (1.0.7-1~bookworm1) bookworm; urgency=medium
 
   * nginx/lyrion-vhost.conf: replace $scheme://$http_host with

--- a/packages/secubox-lyrion/nginx/lyrion-vhost.conf
+++ b/packages/secubox-lyrion/nginx/lyrion-vhost.conf
@@ -7,7 +7,7 @@
 #   1. LAN direct (port 9000) — http://192.168.1.200:9000/ → LXC
 #      No TLS, no WAF. For internal use only.
 #   2. Public chain (port 9080) — Browser → HAProxy:443 (cert) → mitmproxy WAF
-#      → nginx:9080 (lyrion.maegia.tv) → LXC. Operator wires cert + HAProxy
+#      → nginx:9080 (lyrion.gk2.secubox.in) → LXC. Operator wires cert + HAProxy
 #      ACL + mitmproxy route separately (see #246 yacy for the recipe).
 #
 # Lyrion Music Server uses absolute paths internally (/skin/EN/..., /html/..., …)
@@ -46,18 +46,20 @@ server {
     error_log  /var/log/nginx/lyrion_lan_error.log;
 }
 
-# ── 2. Public lyrion.maegia.tv (via HAProxy + mitmproxy) ───────────────────
+# ── 2. Public lyrion.gk2.secubox.in (via HAProxy + mitmproxy) ──────────────
 #
 # IMPORTANT: LMS has no auth of its own (protectSettings was disabled in
-# #248). Even though this vhost is "public" by DNS, the proxy is LAN-only
-# via allow/deny — internet visitors get 403, LAN clients (or anyone
-# reaching the box via VPN/WireGuard) get full access.
+# #248). The Authelia SSO gate below is the only protection — internet
+# visitors hit the SecuBox login portal at admin.gk2.secubox.in/auth/.
 #
-# acme-challenge is exempt from the allow/deny (its own location block
-# above the gated `/`) so Let's Encrypt renewals can hit it from outside.
+# Cookie scope: .gk2.secubox.in (per session.cookies[] in secubox-authelia
+# v1.0.6, #272). Same cookie covers admin., nc., zigbee./nextcloud/ etc.
+#
+# acme-challenge is exempt from SSO (its own location block above the
+# gated `/`) so Let's Encrypt renewals can hit it from outside.
 server {
     listen 0.0.0.0:9080;
-    server_name lyrion.maegia.tv;
+    server_name lyrion.gk2.secubox.in;
 
     # ACME HTTP-01 challenge — outside the LAN gate so renewals work from
     # the public internet. MUST come before the catch-all proxy.
@@ -66,7 +68,7 @@ server {
         try_files $uri =404;
     }
 
-    # Health Banner injection (consistent with yacy.maegia.tv / auth.maegia.tv)
+    # Health Banner injection (consistent with sibling vhosts).
     sub_filter_types text/html;
     sub_filter_once on;
     sub_filter "</body>" '<script src="/shared/health-banner.js"></script></body>';
@@ -104,20 +106,16 @@ server {
         proxy_read_timeout 300s;
     }
 
-    # 401 → 302 to Authelia portal at auth.maegia.tv (same parent
-    # .maegia.tv → authelia_session cookie is shared across subdomains
-    # per #239 spec). Carries the original URL in `rd` so the portal
-    # returns the user to lyrion.maegia.tv after login.
-    # Use https://$host (hostname only) for the rd= target. $scheme is "http"
-    # behind HAProxy TLS termination, and $http_host carries any port in the
-    # Host header (e.g. :9080 from a LAN-direct hit) — both would leak into
-    # the redirect URL. Public traffic is always on :443 over TLS.
+    # 401 → 302 to Authelia portal at admin.gk2.secubox.in/auth/. Same
+    # parent .gk2.secubox.in → authelia_session cookie is shared with
+    # the portal vhost (session.cookies[] per #272).
     location @sbx_auth_login {
-        return 302 https://auth.maegia.tv/?rd=https://$host$request_uri;
+        return 302 https://admin.gk2.secubox.in/auth/?rd=https://$host$request_uri;
     }
 
-    # Internal auth_request target — must be reachable inside this server
-    # block. Re-included from the secubox-authelia snippet via include.
+    # Internal auth_request target — re-declared per server-block scope.
+    # Forwards X-Original-URL + X-Forwarded-* so Authelia picks the
+    # correct session.cookies[] entry (#274 pattern).
     location = /__sbx_auth_verify {
         internal;
         proxy_pass http://unix:/run/secubox/authelia.sock:/verify;
@@ -125,6 +123,12 @@ server {
         proxy_set_header Content-Length "";
         proxy_set_header Cookie $http_cookie;
         proxy_set_header Authorization $http_authorization;
+        proxy_set_header X-Original-URL https://$host$request_uri;
+        proxy_set_header X-Forwarded-Method $request_method;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Uri $request_uri;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
     access_log /var/log/nginx/lyrion_access.log;

--- a/packages/secubox-yacy/debian/changelog
+++ b/packages/secubox-yacy/debian/changelog
@@ -1,3 +1,24 @@
+secubox-yacy (1.0.10-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/yacy-vhost.conf: move public vhost from yacy.maegia.tv to
+    yacy.gk2.secubox.in. Consolidates gk2-board apps under one cookie
+    scope (.gk2.secubox.in) and one SSO portal
+    (admin.gk2.secubox.in/auth/). Same change applied to secubox-lyrion
+    in this branch (#287).
+  * debian/rules: comment updated.
+  * Closes #287.
+
+  Note: yacy-vhost.conf still doesn't carry SSO gating (auth_request).
+  Adding it is a follow-up consistent with siblings
+  (zigbee/lyrion/nextcloud).
+
+  Deploy-side follow-up (operator):
+   - mitmproxy haproxy-routes.json: drop yacy.maegia.tv entry, add
+     yacy.gk2.secubox.in -> [192.168.1.200, 9080].
+   - Wildcard *.gk2.secubox.in.pem already covers the new vhost.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 08:50:00 +0000
+
 secubox-yacy (1.0.9-1~bookworm1) bookworm; urgency=medium
 
   * install-lxc.sh: new configure_yacy_admin() step injects the generated

--- a/packages/secubox-yacy/debian/rules
+++ b/packages/secubox-yacy/debian/rules
@@ -13,7 +13,7 @@ override_dh_auto_install:
 	[ -d menu.d ] && cp -r menu.d/. debian/secubox-yacy/usr/share/secubox/menu.d/ || true
 	install -d debian/secubox-yacy/etc/nginx/secubox.d
 	[ -f nginx/yacy.conf ] && cp nginx/yacy.conf debian/secubox-yacy/etc/nginx/secubox.d/ || true && (install -d debian/secubox-yacy/etc/nginx/secubox-routes.d && cp nginx/yacy.conf debian/secubox-yacy/etc/nginx/secubox-routes.d/)
-	# Public vhost yacy.maegia.tv — shipped to sites-available (operator opts in via ln -s)
+	# Public vhost yacy.gk2.secubox.in — shipped to sites-available (operator opts in via ln -s)
 	install -d debian/secubox-yacy/etc/nginx/sites-available
 	[ -f nginx/yacy-vhost.conf ] && cp nginx/yacy-vhost.conf debian/secubox-yacy/etc/nginx/sites-available/yacy.conf || true
 	install -d debian/secubox-yacy/etc/secubox

--- a/packages/secubox-yacy/nginx/yacy-vhost.conf
+++ b/packages/secubox-yacy/nginx/yacy-vhost.conf
@@ -1,30 +1,30 @@
-# /etc/nginx/sites-available/yacy.conf — public vhost yacy.maegia.tv
+# /etc/nginx/sites-available/yacy.conf — public vhost yacy.gk2.secubox.in
 # Installed by secubox-yacy (#232, #246).
 #
 # Routing flow (validated 2026-05-20):
-#   Browser → HAProxy:443 (TLS, cert /data/haproxy/certs/yacy.maegia.tv.pem)
+#   Browser → HAProxy:443 (TLS, cert /data/haproxy/certs/yacy.gk2.secubox.in.pem)
 #          → mitmproxy WAF (LXC) — entry registered in
 #            /srv/mitmproxy/haproxy-routes.json INSIDE the mitmproxy LXC
 #          → nginx:9080 (this vhost)
 #          → YaCy LXC at 10.100.0.80:8090
 #
 # Operator-side prerequisites (NOT done by this snippet):
-#   1. DNS A record yacy.maegia.tv → public IP
-#   2. TLS cert in /data/haproxy/certs/yacy.maegia.tv.pem
-#      acme.sh --issue -d yacy.maegia.tv -w /usr/share/secubox/www --keylength ec-256
+#   1. DNS A record yacy.gk2.secubox.in → public IP
+#   2. TLS cert in /data/haproxy/certs/yacy.gk2.secubox.in.pem
+#      acme.sh --issue -d yacy.gk2.secubox.in -w /usr/share/secubox/www --keylength ec-256
 #      ↑ relies on the ^~ /.well-known/acme-challenge/ block below
-#   3. haproxyctl vhost add yacy.maegia.tv nginx_vhosts ssl
+#   3. haproxyctl vhost add yacy.gk2.secubox.in nginx_vhosts ssl
 #      ↑ CAUTION: known to drop backend defs (see #238 / v2.11.1).
 #        Prefer manual ACL injection or restore haproxy.cfg from backup.
 #   4. mitmproxy route INSIDE the LXC:
 #        lxc-attach -n mitmproxy -- python3 -c \
 #          "import json; p='/srv/mitmproxy/haproxy-routes.json'; d=json.load(open(p)); \
-#           d['yacy.maegia.tv']=['192.168.1.200',9080]; json.dump(d, open(p,'w'), indent=2, sort_keys=True)"
+#           d['yacy.gk2.secubox.in']=['192.168.1.200',9080]; json.dump(d, open(p,'w'), indent=2, sort_keys=True)"
 #        lxc-attach -n mitmproxy -- systemctl restart mitmproxy
 
 server {
     listen 0.0.0.0:9080;
-    server_name yacy.maegia.tv;
+    server_name yacy.gk2.secubox.in;
 
     # ACME HTTP-01 challenge — MUST come before any other location so
     # acme.sh renewals win against the catch-all proxy below. Without this


### PR DESCRIPTION
Consolidates gk2-board apps under one cookie scope (.gk2.secubox.in) and one SSO portal (admin.gk2.secubox.in/auth/). Wildcard cert already covers both new vhosts.

- secubox-lyrion v1.0.8: lyrion.maegia.tv → lyrion.gk2.secubox.in, /__sbx_auth_verify with #274 X-Original-URL pattern
- secubox-yacy v1.0.10: yacy.maegia.tv → yacy.gk2.secubox.in (no SSO yet, follow-up)