### PR TITLE
fix(secubox-metablogizer): v1.2.1 — uvicorn --log-level info (closes #119)

### DIFF
--- a/packages/secubox-metablogizer/debian/changelog
+++ b/packages/secubox-metablogizer/debian/changelog
@@ -1,3 +1,14 @@
+secubox-metablogizer (1.2.1-1~bookworm1) bookworm; urgency=medium
+
+  * debian/secubox-metablogizer.service: lower uvicorn --log-level from
+    warning to info so the webhook deploy success line
+    `logger.info("deploy site=…")` reaches journald. Previously only
+    error paths were visible, making successful auto-deploys silent.
+    The 8 info-level log sites in api/main.py are all event-driven
+    (startup + webhook + sync) — no flood concern. Closes #119.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Fri, 22 May 2026 05:10:00 +0000
+
 secubox-metablogizer (1.2.0-1~bookworm1) bookworm; urgency=medium
 
   * metablogizerctl site publish: new --public-domain <fqdn> flag.

--- a/packages/secubox-metablogizer/debian/secubox-metablogizer.service
+++ b/packages/secubox-metablogizer/debian/secubox-metablogizer.service
@@ -8,7 +8,7 @@ Type=simple
 User=secubox
 Group=secubox
 WorkingDirectory=/usr/lib/secubox/metablogizer
-ExecStart=/usr/bin/python3 -m uvicorn api.main:app --uds /run/secubox/metablogizer.sock --log-level warning
+ExecStart=/usr/bin/python3 -m uvicorn api.main:app --uds /run/secubox/metablogizer.sock --log-level info
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## Summary
Lower uvicorn's `--log-level` from `warning` to `info` in `secubox-metablogizer.service` so the webhook deploy success line surfaces in journald.

## Why
`logger.info("deploy site=… from=… to=… duration_ms=… domain_changed=…")` at `api/main.py:779` only fires on success — but `--log-level warning` swallows it. Operators reported they could only see deploy *failures* in `journalctl -u secubox-metablogizer`, not the successful auto-deploys that come through the Gitea webhook. This is the symptom #119 describes.

## Noise check
`grep -nE "logger\.info" api/main.py` → 8 sites, all event-driven (startup auto-publish, mitmproxy route sync, webhook skip/unknown/no-git-dir/deploy). None of them poll or fire on a timer, so info-level can't flood journald.

## Files
- `packages/secubox-metablogizer/debian/secubox-metablogizer.service` — `--log-level warning` → `info`
- `packages/secubox-metablogizer/debian/changelog` — bump to 1.2.1-1~bookworm1

## Test plan
- [ ] rebuild .deb, install on gk2
- [ ] push to a metablog-* repo in Gitea, watch `journalctl -u secubox-metablogizer -f`
- [ ] confirm `deploy site=… from=… to=… duration_ms=… domain_changed=…` appears
- [ ] confirm no obvious info-level flood after 1h idle

Closes #119.