### PR TITLE
feat(secubox-zigbee): v2.5.0 — split SecuBox config module from public z2m vhost (closes #289)

### DIFF
--- a/packages/secubox-zigbee/debian/changelog
+++ b/packages/secubox-zigbee/debian/changelog
@@ -1,3 +1,45 @@
+secubox-zigbee (2.5.0-1~bookworm1) bookworm; urgency=medium
+
+  * Split SecuBox config module from the public z2m frontend (mirrors
+    the nextcloud split in #282).
+
+  * nginx/zigbee.conf: `/zigbee/` on the canonical hub vhost
+    (admin.gk2.secubox.in) is now a static alias to
+    /usr/share/secubox/www/zigbee/ — the SecuBox configuration UI that
+    drives /api/v1/zigbee/* (components / status / access) and links to
+    the full Zigbee Manager. Was a reverse-proxy to the LXC z2m
+    frontend in v2.4.x, which conflated the SecuBox view with the
+    upstream app.
+
+  * nginx/zigbee-vhost.conf (new): public vhost zigbee.gk2.secubox.in
+    reverse-proxies / to the z2m LXC (10.100.0.111:8080) with
+    WebSocket upgrade for live device-state pushes. Authelia SSO via
+    auth_request /__sbx_auth_verify (X-Original-URL + X-Forwarded-*
+    per #274). @sbx_auth_login redirects to
+    https://admin.gk2.secubox.in/auth/ — session.cookies on
+    .gk2.secubox.in (#272) cover this vhost.
+
+  * www/zigbee/index.html: rewrite (was a copy-paste of the Lyrion
+    stub). Now properly titled "SecuBox - Zigbee", calls
+    /api/v1/zigbee/* with the standard SecuBox auth wrapper, and
+    surfaces a prominent "Open Zigbee Manager ->" button linking to
+    https://zigbee.gk2.secubox.in/.
+
+  * debian/rules: ships nginx/zigbee-vhost.conf to
+    /etc/nginx/sites-available/zigbee.conf for operator opt-in via
+    `ln -s ../sites-available/zigbee.conf /etc/nginx/sites-enabled/`.
+
+  * Closes #289.
+
+  Deploy-side follow-up (operator):
+   - DNS zigbee.gk2.secubox.in -> board public IP.
+   - mitmproxy haproxy-routes.json (inside the mitmproxy LXC):
+       zigbee.gk2.secubox.in -> [192.168.1.200, 9080].
+   - Wildcard *.gk2.secubox.in.pem already covers the new vhost.
+   - `ln -s` + `systemctl reload nginx`.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 09:00:00 +0000
+
 secubox-zigbee (2.4.5-1~bookworm1) bookworm; urgency=medium
 
   * nginx/zigbee.conf: stop defining the `@sbx_auth_login` named location.

--- a/packages/secubox-zigbee/debian/rules
+++ b/packages/secubox-zigbee/debian/rules
@@ -15,9 +15,14 @@ override_dh_auto_install:
 	# Menu entry
 	install -d debian/secubox-zigbee/usr/share/secubox/menu.d
 	[ -d menu.d ] && cp -r menu.d/. debian/secubox-zigbee/usr/share/secubox/menu.d/ || true
-	# nginx snippet — install to BOTH secubox.d/ and secubox-routes.d/ (per v2.11.1 lesson)
+	# nginx canonical-hub snippet (SecuBox config module + API). Installed to
+	# both secubox.d/ and secubox-routes.d/ (per v2.11.1 lesson).
 	install -d debian/secubox-zigbee/etc/nginx/secubox.d
 	[ -f nginx/zigbee.conf ] && cp nginx/zigbee.conf debian/secubox-zigbee/etc/nginx/secubox.d/ && (install -d debian/secubox-zigbee/etc/nginx/secubox-routes.d && cp nginx/zigbee.conf debian/secubox-zigbee/etc/nginx/secubox-routes.d/) || true
+	# Public Zigbee Manager vhost (zigbee.gk2.secubox.in). Operator enables
+	# with ln -s ../sites-available/zigbee.conf /etc/nginx/sites-enabled/
+	install -d debian/secubox-zigbee/etc/nginx/sites-available
+	[ -f nginx/zigbee-vhost.conf ] && install -m 644 nginx/zigbee-vhost.conf debian/secubox-zigbee/etc/nginx/sites-available/zigbee.conf || true
 	# Config example
 	install -d debian/secubox-zigbee/etc/secubox
 	[ -f conf/zigbee.toml.example ] && cp conf/zigbee.toml.example debian/secubox-zigbee/etc/secubox/zigbee.toml.example || true

--- a/packages/secubox-zigbee/nginx/zigbee-vhost.conf
+++ b/packages/secubox-zigbee/nginx/zigbee-vhost.conf
@@ -1,0 +1,99 @@
+# /etc/nginx/sites-available/zigbee.conf — public Zigbee Manager vhost
+# Installed by secubox-zigbee (#289). Operator enables with:
+#   ln -s ../sites-available/zigbee.conf /etc/nginx/sites-enabled/
+#   systemctl reload nginx
+#
+# Public chain: Browser → HAProxy:443 (cert) → mitmproxy WAF → nginx:9080
+#               (zigbee.gk2.secubox.in) → z2m LXC (10.100.0.111:8080).
+# Operator wires the HAProxy SNI ACL, the mitmproxy haproxy-routes.json
+# entry inside the mitmproxy LXC, and the ACME cert separately
+# (wildcard *.gk2.secubox.in.pem already covers this vhost). See
+# CLAUDE.md WAF rule.
+#
+# zigbee2mqtt's frontend uses WebSocket for live device-state pushes, so
+# proxy_http_version 1.1 + Upgrade/Connection MUST be set.
+
+server {
+    listen 0.0.0.0:9080;
+    listen [::]:9080;
+    server_name zigbee.gk2.secubox.in;
+
+    # ACME HTTP-01 challenge — outside SSO so renewals work from the
+    # public internet. MUST come before the catch-all proxy.
+    location ^~ /.well-known/acme-challenge/ {
+        root /usr/share/secubox/www;
+        try_files $uri =404;
+    }
+
+    # Health Banner injection (consistent with sibling vhosts).
+    sub_filter_types text/html;
+    sub_filter_once on;
+    sub_filter "</body>" '<script src="/shared/health-banner.js"></script></body>';
+
+    # Shared assets — banner JS, error pages (LAN-only).
+    location /shared/ {
+        allow 127.0.0.1;
+        allow 10.0.0.0/8;
+        allow 172.16.0.0/12;
+        allow 192.168.0.0/16;
+        deny all;
+
+        add_header Access-Control-Allow-Origin "*" always;
+        alias /usr/share/secubox/www/shared/;
+    }
+
+    # z2m frontend proxied to the LXC at root. Gated by Authelia SSO.
+    # 401 → 302 to /auth/ on the canonical hub.
+    location / {
+        auth_request /__sbx_auth_verify;
+        error_page 401 = @sbx_auth_login;
+
+        auth_request_set $sbx_user   $upstream_http_remote_user;
+        auth_request_set $sbx_groups $upstream_http_remote_groups;
+
+        proxy_pass http://10.100.0.111:8080/;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host  $host;
+        proxy_set_header X-Forwarded-User  $sbx_user;
+        proxy_set_header X-Forwarded-Groups $sbx_groups;
+
+        # WebSocket upgrade for live device-state pushes.
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_buffering off;
+        proxy_read_timeout 86400;
+    }
+
+    # 401 → 302 to Authelia portal at admin.gk2.secubox.in/auth/. Same
+    # parent .gk2.secubox.in → authelia_session cookie covers this vhost
+    # (session.cookies[] per #272).
+    location @sbx_auth_login {
+        return 302 https://admin.gk2.secubox.in/auth/?rd=https://$host$request_uri;
+    }
+
+    # Internal auth_request target — re-declared per server-block scope.
+    # Forwards X-Original-URL + X-Forwarded-* so Authelia picks the
+    # correct session.cookies[] entry (#274 pattern).
+    location = /__sbx_auth_verify {
+        internal;
+        proxy_pass http://unix:/run/secubox/authelia.sock:/verify;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header Authorization $http_authorization;
+        proxy_set_header X-Original-URL https://$host$request_uri;
+        proxy_set_header X-Forwarded-Method $request_method;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Uri $request_uri;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    access_log /var/log/nginx/zigbee_access.log;
+    error_log  /var/log/nginx/zigbee_error.log;
+}

--- a/packages/secubox-zigbee/nginx/zigbee.conf
+++ b/packages/secubox-zigbee/nginx/zigbee.conf
@@ -1,56 +1,18 @@
 # /etc/nginx/secubox.d/zigbee.conf + /etc/nginx/secubox-routes.d/zigbee.conf
-# Installed by secubox-zigbee (#241, v2.4.1 adds the z2m frontend proxy).
+# Installed by secubox-zigbee (#241; #289 split SecuBox config module from
+# the public z2m frontend at zigbee.gk2.secubox.in).
 
-# Host control-plane API
+# Host control-plane API. Drives the static SecuBox config module below.
 location /api/v1/zigbee/ {
     rewrite ^/api/v1/zigbee/(.*)$ /$1 break;
     proxy_pass http://unix:/run/secubox/zigbee.sock;
     include /etc/nginx/snippets/secubox-proxy.conf;
 }
 
-# Native zigbee2mqtt frontend (LXC :8080) — proxied at /zigbee/ on the
-# canonical hub vhost so it shows up inside the SecuBox WebUI without
-# needing a separate public vhost. WebSocket upgrade required for live
-# device state pushes.
+# SecuBox configuration module for Zigbee (static UI). Calls /api/v1/zigbee/*
+# for components / status / access, and links to the full z2m manager on its
+# own vhost (zigbee.gk2.secubox.in, see /etc/nginx/sites-available/zigbee.conf).
 location /zigbee/ {
-    # z2m has no authentication of its own. Gate via Authelia SSO:
-    # nginx auth_request → /__sbx_auth_verify (host FastAPI, implemented
-    # in secubox-authelia v1.0.2+ #263, which reverse-proxies to the
-    # Authelia LXC's native /api/verify and returns 200 + Remote-User
-    # headers when the authelia_session cookie is valid).
-    auth_request /__sbx_auth_verify;
-    error_page 401 = @sbx_auth_login;
-
-    # Capture the Authelia-validated identity and forward to z2m.
-    # z2m doesn't use it (no native SSO), but downstream logging /
-    # auditing can.
-    auth_request_set $sbx_user   $upstream_http_remote_user;
-    auth_request_set $sbx_groups $upstream_http_remote_groups;
-    proxy_set_header X-Forwarded-User   $sbx_user;
-    proxy_set_header X-Forwarded-Groups $sbx_groups;
-
-    proxy_pass http://10.100.0.111:8080/;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-
-    # z2m frontend uses WebSocket — must upgrade.
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-
-    proxy_buffering off;
-    proxy_read_timeout 86400;
-
-    # Health-banner injection (consistent with sibling iframe targets like
-    # /yacy/, /lyrion/, /auth/).
-    sub_filter_types text/html;
-    sub_filter_once on;
-    sub_filter "</body>" '<script src="/shared/health-banner.js"></script></body>';
+    alias /usr/share/secubox/www/zigbee/;
+    try_files $uri $uri/ /zigbee/index.html;
 }
-
-# The `@sbx_auth_login` named location used by `error_page 401 = …;` above
-# is owned by secubox-authelia (see /etc/nginx/secubox.d/authelia.conf).
-# Defining it here would make this package the unintentional provider for
-# every other SSO-gated app on the canonical hub vhost.

--- a/packages/secubox-zigbee/www/zigbee/index.html
+++ b/packages/secubox-zigbee/www/zigbee/index.html
@@ -3,27 +3,22 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>SecuBox — Lyrion</title>
+<title>SecuBox — Zigbee</title>
 <link rel="stylesheet" href="/shared/crt-light.css">
 <link rel="stylesheet" href="/shared/sidebar-light.css">
 <style>
-  html, body { margin: 0; padding: 0; height: 100%; }
+  html, body { margin: 0; padding: 0; min-height: 100%; }
   .layout {
     display: grid;
     grid-template-columns: 260px 1fr;
-    height: 100vh;
+    min-height: 100vh;
   }
-  .lyrion-frame {
-    border: 0;
-    width: 100%;
-    height: 100%;
-    background: var(--bg-1, #0f1320);
-  }
+  .container { display: flex; flex-direction: column; min-height: 100vh; }
   .topbar {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.5rem 1rem;
+    padding: 0.6rem 1.25rem;
     background: var(--bg-2, #181c2c);
     border-bottom: 1px solid var(--border, #2a3354);
     color: var(--root-main, #00d49b);
@@ -36,29 +31,66 @@
     text-decoration: none;
   }
   .topbar .actions a:hover { text-decoration: underline; }
+  .open-manager {
+    display: inline-block;
+    padding: 0.45rem 0.9rem;
+    border: 1px solid var(--root-main, #00d49b);
+    border-radius: 4px;
+    background: rgba(0,212,155,0.08);
+    color: var(--root-main, #00d49b);
+    text-decoration: none;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.85rem;
+  }
+  .open-manager:hover { background: rgba(0,212,155,0.18); }
   .threefold {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 1rem;
-    padding: 1rem;
-    background: var(--bg-1);
+    padding: 1.25rem;
+    background: var(--bg-1, #0f1320);
   }
   .threefold article {
     background: var(--bg-2);
     border: 1px solid var(--border);
-    padding: 0.75rem 1rem;
+    padding: 0.85rem 1rem;
     border-radius: 4px;
+    min-height: 110px;
   }
   .threefold h3 {
-    margin: 0 0 0.5rem 0;
+    margin: 0 0 0.6rem 0;
     color: var(--root-main);
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.1em;
   }
-  .threefold .v { font-family: 'JetBrains Mono', monospace; font-size: 0.85rem; }
-  .container { display: flex; flex-direction: column; height: 100vh; }
-  .iframe-wrap { flex: 1; }
+  .threefold .v {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.85rem;
+    line-height: 1.5;
+  }
+  .threefold .v a { color: var(--root-main); }
+  .info-block {
+    padding: 1.25rem;
+    color: var(--text, #b8c5e0);
+    font-size: 0.9rem;
+    line-height: 1.6;
+    border-top: 1px solid var(--border);
+  }
+  .info-block h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--root-main);
+    margin: 0 0 0.6rem 0;
+  }
+  .info-block code {
+    background: var(--bg-2);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.85em;
+  }
 </style>
 </head>
 <body class="crt-light">
@@ -67,33 +99,43 @@
   <nav class="sidebar" id="sidebar"></nav>
   <div class="container">
     <div class="topbar">
-      <div><strong>SecuBox</strong> · Lyrion — Music server</div>
+      <div><strong>SecuBox</strong> · Zigbee — Mesh manager</div>
       <div class="actions">
-        <a href="/" title="Back to SecuBox hub">← hub</a>
-        <a href="#" id="open-native" title="Open native Lyrion in this tab">native UI</a>
+        <a href="/" title="Back to SecuBox hub">&larr; hub</a>
+        <a class="open-manager" href="https://zigbee.gk2.secubox.in/" id="open-manager"
+           title="Open the full zigbee2mqtt manager">Open Zigbee Manager &rarr;</a>
       </div>
     </div>
 
     <section class="threefold" id="threefold">
       <article id="components-card">
         <h3>Components</h3>
-        <div class="v" id="components-v">loading…</div>
+        <div class="v" id="components-v">loading&hellip;</div>
       </article>
       <article id="status-card">
         <h3>Status</h3>
-        <div class="v" id="status-v">loading…</div>
+        <div class="v" id="status-v">loading&hellip;</div>
       </article>
       <article id="access-card">
         <h3>Access</h3>
-        <div class="v" id="access-v">loading…</div>
+        <div class="v" id="access-v">loading&hellip;</div>
       </article>
     </section>
 
-    <div class="iframe-wrap">
-      <iframe class="lyrion-frame"
-              src="/lyrion/d////-overview?kiosk=tv&theme=light"
-              title="Lyrion dashboards"
-              referrerpolicy="no-referrer"></iframe>
+    <div class="info-block">
+      <h2>About this module</h2>
+      <p>
+        SecuBox manages a <code>zigbee2mqtt</code> instance running in an
+        LXC at <code>10.100.0.111</code> with a SONOFF Dongle-E coordinator.
+        Pairing, network maps, OTA updates, and group bindings are handled
+        by the <em>Zigbee Manager</em> &mdash; open it via the button above
+        (Authelia SSO-gated).
+      </p>
+      <p>
+        This module surfaces the SecuBox-side health (component state, MQTT
+        bridge status, access points) so operators can confirm the stack
+        is up before opening the manager.
+      </p>
     </div>
   </div>
 </div>
@@ -102,7 +144,7 @@
 <script src="/shared/api-utils.js"></script>
 <script>
 // Mandatory auth wrapper (matches docs/MODULE-GUIDELINES.md §4)
-(function() {
+(function () {
   function getToken() { return localStorage.getItem('sbx_token'); }
   function checkAuth() {
     if (!getToken()) {
@@ -112,42 +154,41 @@
     return true;
   }
   if (!checkAuth()) {
-    document.body.innerHTML = '<div style="padding:2rem;color:var(--root-main);">Redirecting to login...</div>';
+    document.body.innerHTML = '<div style="padding:2rem;color:var(--root-main);">Redirecting to login&hellip;</div>';
     return;
   }
 
-  // Fill the threefold cards from /api/v1/lyrion/*
   function get(path) {
-    return fetch('/api/v1/lyrion' + path, {
+    return fetch('/api/v1/zigbee' + path, {
       headers: { 'Authorization': 'Bearer ' + getToken() }
     }).then(r => r.ok ? r.json() : Promise.reject(r.status));
   }
 
   get('/components').then(d => {
-    document.getElementById('components-v').innerHTML =
-      d.components.map(c => '<div>' + c.name + ': <strong>' + c.state + '</strong></div>').join('');
+    const list = (d.components || []).map(c =>
+      '<div>' + c.name + ': <strong>' + c.state + '</strong></div>').join('');
+    document.getElementById('components-v').innerHTML = list || 'no components';
   }).catch(() => {
     document.getElementById('components-v').textContent = 'unavailable';
   });
 
   get('/status').then(d => {
+    const overall = (d.overall || 'unknown').toUpperCase();
+    const color = d.overall === 'green' ? 'root-main'
+                : d.overall === 'yellow' ? 'wall-main'
+                : 'cinnabar';
     document.getElementById('status-v').innerHTML =
-      '<span style="color:var(--' + (d.overall === 'green' ? 'root-main' : d.overall === 'yellow' ? 'wall-main' : 'root-main') + ')">'
-      + (d.overall || 'unknown').toUpperCase() + '</span>';
+      '<span style="color:var(--' + color + ')">' + overall + '</span>';
   }).catch(() => {
     document.getElementById('status-v').textContent = 'unavailable';
   });
 
   get('/access').then(d => {
-    document.getElementById('access-v').innerHTML =
-      (d.access || []).map(a => '<div>' + a.scope + ': <a href="' + a.url + '">' + a.url + '</a></div>').join('');
+    const list = (d.access || []).map(a =>
+      '<div>' + a.scope + ': <a href="' + a.url + '">' + a.url + '</a></div>').join('');
+    document.getElementById('access-v').innerHTML = list || 'no access points';
   }).catch(() => {
     document.getElementById('access-v').textContent = 'unavailable';
-  });
-
-  document.getElementById('open-native').addEventListener('click', e => {
-    e.preventDefault();
-    window.location.href = '/lyrion/';
   });
 })();
 </script>


### PR DESCRIPTION
Mirrors the nextcloud split (#282). /zigbee/ on the canonical hub becomes a static config UI; the actual z2m frontend moves to its own vhost.

- nginx/zigbee.conf — /zigbee/ becomes a static alias to /usr/share/secubox/www/zigbee/
- nginx/zigbee-vhost.conf (new) — zigbee.gk2.secubox.in reverse-proxies to 10.100.0.111:8080 with WebSocket + Authelia SSO
- www/zigbee/index.html — rewritten (was a copy-paste Lyrion stub); now calls /api/v1/zigbee/* and has 'Open Zigbee Manager ->' button
- debian/rules — ships vhost to sites-available/