### PR TITLE
fix(kernel-build): assert CONFIG_ZRAM_DEF_COMP_ZSTD not the auto-derived string

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -74,7 +74,11 @@ jobs:
           # Sanity-check key configs landed.
           grep -q "CONFIG_LEDS_IS31FL319X=m" .config || (echo "FAIL: LED module missing" && exit 1)
           grep -q "CONFIG_ZRAM=m" .config           || (echo "FAIL: ZRAM module missing" && exit 1)
-          grep -q "CONFIG_ZRAM_DEF_COMP=\"zstd\"" .config || (echo "FAIL: ZRAM zstd default missing" && exit 1)
+          # CONFIG_ZRAM_DEF_COMP_ZSTD is the *choice* we set in the fragment;
+          # CONFIG_ZRAM_DEF_COMP="zstd" is the auto-derived string and may or
+          # may not be emitted depending on kconfig's choice handling — check
+          # the source-of-truth symbol instead.
+          grep -q "^CONFIG_ZRAM_DEF_COMP_ZSTD=y" .config || (echo "FAIL: ZRAM zstd default missing" && exit 1)
 
       - name: Build kernel .deb (bindeb-pkg)
         run: |

--- a/board/mochabin/kernel/config-6.12.85-secubox-zram.fragment
+++ b/board/mochabin/kernel/config-6.12.85-secubox-zram.fragment
@@ -14,7 +14,9 @@ CONFIG_ZRAM=m
 # Default compressor at /sys/block/zram0/comp_algorithm initial value.
 # zstd gives the best ratio at acceptable CPU cost on Armada 7040.
 CONFIG_ZRAM_DEF_COMP_ZSTD=y
-CONFIG_ZRAM_DEF_COMP="zstd"
+# CONFIG_ZRAM_DEF_COMP is auto-derived by kconfig from the choice above;
+# do not set it explicitly here — merge_config.sh handles it as a generic
+# overlay and the resulting .config has the right value either way.
 # Multi-comp slots so userspace can switch compressors on the fly.
 CONFIG_ZRAM_MULTI_COMP=y
 # Writeback to a backing block device — kept off; pure RAM only.


### PR DESCRIPTION
Build sanity check looked for the auto-derived CONFIG_ZRAM_DEF_COMP="zstd" which kconfig may not emit verbatim. Check the choice symbol CONFIG_ZRAM_DEF_COMP_ZSTD=y instead.