### PR TITLE
fix(auth): icon 🛂 → 🎯 per charter (AUTH = hexagonal target)

### DIFF
--- a/packages/secubox-authelia/www/authelia/index.html
+++ b/packages/secubox-authelia/www/authelia/index.html
@@ -80,7 +80,7 @@
 
 <main class="main">
   <div class="header">
-    <h1><span class="icon">🛂</span> Auth — SSO control</h1>
+    <h1><span class="icon">🎯</span> Auth — SSO control</h1>
     <div class="header-actions">
       <a class="btn" href="/" title="Back to SecuBox hub">← hub</a>
       <a class="btn primary" href="https://sso.gk2.secubox.in/" title="Open the Authelia SSO portal (login surface)">Open SSO Portal →</a>

--- a/packages/secubox-hub/api/main.py
+++ b/packages/secubox-hub/api/main.py
@@ -1750,7 +1750,7 @@ CATEGORY_META = {
     # Every menu.d entry MUST set `category` to one of these six. The
     # ordering mirrors the charter's complementary-pair sequence:
     # AUTH/WALL/BOOT then their counterparts MIND/ROOT/MESH.
-    "auth": {"name": "Auth", "icon": "🛂", "order": 0, "color": "#C04E24"},
+    "auth": {"name": "Auth", "icon": "🎯", "order": 0, "color": "#C04E24"},
     "wall": {"name": "Wall", "icon": "🛡️", "order": 1, "color": "#9A6010"},
     "boot": {"name": "Boot", "icon": "🚀", "order": 2, "color": "#803018"},
     "mind": {"name": "Mind", "icon": "🧠", "order": 3, "color": "#3D35A0"},


### PR DESCRIPTION
Charter §Module Icons/Symbols: AUTH = Hexagonal target → use 🎯. Was 🛂 (passport control) which didn't fit.