### PR TITLE
fix(secubox-core): v1.1.4 — secubox-runtime defers /run/secubox perms to tmpfiles.d (closes #151)

### DIFF
--- a/packages/secubox-core/debian/changelog
+++ b/packages/secubox-core/debian/changelog
@@ -1,3 +1,16 @@
+secubox-core (1.1.4-1~bookworm1) bookworm; urgency=medium
+
+  * systemd/secubox-runtime.service: stop fighting tmpfiles.d. The old
+    ExecStart sequence ran `mkdir + chown secubox:secubox + chmod 775`
+    on /run/secubox AFTER tmpfiles.d had already created it `1777
+    root:root`. Result on every reboot: /run/secubox loses world +x,
+    nginx workers can't reach the secubox-*.sock files, EVERY upstream
+    returns 502 (#151 + observed post-freeze on 2026-05-21). New unit
+    only re-applies the canonical tmpfiles rule and ordered After=
+    systemd-tmpfiles-setup.service. Closes #151.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Thu, 21 May 2026 14:55:00 +0000
+
 secubox-core (1.1.3-1~bookworm1) bookworm; urgency=medium
 
   * Ship /etc/systemd/system/nftables.service.d/override.conf so that

--- a/packages/secubox-core/systemd/secubox-runtime.service
+++ b/packages/secubox-core/systemd/secubox-runtime.service
@@ -1,15 +1,22 @@
 [Unit]
-Description=SecuBox Runtime Directory Setup
+Description=SecuBox Runtime Directory Setup (defers perms to tmpfiles.d)
 DefaultDependencies=no
 Before=secubox-hub.service secubox-portal.service secubox-p2p.service
-After=local-fs.target
+After=systemd-tmpfiles-setup.service local-fs.target
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+# #151 + post-reboot freeze: the previous version chown'd /run/secubox to
+# secubox:secubox mode 775, which conflicts with the canonical tmpfiles.d
+# rule (`d /run/secubox 1777 root root -`). With 775 secubox:secubox the
+# other user (nginx / www-data) loses +x on the parent and can't reach the
+# socket files inside — every secubox-* upstream becomes a 502.
+#
+# Keep the directory-create as a safety net for boards whose tmpfiles
+# hasn't fired yet, then re-apply the canonical tmpfiles rule. NO chown.
 ExecStart=/bin/mkdir -p /run/secubox
-ExecStart=/bin/chown secubox:secubox /run/secubox
-ExecStart=/bin/chmod 775 /run/secubox
+ExecStart=/usr/bin/systemd-tmpfiles --create /usr/lib/tmpfiles.d/secubox.conf
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Stop fighting tmpfiles.d. Old ExecStart chmod 775 secubox:secubox blocked nginx from traversing /run/secubox, every secubox-*.sock returned 502 post-reboot.