### PR TITLE
fix(secubox-core): v1.1.3 — nftables.service tolerates built-in nf_nat modules (closes #150 nftables half)

### DIFF
--- a/packages/secubox-core/debian/changelog
+++ b/packages/secubox-core/debian/changelog
@@ -1,3 +1,17 @@
+secubox-core (1.1.3-1~bookworm1) bookworm; urgency=medium
+
+  * Ship /etc/systemd/system/nftables.service.d/override.conf so that
+    `modprobe nf_conntrack / nf_nat / nft_chain_nat` are non-fatal in
+    the nftables.service ExecStartPre. The MOCHAbin custom kernel
+    (6.12.85-secubox-cybermind) builds these as `=y` not `=m`, so
+    modprobe exits 1 with no .ko file on disk — systemd then kills
+    the unit before ExecStart can load the rules. Every reboot
+    therefore lost all SecuBox DNAT/MASQUERADE rules: lyrion slimproto
+    :3483 (Squeezelite players), mqtt forwards, lxc masquerade.
+    Closes the nftables half of #150.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 14:00:00 +0000
+
 secubox-core (1.1.2-1~bookworm1) bookworm; urgency=medium
 
   * postinst: gate /etc/nginx/sites-available/secubox install on first install

--- a/packages/secubox-core/debian/rules
+++ b/packages/secubox-core/debian/rules
@@ -36,6 +36,12 @@ override_dh_auto_install:
 	               debian/secubox-core/usr/lib/systemd/system/
 	install -m 644 systemd/secubox-runtime.service \
 	               debian/secubox-core/usr/lib/systemd/system/
+	# Drop-in override for nftables.service: tolerate missing nf_nat /
+	# nft_chain_nat kernel modules when those are BUILT-IN on the MOCHAbin
+	# custom kernel (#150 + lyrion-slimproto-after-reboot).
+	install -d debian/secubox-core/etc/systemd/system/nftables.service.d
+	install -m 644 systemd/nftables.service.d/override.conf \
+	               debian/secubox-core/etc/systemd/system/nftables.service.d/override.conf
 	# Create modular nginx directory (modules install their snippets here)
 	install -d debian/secubox-core/etc/nginx/secubox.d
 

--- a/packages/secubox-core/systemd/nftables.service.d/override.conf
+++ b/packages/secubox-core/systemd/nftables.service.d/override.conf
@@ -1,0 +1,17 @@
+# /etc/systemd/system/nftables.service.d/override.conf — installed by
+# secubox-core. On the MOCHAbin custom kernel (6.12.85-secubox-cybermind)
+# CONFIG_NF_NAT=y / CONFIG_NF_CONNTRACK=y / CONFIG_NFT_CHAIN_NAT=y are
+# BUILT-IN, not modular. The stock nftables.service ExecStartPre runs
+# `modprobe nf_nat` etc. which exit 1 when the module file isn't on disk —
+# systemd then kills the unit before ExecStart can load the rules.
+#
+# Symptom: every reboot loses all SecuBox DNAT/MASQUERADE rules (lyrion
+# slimproto :3483, mqtt forwards, lxc masquerade), Squeezelite players
+# can't reach LMS, etc. Tracked as #150 (lyrion :3483 LAN-direct subset).
+#
+# Fix: swallow the modprobe exit code so the built-in path still works.
+[Service]
+ExecStartPre=
+ExecStartPre=/bin/sh -c "modprobe nf_conntrack 2>/dev/null || true"
+ExecStartPre=/bin/sh -c "modprobe nf_nat 2>/dev/null || true"
+ExecStartPre=/bin/sh -c "modprobe nft_chain_nat 2>/dev/null || true"


### PR DESCRIPTION
MOCHAbin kernel has nf_nat etc. built-in; modprobe fails non-zero → systemd kills the unit → DNAT/MASQ rules lost on boot. Drop-in tolerates modprobe failures.