### PR TITLE
fix(secubox-dns-provider): v1.0.3 — dismiss modal on save, toast probe verdict (closes #304)

### DIFF
--- a/packages/secubox-dns-provider/debian/changelog
+++ b/packages/secubox-dns-provider/debian/changelog
@@ -1,3 +1,14 @@
+secubox-dns-provider (1.0.3-1~bookworm1) bookworm; urgency=medium
+
+  * www/dns-provider/index.html: dismiss the Add-Provider modal as
+    soon as the POST succeeds; surface the upstream /domains probe
+    verdict as a non-modal toast that auto-dismisses after 6s.
+    Previously the modal stayed open on a yellow probe-warning even
+    after the underlying issue got resolved, so the operator saw a
+    stale message contradicting the providers list. Closes #304.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Fri, 22 May 2026 04:55:00 +0000
+
 secubox-dns-provider (1.0.2-1~bookworm1) bookworm; urgency=medium
 
   * www/dns-provider/index.html: bump .modal z-index 100 → 1500. The

--- a/packages/secubox-dns-provider/www/dns-provider/index.html
+++ b/packages/secubox-dns-provider/www/dns-provider/index.html
@@ -835,43 +835,62 @@
             }
 
             const id = r.data.id;
-            stat.textContent = 'Saved. Probing ' + type + '…';
-            stat.style.color = 'var(--text-dim)';
-
-            // Probe the new credentials against /domains to confirm the key
-            // actually works upstream. Hide the modal either way; surface a
-            // toast / inline note so the operator sees the verdict.
-            const probe = await apiStrict('/domains?provider_id=' + encodeURIComponent(id));
+            // #304: provider is persisted — close the modal IMMEDIATELY and
+            // surface the probe verdict as a non-modal toast. The previous
+            // behaviour kept the modal open on a yellow warning even when
+            // the underlying issue (e.g. outbound down) got resolved, so the
+            // operator saw a stale message contradicting the providers list.
             btn.disabled = false;
             btn.textContent = origLabel;
+            hideModal('provider-modal');
+            document.getElementById('provider-name').value = '';
+            stat.textContent = '';
+            refresh();
 
-            if (!probe.ok) {
-                stat.textContent = '⚠ Saved, but /domains probe failed: ' + (probe.error || probe.status);
-                stat.style.color = 'var(--yellow, #ffb347)';
-            } else {
+            // Background probe — even a slow Gandi response can't block the
+            // modal close anymore.
+            (async () => {
+                const probe = await apiStrict('/domains?provider_id=' + encodeURIComponent(id));
+                if (!probe.ok) {
+                    showToast('warn', 'Saved, /domains probe failed: ' + (probe.error || probe.status));
+                    return;
+                }
                 const domains = (probe.data.domains || []).filter(d => !d.error);
                 const errored = (probe.data.domains || []).filter(d => d.error);
                 if (errored.length) {
-                    stat.innerHTML = '⚠ Saved, but provider returned an error: <code>' +
-                        (errored[0].error || 'unknown') + '</code>. Check key scope / format.';
-                    stat.style.color = 'var(--yellow, #ffb347)';
+                    showToast('warn', 'Saved, but ' + type + ' returned: ' + (errored[0].error || 'unknown') + '. Check key scope.');
                 } else if (domains.length === 0) {
-                    stat.textContent = '⚠ Saved. Authenticated to ' + type + ' but no domains visible — check API token scope.';
-                    stat.style.color = 'var(--yellow, #ffb347)';
+                    showToast('warn', 'Saved. Authenticated to ' + type + ' but no domains visible — check API token scope.');
                 } else {
-                    stat.textContent = '✓ Saved. ' + domains.length + ' domain(s) visible. Closing…';
-                    stat.style.color = 'var(--green, #00dd44)';
-                    setTimeout(() => {
-                        hideModal('provider-modal');
-                        document.getElementById('provider-name').value = '';
-                        stat.textContent = '';
-                        refresh();
-                    }, 900);
-                    return;
+                    showToast('ok', '✓ ' + name + ': ' + domains.length + ' domain(s) visible.');
                 }
+                refresh();
+            })();
+        }
+
+        // #304 — simple toast, auto-dismiss 6s, no extra deps.
+        function showToast(kind, message) {
+            let host = document.getElementById('sbx-toast-host');
+            if (!host) {
+                host = document.createElement('div');
+                host.id = 'sbx-toast-host';
+                host.style.cssText = 'position:fixed;top:80px;right:24px;z-index:2000;display:flex;flex-direction:column;gap:0.5rem;max-width:420px;';
+                document.body.appendChild(host);
             }
-            // Non-fatal warning paths still refresh + leave modal open.
-            refresh();
+            const t = document.createElement('div');
+            const palette = kind === 'ok'
+                ? 'background:rgba(0,221,68,0.12);border:1px solid #00dd44;color:#00dd44;'
+                : kind === 'warn'
+                ? 'background:rgba(255,179,71,0.12);border:1px solid #ffb347;color:#ffb347;'
+                : 'background:rgba(255,68,102,0.12);border:1px solid #ff4466;color:#ff4466;';
+            t.style.cssText = 'padding:0.6rem 1rem;border-radius:6px;font-family:JetBrains Mono,monospace;font-size:0.85rem;opacity:0;transition:opacity 0.2s;' + palette;
+            t.textContent = message;
+            host.appendChild(t);
+            requestAnimationFrame(() => { t.style.opacity = '1'; });
+            setTimeout(() => {
+                t.style.opacity = '0';
+                setTimeout(() => t.remove(), 250);
+            }, 6000);
         }
 
         async function toggleProvider(id, enabled) {


### PR DESCRIPTION
## Summary
- Dismiss the Add-Provider modal **immediately** on POST success — the provider is already persisted at that point.
- Move the upstream `/domains` probe to the background and surface its verdict as a **non-modal toast** that auto-dismisses after 6s.
- Drop the in-modal yellow warning that could go stale (operator saw an old warning while the providers list already showed the new entry).

## Why
After #299 fixed silent failures and #301 fixed the modal being hidden behind the global menu bar, the remaining UX bug (#304) was the stale warning: when the credential test was slow or transient, the modal kept showing yellow text long after the provider was saved and listed. Operators reported the warning contradicting what the table already showed.

## Files
- `packages/secubox-dns-provider/www/dns-provider/index.html` — modal close + `showToast()` helper
- `packages/secubox-dns-provider/debian/changelog` — bump to 1.0.3-1~bookworm1

## Test plan
- [x] dev rebuild + scp index.html to gk2
- [ ] add Gandi provider on gk2, confirm modal closes immediately, green toast appears 6s
- [ ] add a deliberately bad provider, confirm yellow toast appears 6s, modal still closed

Closes #304.