### PR TITLE
fix(secubox-zigbee): v2.5.1 — /zigbee/ UI under global navbar (closes #293)

### DIFF
--- a/packages/secubox-zigbee/debian/changelog
+++ b/packages/secubox-zigbee/debian/changelog
@@ -1,3 +1,13 @@
+secubox-zigbee (2.5.1-1~bookworm1) bookworm; urgency=medium
+
+  * www/zigbee/index.html: layout fix. The shared sidebar.js injects a
+    `.global-menu-bar` (position:fixed, height:48px, z-index:998,
+    left:220px) at body top — page content was rendering under it.
+    Add `body { padding-top: 48px }` and adjust the grid sidebar column
+    from 260px to the canonical 220px. Closes #293.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 09:50:00 +0000
+
 secubox-zigbee (2.5.0-1~bookworm1) bookworm; urgency=medium
 
   * Split SecuBox config module from the public z2m frontend (mirrors

--- a/packages/secubox-zigbee/www/zigbee/index.html
+++ b/packages/secubox-zigbee/www/zigbee/index.html
@@ -8,12 +8,15 @@
 <link rel="stylesheet" href="/shared/sidebar-light.css">
 <style>
   html, body { margin: 0; padding: 0; min-height: 100%; }
+  /* Global menu bar (injected by shared/sidebar.js) is position:fixed,
+     top:0, height:48px, z-index:998. Push our content below it. */
+  body { padding-top: 48px; box-sizing: border-box; }
   .layout {
     display: grid;
-    grid-template-columns: 260px 1fr;
-    min-height: 100vh;
+    grid-template-columns: 220px 1fr; /* canonical SecuBox sidebar width */
+    min-height: calc(100vh - 48px);
   }
-  .container { display: flex; flex-direction: column; min-height: 100vh; }
+  .container { display: flex; flex-direction: column; min-height: calc(100vh - 48px); }
   .topbar {
     display: flex;
     align-items: center;


### PR DESCRIPTION
body padding-top:48px to clear the fixed global-menu-bar; sidebar grid 260px → 220px (canonical).