### PR TITLE
fix(secubox-zigbee): v2.5.2 — proper menu.d entry (closes #303)

### DIFF
--- a/packages/secubox-zigbee/debian/changelog
+++ b/packages/secubox-zigbee/debian/changelog
@@ -1,3 +1,14 @@
+secubox-zigbee (2.5.2-1~bookworm1) bookworm; urgency=medium
+
+  * menu.d/80-zigbee.json: rewrite (was a copy-paste of Lyrion's
+    menu entry — title 'Lyrion', url '/lyrion/', module 'lyrion').
+    Two 'Lyrion' entries appeared in the SecuBox navbar and no
+    'Zigbee' entry at all. Now title 'Zigbee', subtitle 'Mesh
+    manager (z2m)', icon fa-microchip, url '/zigbee/', section
+    'hosting', order 85, module 'zigbee'. Closes #303.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 10:55:00 +0000
+
 secubox-zigbee (2.5.1-1~bookworm1) bookworm; urgency=medium
 
   * www/zigbee/index.html: layout fix. The shared sidebar.js injects a

--- a/packages/secubox-zigbee/menu.d/80-zigbee.json
+++ b/packages/secubox-zigbee/menu.d/80-zigbee.json
@@ -1,9 +1,9 @@
 {
-  "title": "Lyrion",
-  "subtitle": "Music server",
-  "icon": "fa-music",
-  "url": "/lyrion/",
+  "title": "Zigbee",
+  "subtitle": "Mesh manager (z2m)",
+  "icon": "fa-microchip",
+  "url": "/zigbee/",
   "section": "hosting",
-  "order": 80,
-  "module": "lyrion"
+  "order": 85,
+  "module": "zigbee"
 }


### PR DESCRIPTION
menu.d/80-zigbee.json was a copy-paste of Lyrion. Two Lyrion entries showed in the navbar, no Zigbee. Now correct.