### PR TITLE
fix(secubox-hub): v1.3.4 — health-banner non-clickable alerts (closes #290)

### DIFF
--- a/packages/secubox-hub/debian/changelog
+++ b/packages/secubox-hub/debian/changelog
@@ -1,3 +1,15 @@
+secubox-hub (1.3.4-1~bookworm1) bookworm; urgency=medium
+
+  * www/shared/health-banner.js: stop emitting clickable <a href="…">
+    alerts. Targets were relative paths like /waf/, /crowdsec/,
+    /system/ that resolved against whatever host embedded the banner —
+    cross-origin embeds (e.g. oracle.ganimed.fr) produced wrong-host
+    links like https://oracle.ganimed.fr/system/. Banner is now purely
+    informational; navigation belongs to the dashboard sidebar.
+  * Closes #290.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 09:30:00 +0000
+
 secubox-hub (1.3.3-1~bookworm1) bookworm; urgency=medium
 
   * Drop www/nac/index.html, www/soc/index.html and www/soc.html from

--- a/packages/secubox-hub/www/shared/health-banner.js
+++ b/packages/secubox-hub/www/shared/health-banner.js
@@ -821,16 +821,16 @@
             const alerts = diagnose(health);
             const visibleAlerts = alerts.filter(a => a.severity !== 'celebration' || score >= 95).slice(0, 5);
             const hub = isHubVhost();
+            // Alerts are always non-clickable (#290). The previous <a href>
+            // branch emitted relative URLs that resolved to whatever host the
+            // banner was embedded on — e.g. https://oracle.ganimed.fr/system/
+            // when loaded cross-origin. Banner stays purely informational;
+            // the dashboard sidebar is the canonical navigation surface.
             alertsEl.innerHTML = visibleAlerts.map(a =>
-                (a.action && hub)
-                    ? `<a href="${a.action}" class="hb-alert ${a.severity}" title="${a.message}">
-                        <span class="hb-alert-icon">${a.icon}</span>
-                        <span class="hb-alert-text">${a.message}</span>
-                    </a>`
-                    : `<div class="hb-alert ${a.severity}" title="${a.message}">
-                        <span class="hb-alert-icon">${a.icon}</span>
-                        <span class="hb-alert-text">${a.message}</span>
-                    </div>`
+                `<div class="hb-alert ${a.severity}" title="${a.message}">
+                    <span class="hb-alert-icon">${a.icon}</span>
+                    <span class="hb-alert-text">${a.message}</span>
+                </div>`
             ).join('');
         }
 


### PR DESCRIPTION
Banner used to emit <a href=/waf/> etc. that resolved cross-origin to wrong URLs (e.g. https://oracle.ganimed.fr/system/). Now always emits <div>.