### PR TITLE
feat(secubox-authelia): split SSO portal from operator dashboard (closes #310)

### DIFF
--- a/packages/secubox-authelia/debian/changelog
+++ b/packages/secubox-authelia/debian/changelog
@@ -1,3 +1,24 @@
+secubox-authelia (1.0.9-1~bookworm1) bookworm; urgency=medium
+
+  * Split SSO portal from operator dashboard (#310):
+    - nginx/authelia.conf: /auth/ on the canonical hub vhost is now a
+      static alias to /usr/share/secubox/www/authelia/ (control + status
+      dashboard). Used to reverse-proxy the Authelia LXC portal.
+    - nginx/authelia.conf: @sbx_auth_login redirects to
+      https://sso.gk2.secubox.in/?rd=… (was https://$host/auth/?rd=…).
+    - nginx/authelia-vhost.conf: new public vhost sso.gk2.secubox.in,
+      reverse-proxies / → /auth/ → Authelia LXC 10.100.0.20:9091. Same
+      pattern as the existing auth.maegia.tv block, on the
+      .gk2.secubox.in cookie scope.
+    - www/authelia/index.html: rewrite as the SecuBox AUTH config
+      module — service state, version, user count, cookie scopes,
+      access rules, components / status / access cards. Charter AUTH
+      palette (#C04E24 orange). Was a Lyrion copy-paste stub.
+    - lib/authelia/install-lxc.sh: session.cookies[] for the hub
+      domain now points authelia_url at sso.${SECUBOX_HUB_DOMAIN}.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 12:30:00 +0000
+
 secubox-authelia (1.0.8-1~bookworm1) bookworm; urgency=medium
 
   * nginx/authelia.conf: own the `@sbx_auth_login` named location.

--- a/packages/secubox-authelia/lib/authelia/install-lxc.sh
+++ b/packages/secubox-authelia/lib/authelia/install-lxc.sh
@@ -288,7 +288,10 @@ session:
       inactivity: 300
     - name: authelia_session
       domain: ${SECUBOX_HUB_DOMAIN}
-      authelia_url: 'https://admin.${SECUBOX_HUB_DOMAIN}/auth/'
+      # SSO portal moved to its own vhost in #310 — sibling vhosts (zigbee,
+      # lyrion, nextcloud) now redirect here for login. The canonical hub
+      # /auth/ is the operator dashboard, not the portal anymore.
+      authelia_url: 'https://sso.${SECUBOX_HUB_DOMAIN}/'
       expiration: 3600
       inactivity: 300
   secret: ${jwt_secret}

--- a/packages/secubox-authelia/nginx/authelia-vhost.conf
+++ b/packages/secubox-authelia/nginx/authelia-vhost.conf
@@ -56,3 +56,67 @@ server {
     access_log /var/log/nginx/authelia_access.log;
     error_log  /var/log/nginx/authelia_error.log;
 }
+
+# ── Public SSO portal — sso.gk2.secubox.in (#310) ────────────────────────────
+#
+# Multi-SP entry point for SecuBox SSO. All SSO-gated apps on the gk2 board
+# (zigbee, lyrion, nextcloud, …) redirect their unauthenticated requests
+# here for login. Same chain as auth.maegia.tv above but on the
+# .gk2.secubox.in cookie scope (session.cookies[] #272 already covers it).
+#
+# Routing: Browser → HAProxy:443 → mitmproxy LXC → nginx:9080 (this vhost)
+#                  → Authelia LXC at 10.100.0.20:9091
+#
+# Operator-side prerequisites:
+#   1. DNS A record sso.gk2.secubox.in → public IP
+#   2. TLS — covered by the existing wildcard *.gk2.secubox.in.pem in
+#      /data/haproxy/certs/ (no new cert needed)
+#   3. haproxyctl vhost add sso.gk2.secubox.in mitmproxy_inspector
+#      (then repair haproxy.cfg backend defs per #286)
+#   4. mitmproxy route INSIDE the LXC:
+#        lxc-attach -n mitmproxy -- python3 -c \
+#          "import json; p='/srv/mitmproxy/haproxy-routes.json'; \
+#           d=json.load(open(p)); d['sso.gk2.secubox.in']=['192.168.1.200',9080]; \
+#           open(p,'w').write(json.dumps(d, indent=2, sort_keys=True))"
+#        lxc-attach -n mitmproxy -- systemctl restart mitmproxy.service
+
+server {
+    listen 0.0.0.0:9080;
+    listen [::]:9080;
+    server_name sso.gk2.secubox.in;
+
+    # ACME HTTP-01 challenge — exempt from any gate so renewals work
+    # from the public internet. MUST come before catch-all locations.
+    location ^~ /.well-known/acme-challenge/ {
+        root /usr/share/secubox/www;
+        try_files $uri =404;
+    }
+
+    # Shared assets (banner JS, error pages)
+    location /shared/ {
+        add_header Access-Control-Allow-Origin "*" always;
+        alias /usr/share/secubox/www/shared/;
+    }
+
+    # Redirect root → /auth/ so the SPA lives at the same path the
+    # Authelia binary expects (server.address: tcp://0.0.0.0:9091/auth).
+    location = / {
+        return 302 https://$host/auth/;
+    }
+
+    # Authelia portal UI — proxy_pass with NO trailing slash to preserve
+    # the /auth/ prefix expected by Authelia 4.39+.
+    location /auth/ {
+        proxy_pass http://10.100.0.20:9091;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_read_timeout 300s;
+    }
+
+    access_log /var/log/nginx/sso_access.log;
+    error_log  /var/log/nginx/sso_error.log;
+}

--- a/packages/secubox-authelia/nginx/authelia.conf
+++ b/packages/secubox-authelia/nginx/authelia.conf
@@ -1,46 +1,28 @@
 # /etc/nginx/secubox.d/authelia.conf + /etc/nginx/secubox-routes.d/authelia.conf
-# Installed by secubox-authelia (#239)
+# Installed by secubox-authelia (#239, split per #310)
 #
 # Authelia exposes:
 #   /api/v1/authelia/   → host FastAPI on Unix socket (CTL surface + /verify)
-#   /auth/              → LXC at 10.100.0.20:9091 (native Authelia portal UI)
+#   /auth/              → SecuBox AUTH config module (static dashboard)
+#                         — control / status / metrics. NOT the portal.
 #
-# The public vhost auth.maegia.tv lives in /etc/nginx/sites-available/authelia.conf
-# (separate file) so the canonical hub vhost only carries the /auth/ subpath.
+# The actual Authelia portal lives on its own public vhost at
+# sso.gk2.secubox.in (see /etc/nginx/sites-available/authelia.conf).
+# Sibling SSO-gated apps redirect to sso.gk2.secubox.in/?rd=… for login.
 
+# Host control-plane API. Drives the SecuBox AUTH config UI below.
 location /api/v1/authelia/ {
     rewrite ^/api/v1/authelia/(.*)$ /$1 break;
     proxy_pass http://unix:/run/secubox/authelia.sock;
     include /etc/nginx/snippets/secubox-proxy.conf;
 }
 
-# Native Authelia portal UI. NO trailing slash on proxy_pass — Authelia
-# 4.39+ is path-aware (server.address: tcp://0.0.0.0:9091/auth), so the
-# /auth/ prefix MUST be forwarded as-is.
-#
-# Banner injection MUST be suppressed here: Authelia ships a strict CSP
-# (default-src 'self'; style-src 'self' 'nonce-...'; base-uri 'self')
-# that rejects the <script src="/shared/health-banner.js"></script>
-# the canonical hub vhost (webui.conf) injects at the server level.
-#
-# Just NOT declaring sub_filter here isn't enough — per nginx docs,
-# sub_filter inherits from the parent server block unless overridden.
-# We declare a never-match sub_filter pattern inside this location to
-# replace the inherited one with a noop.
+# SecuBox AUTH config module — static dashboard (control + status metrics).
+# Calls /api/v1/authelia/* for sessions, components, access policy etc.,
+# and offers an "Open SSO Portal →" button to https://sso.gk2.secubox.in/.
 location /auth/ {
-    proxy_pass http://10.100.0.20:9091;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto https;
-    proxy_http_version 1.1;
-    proxy_set_header Connection "";
-    proxy_read_timeout 300s;
-
-    # Suppress the inherited server-level banner injection — never-match
-    # pattern replaces the parent's sub_filter so the response passes
-    # through unmodified.
-    sub_filter "__SBX_BANNER_OFF" "";
+    alias /usr/share/secubox/www/authelia/;
+    try_files $uri $uri/ /auth/index.html;
 }
 
 # nginx `auth_request` endpoint for SSO-less backends (yacy, rustdesk-web,
@@ -70,13 +52,9 @@ location = /__sbx_auth_verify {
 
 # Named location consumed by every SSO-gated backend on the canonical hub
 # vhost (zigbee, lyrion, future apps) via `error_page 401 = @sbx_auth_login;`.
-# 401 from auth_request → 302 to the Authelia portal, carrying the original
-# URL in `rd` so the user lands back where they started post-login.
-#
-# $host (hostname only) and hardcoded `https://` strip both the internal
-# :9080 port that the Host header may carry (LAN-direct hit, HAProxy
-# passthrough) and the http scheme nginx sees behind TLS termination —
-# neither must appear in a public redirect.
+# 401 from auth_request → 302 to the public Authelia portal vhost
+# (sso.gk2.secubox.in), carrying the original URL in `rd` so the user
+# lands back where they started post-login.
 location @sbx_auth_login {
-    return 302 https://$host/auth/?rd=https://$host$request_uri;
+    return 302 https://sso.gk2.secubox.in/?rd=https://$host$request_uri;
 }

--- a/packages/secubox-authelia/www/authelia/index.html
+++ b/packages/secubox-authelia/www/authelia/index.html
@@ -3,106 +3,150 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>SecuBox — Authelia</title>
+<title>SecuBox - Auth</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/shared/crt-light.css">
 <link rel="stylesheet" href="/shared/sidebar-light.css">
 <style>
-  html, body { margin: 0; padding: 0; height: 100%; }
-  .layout {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    height: 100vh;
+  :root {
+    /* AUTH palette (Charte SecuBox §Six Module Color System) — orange. */
+    --auth-main:  #C04E24;
+    --auth-light: #E8845A;
+    --auth-xlt:   #FAECE7;
+    --accent:       var(--auth-main);
+    --accent-light: var(--auth-light);
+
+    --bg:       #FFFFFF;
+    --surface:  #FAFAF8;
+    --surface2: #F4F3EF;
+    --border:   #E2E0D8;
+    --border2:  #C8C6BE;
+    --text:     #1A1A18;
+    --muted:    #6B6963;
+
+    --green:  #0A5840;
+    --yellow: #9A6010;
+    --red:    #803018;
+
+    --gmb-h: 48px;
   }
-  .authelia-frame {
-    border: 0;
-    width: 100%;
-    height: 100%;
-    background: var(--bg-1, #0f1320);
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: 'Space Grotesk', sans-serif; background: var(--bg); color: var(--text); display: flex; min-height: 100vh; font-size: 14px; line-height: 1.6; }
+  .main { flex: 1; margin-left: 220px; padding: calc(var(--gmb-h) + 1.5rem) 1.5rem 1.5rem; min-width: 0; }
+  .header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; gap: 1rem; flex-wrap: wrap; }
+  .header h1 { font-size: 24px; font-weight: 600; letter-spacing: -0.4px; color: var(--accent); }
+  .header h1 .icon { margin-right: 0.5rem; }
+  .header-actions { display: flex; gap: 0.5rem; }
+  .btn { padding: 0.5rem 1rem; border-radius: 6px; border: 1px solid var(--border2); background: var(--surface); color: var(--text); cursor: pointer; font-family: inherit; font-size: 14px; text-decoration: none; display: inline-flex; align-items: center; gap: 0.4rem; transition: all 0.15s; }
+  .btn:hover { border-color: var(--accent); color: var(--accent); background: var(--auth-xlt); }
+  .btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+  .btn.primary:hover { background: var(--accent-light); color: #fff; }
+
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; margin-bottom: 1.5rem; }
+  .stat { background: var(--surface); border: 1px solid var(--border); border-radius: 14px; padding: 1rem 1.25rem; }
+  .stat .label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); margin-bottom: 0.4rem; }
+  .stat .value { font-family: 'JetBrains Mono', monospace; font-size: 22px; font-weight: 700; color: var(--accent); }
+  .stat .sub { font-size: 12px; color: var(--muted); margin-top: 0.2rem; }
+
+  .threefold { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; margin-bottom: 1.5rem; }
+  .card { background: var(--surface); border: 1px solid var(--border); border-radius: 14px; padding: 1.25rem 1.5rem; }
+  .card h3 { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); margin-bottom: 0.75rem; }
+  .card .v { font-family: 'JetBrains Mono', monospace; font-size: 13px; line-height: 1.7; color: var(--text); }
+  .card .v a { color: var(--accent); text-decoration: none; }
+  .card .v a:hover { text-decoration: underline; }
+  .card .v strong { color: var(--accent); font-weight: 700; }
+
+  .status-pill { display: inline-block; padding: 0.2rem 0.6rem; border-radius: 999px; font-size: 12px; font-weight: 700; letter-spacing: 0.05em; }
+  .status-pill.green  { background: rgba(10,88,64,0.1);  color: var(--green); }
+  .status-pill.yellow { background: rgba(154,96,16,0.1); color: var(--yellow); }
+  .status-pill.red    { background: rgba(128,48,24,0.1); color: var(--red); }
+
+  .about { background: var(--surface2); border: 1px solid var(--border); border-radius: 14px; padding: 1.25rem 1.5rem; color: var(--muted); }
+  .about h2 { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text); margin-bottom: 0.5rem; }
+  .about p { margin-bottom: 0.5rem; }
+  .about code { background: var(--bg); padding: 0.05rem 0.4rem; border-radius: 3px; font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--text); border: 1px solid var(--border); }
+
+  @media (max-width: 900px) {
+    .main { margin-left: 0; padding-top: calc(var(--gmb-h) + 1rem); }
+    .stats, .threefold { grid-template-columns: 1fr; }
   }
-  .topbar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0.5rem 1rem;
-    background: var(--bg-2, #181c2c);
-    border-bottom: 1px solid var(--border, #2a3354);
-    color: var(--auth-main, #00d49b);
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.85rem;
-  }
-  .topbar .actions a {
-    color: var(--auth-main, #00d49b);
-    margin-left: 1rem;
-    text-decoration: none;
-  }
-  .topbar .actions a:hover { text-decoration: underline; }
-  .threefold {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 1rem;
-    padding: 1rem;
-    background: var(--bg-1);
-  }
-  .threefold article {
-    background: var(--bg-2);
-    border: 1px solid var(--border);
-    padding: 0.75rem 1rem;
-    border-radius: 4px;
-  }
-  .threefold h3 {
-    margin: 0 0 0.5rem 0;
-    color: var(--auth-main);
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-  }
-  .threefold .v { font-family: 'JetBrains Mono', monospace; font-size: 0.85rem; }
-  .container { display: flex; flex-direction: column; height: 100vh; }
-  .iframe-wrap { flex: 1; }
 </style>
 </head>
 <body class="crt-light">
 
-<div class="layout">
-  <nav class="sidebar" id="sidebar"></nav>
-  <div class="container">
-    <div class="topbar">
-      <div><strong>SecuBox</strong> · Authelia — SSO identity provider</div>
-      <div class="actions">
-        <a href="/" title="Back to SecuBox hub">← hub</a>
-        <a href="#" id="open-native" title="Open native Authelia in this tab">native UI</a>
-      </div>
-    </div>
+<nav class="sidebar" id="sidebar"></nav>
 
-    <section class="threefold" id="threefold">
-      <article id="components-card">
-        <h3>Components</h3>
-        <div class="v" id="components-v">loading…</div>
-      </article>
-      <article id="status-card">
-        <h3>Status</h3>
-        <div class="v" id="status-v">loading…</div>
-      </article>
-      <article id="access-card">
-        <h3>Access</h3>
-        <div class="v" id="access-v">loading…</div>
-      </article>
-    </section>
-
-    <div class="iframe-wrap">
-      <iframe class="authelia-frame"
-              src="/authelia/d////-overview?kiosk=tv&theme=light"
-              title="Authelia dashboards"
-              referrerpolicy="no-referrer"></iframe>
+<main class="main">
+  <div class="header">
+    <h1><span class="icon">🛂</span> Auth — SSO control</h1>
+    <div class="header-actions">
+      <a class="btn" href="/" title="Back to SecuBox hub">← hub</a>
+      <a class="btn primary" href="https://sso.gk2.secubox.in/" title="Open the Authelia SSO portal (login surface)">Open SSO Portal →</a>
     </div>
   </div>
-</div>
+
+  <section class="stats">
+    <div class="stat">
+      <div class="label">Authelia</div>
+      <div class="value" id="stat-status">…</div>
+      <div class="sub" id="stat-version">probing</div>
+    </div>
+    <div class="stat">
+      <div class="label">Users (file backend)</div>
+      <div class="value" id="stat-users">…</div>
+      <div class="sub">enabled accounts</div>
+    </div>
+    <div class="stat">
+      <div class="label">Cookie domains</div>
+      <div class="value" id="stat-cookies">…</div>
+      <div class="sub" id="stat-cookies-sub">session.cookies[]</div>
+    </div>
+    <div class="stat">
+      <div class="label">Access rules</div>
+      <div class="value" id="stat-rules">…</div>
+      <div class="sub">access_control</div>
+    </div>
+  </section>
+
+  <section class="threefold">
+    <div class="card">
+      <h3>Components</h3>
+      <div class="v" id="components-v">loading…</div>
+    </div>
+    <div class="card">
+      <h3>Status</h3>
+      <div class="v" id="status-v">loading…</div>
+    </div>
+    <div class="card">
+      <h3>Access</h3>
+      <div class="v" id="access-v">loading…</div>
+    </div>
+  </section>
+
+  <div class="about">
+    <h2>About this module</h2>
+    <p>
+      SecuBox runs <strong>Authelia 4.39+</strong> in an LXC at
+      <code>10.100.0.20</code>. This page surfaces operator metrics —
+      service state, configured users, cookie scopes, access policies.
+      The actual login portal lives on its own public vhost
+      <code>sso.gk2.secubox.in</code>; every sibling app (zigbee, lyrion,
+      nextcloud, …) redirects unauthenticated requests there.
+    </p>
+    <p>
+      Click <strong>Open SSO Portal →</strong> to reach the login UI.
+      Backups of <code>/etc/secubox/secrets/authelia-*</code> survive
+      package upgrades.
+    </p>
+  </div>
+</main>
 
 <script src="/shared/sidebar.js"></script>
 <script src="/shared/api-utils.js"></script>
 <script>
-// Mandatory auth wrapper (matches docs/MODULE-GUIDELINES.md §4)
-(function() {
+(function () {
   function getToken() { return localStorage.getItem('sbx_token'); }
   function checkAuth() {
     if (!getToken()) {
@@ -112,42 +156,45 @@
     return true;
   }
   if (!checkAuth()) {
-    document.body.innerHTML = '<div style="padding:2rem;color:var(--auth-main);">Redirecting to login...</div>';
+    document.querySelector('main.main').innerHTML = '<div style="padding:2rem;color:var(--muted);">Redirecting to login…</div>';
     return;
   }
-
-  // Fill the threefold cards from /api/v1/authelia/*
   function get(path) {
-    return fetch('/api/v1/authelia' + path, {
-      headers: { 'Authorization': 'Bearer ' + getToken() }
-    }).then(r => r.ok ? r.json() : Promise.reject(r.status));
+    return fetch('/api/v1/authelia' + path, { headers: { 'Authorization': 'Bearer ' + getToken() } })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); });
   }
 
-  get('/components').then(d => {
-    document.getElementById('components-v').innerHTML =
-      d.components.map(c => '<div>' + c.name + ': <strong>' + c.state + '</strong></div>').join('');
-  }).catch(() => {
-    document.getElementById('components-v').textContent = 'unavailable';
+  get('/version').then(function (d) {
+    document.getElementById('stat-version').textContent = 'v' + (d.version || '?');
+  }).catch(function () {});
+
+  get('/status').then(function (d) {
+    var pill = (d.overall === 'green') ? 'green' : (d.overall === 'yellow') ? 'yellow' : 'red';
+    document.getElementById('stat-status').innerHTML = '<span class="status-pill ' + pill + '">' + (d.overall || 'unknown').toUpperCase() + '</span>';
+    document.getElementById('status-v').innerHTML = '<span class="status-pill ' + pill + '">' + (d.overall || 'unknown').toUpperCase() + '</span>';
+  }).catch(function () {
+    document.getElementById('stat-status').innerHTML = '<span class="status-pill red">DOWN</span>';
+    document.getElementById('status-v').innerHTML = '<span style="color:var(--muted)">unavailable</span>';
   });
 
-  get('/status').then(d => {
-    document.getElementById('status-v').innerHTML =
-      '<span style="color:var(--' + (d.overall === 'green' ? 'auth-main' : d.overall === 'yellow' ? 'wall-main' : 'auth-main') + ')">'
-      + (d.overall || 'unknown').toUpperCase() + '</span>';
-  }).catch(() => {
-    document.getElementById('status-v').textContent = 'unavailable';
-  });
+  get('/components').then(function (d) {
+    var list = (d.components || []).map(function (c) { return '<div>' + c.name + ': <strong>' + c.state + '</strong></div>'; }).join('');
+    document.getElementById('components-v').innerHTML = list || '<span style="color:var(--muted)">no components</span>';
+  }).catch(function () { document.getElementById('components-v').innerHTML = '<span style="color:var(--muted)">unavailable</span>'; });
 
-  get('/access').then(d => {
-    document.getElementById('access-v').innerHTML =
-      (d.access || []).map(a => '<div>' + a.scope + ': <a href="' + a.url + '">' + a.url + '</a></div>').join('');
-  }).catch(() => {
-    document.getElementById('access-v').textContent = 'unavailable';
-  });
+  get('/access').then(function (d) {
+    var rules    = (d.rules || d.access_rules || []);
+    var cookies  = (d.cookies || d.session_cookies || []);
+    var users    = (d.users != null) ? d.users : (d.user_count != null ? d.user_count : '?');
+    document.getElementById('stat-users').textContent = String(users);
+    document.getElementById('stat-cookies').textContent = String(cookies.length || '?');
+    document.getElementById('stat-cookies-sub').textContent = cookies.map(function (c) { return c.domain || c; }).join(', ') || 'session.cookies[]';
+    document.getElementById('stat-rules').textContent = String(rules.length || '?');
 
-  document.getElementById('open-native').addEventListener('click', e => {
-    e.preventDefault();
-    window.location.href = '/authelia/';
+    var v = (d.access || []).map(function (a) { return '<div>' + (a.scope || '') + ': <a href="' + (a.url || '#') + '">' + (a.url || '?') + '</a></div>'; }).join('');
+    document.getElementById('access-v').innerHTML = v || '<span style="color:var(--muted)">no access points</span>';
+  }).catch(function () {
+    document.getElementById('access-v').innerHTML = '<span style="color:var(--muted)">unavailable</span>';
   });
 })();
 </script>

--- a/packages/secubox-lyrion/debian/changelog
+++ b/packages/secubox-lyrion/debian/changelog
@@ -1,3 +1,11 @@
+secubox-lyrion (1.0.9-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/lyrion-vhost.conf: @sbx_auth_login redirects to
+    https://sso.gk2.secubox.in/?rd=… (was admin.gk2.secubox.in/auth/).
+    Follow-up to the SSO portal split (#310).
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 12:30:00 +0000
+
 secubox-lyrion (1.0.8-1~bookworm1) bookworm; urgency=medium
 
   * nginx/lyrion-vhost.conf: move public vhost from lyrion.maegia.tv to

--- a/packages/secubox-lyrion/nginx/lyrion-vhost.conf
+++ b/packages/secubox-lyrion/nginx/lyrion-vhost.conf
@@ -110,7 +110,7 @@ server {
     # parent .gk2.secubox.in → authelia_session cookie is shared with
     # the portal vhost (session.cookies[] per #272).
     location @sbx_auth_login {
-        return 302 https://admin.gk2.secubox.in/auth/?rd=https://$host$request_uri;
+        return 302 https://sso.gk2.secubox.in/?rd=https://$host$request_uri;
     }
 
     # Internal auth_request target — re-declared per server-block scope.

--- a/packages/secubox-nextcloud/debian/changelog
+++ b/packages/secubox-nextcloud/debian/changelog
@@ -1,3 +1,12 @@
+secubox-nextcloud (1.3.3-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/nextcloud-vhost.conf: @sbx_auth_login redirects to
+    https://sso.gk2.secubox.in/?rd=… (was admin.gk2.secubox.in/auth/).
+    Follow-up to the SSO portal split (#310). The cookie scope
+    .gk2.secubox.in (#272) already covers the new portal vhost.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 12:30:00 +0000
+
 secubox-nextcloud (1.3.2-1~bookworm1) bookworm; urgency=medium
 
   * conf/nextcloud.toml.example (new): operator-facing config template

--- a/packages/secubox-nextcloud/nginx/nextcloud-vhost.conf
+++ b/packages/secubox-nextcloud/nginx/nextcloud-vhost.conf
@@ -69,7 +69,7 @@ server {
     # parent .gk2.secubox.in → authelia_session cookie is shared with
     # the portal vhost (session.cookies[] per #272).
     location @sbx_auth_login {
-        return 302 https://admin.gk2.secubox.in/auth/?rd=https://$host$request_uri;
+        return 302 https://sso.gk2.secubox.in/?rd=https://$host$request_uri;
     }
 
     # Internal auth_request target — re-declared per server-block scope.

--- a/packages/secubox-zigbee/debian/changelog
+++ b/packages/secubox-zigbee/debian/changelog
@@ -1,3 +1,11 @@
+secubox-zigbee (2.5.4-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/zigbee-vhost.conf: @sbx_auth_login redirects to
+    https://sso.gk2.secubox.in/?rd=… (was admin.gk2.secubox.in/auth/).
+    Follow-up to the SSO portal split (#310).
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 12:30:00 +0000
+
 secubox-zigbee (2.5.3-1~bookworm1) bookworm; urgency=medium
 
   * www/zigbee/index.html: rewrite using the canonical SecuBox webui

--- a/packages/secubox-zigbee/nginx/zigbee-vhost.conf
+++ b/packages/secubox-zigbee/nginx/zigbee-vhost.conf
@@ -73,7 +73,7 @@ server {
     # parent .gk2.secubox.in → authelia_session cookie covers this vhost
     # (session.cookies[] per #272).
     location @sbx_auth_login {
-        return 302 https://admin.gk2.secubox.in/auth/?rd=https://$host$request_uri;
+        return 302 https://sso.gk2.secubox.in/?rd=https://$host$request_uri;
     }
 
     # Internal auth_request target — re-declared per server-block scope.


### PR DESCRIPTION
Split /auth/ (canonical hub) into operator dashboard, move portal to new public vhost sso.gk2.secubox.in. Sibling vhosts (nextcloud/zigbee/lyrion) redirect to the new portal. Authelia install-lxc.sh updated. Operator follow-up: DNS + mitmproxy route + haproxyctl vhost + LXC config re-render.