### PR TITLE
fix(secubox-dns-provider): v1.0.2 — modal z-index 100 → 1500 (closes #301)

### DIFF
--- a/packages/secubox-dns-provider/debian/changelog
+++ b/packages/secubox-dns-provider/debian/changelog
@@ -1,3 +1,12 @@
+secubox-dns-provider (1.0.2-1~bookworm1) bookworm; urgency=medium
+
+  * www/dns-provider/index.html: bump .modal z-index 100 → 1500. The
+    injected .global-menu-bar (z-index 998 !important, from
+    secubox-hub's hybrid-skin.css) overlapped the modal top, making
+    the Add Provider dialog look unviewable. Closes #301.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 10:35:00 +0000
+
 secubox-dns-provider (1.0.1-1~bookworm1) bookworm; urgency=medium
 
   * www/dns-provider/index.html: Add Provider modal hardening (#299):

--- a/packages/secubox-dns-provider/www/dns-provider/index.html
+++ b/packages/secubox-dns-provider/www/dns-provider/index.html
@@ -197,7 +197,10 @@
             position: fixed;
             top: 0; left: 0; right: 0; bottom: 0;
             background: rgba(0,0,0,0.7);
-            z-index: 100;
+            /* #301: must be > .global-menu-bar (z-index 998 !important from
+               shared/hybrid-skin.css) otherwise the modal opens behind the
+               navbar and looks unviewable. */
+            z-index: 1500;
             align-items: center;
             justify-content: center;
         }


### PR DESCRIPTION
Add Provider dialog opened behind .global-menu-bar (z-index 998 !important). One-liner CSS fix.