### PR TITLE
fix(build-live-usb): default --iface en*, skip net-detect on static images (closes #128)

### DIFF
--- a/image/build-live-usb.sh
+++ b/image/build-live-usb.sh
@@ -37,7 +37,10 @@ OVERLAY_MODE=0
 STATIC_IP=""
 STATIC_GATEWAY=""
 STATIC_DNS=""
-STATIC_IFACE="eth0"
+# Default to the modern predictable-name wildcard (enp*, eno*, ens*, enx*).
+# Literal "eth0" is the exception on Debian + systemd-udev — almost no
+# modern hardware enumerates the primary NIC as eth0. See #128.
+STATIC_IFACE="en*"
 STATIC_HOSTNAME=""
 
 RED='\033[0;31m'; CYAN='\033[0;36m'; GOLD='\033[0;33m'
@@ -69,7 +72,10 @@ Usage: sudo bash build-live-usb.sh [OPTIONS]
                      secubox-net-detect; writes a static netplan instead.
   --gateway IP       Default gateway (required when --static-ip is set)
   --dns LIST         DNS servers, comma-separated (default: gateway)
-  --iface NAME       Netplan match name for the static iface (default: eth0)
+  --iface NAME       Netplan match name for the static iface. Supports
+                     shell-style globs (default: en* — matches enp*,
+                     eno*, ens*, enx*). Use a literal name only when
+                     you know systemd-udev hasn't renamed the NIC.
   --hostname NAME    Hostname baked into the image (default: secubox-live)
   --help             Show this help
 

--- a/image/firstboot.sh
+++ b/image/firstboot.sh
@@ -375,7 +375,13 @@ fi
 
 # ── 11. Network Auto-Detection ──────────────────────────────────
 log "=== Network Detection ==="
-if [[ -x /usr/sbin/secubox-net-detect ]]; then
+# Short-circuit when the image was built with --static-ip: build-live-usb.sh
+# wrote a fixed netplan AND pre-touched /var/lib/secubox/.net-configured.
+# Running net-detect here would clobber the static config with router-mode
+# defaults (WAN + br-lan 192.168.1.1/24), the exact regression in #128.
+if [[ -f /var/lib/secubox/.net-configured ]]; then
+  log "Static netplan in effect (.net-configured present) — skipping net-detect"
+elif [[ -x /usr/sbin/secubox-net-detect ]]; then
   # Run detection
   /usr/sbin/secubox-net-detect detect /run/secubox/net-detect.json
 


### PR DESCRIPTION
## Summary
Two regressions when `--static-ip` is used:

1. **`--iface eth0` matched nothing on modern Debian.** Reporter's kiosk booted with link-local 169.254.x.x on `enp0s31f6` because the static netplan's `match: name: "eth0"` was inert.
2. **`br-lan` stanza came up with 192.168.1.1/24 anyway.** Even though `build-live-usb.sh` pre-touches `/var/lib/secubox/.net-configured` to gate the systemd `secubox-net-detect.service`, `firstboot.sh:378` runs `secubox-net-detect apply router` directly, ignoring the marker. That re-injects the router-mode bootstrap and clobbers the static config.

## Fix
- `image/build-live-usb.sh`: default `STATIC_IFACE` from `eth0` → `en*` (matches `enp*`, `eno*`, `ens*`, `enx*`). Update `--help` to document glob semantics.
- `image/firstboot.sh`: gate the inline net-detect block on `! -f /var/lib/secubox/.net-configured`. When the marker is present, log and skip — the systemd unit already does this.

## Test plan
- [ ] Rebuild image with `--static-ip 192.168.1.50/24 --gateway 192.168.1.254`
- [ ] Flash, boot — verify `ip a` shows the static IP on `enp*` and **no** br-lan with 192.168.1.1/24
- [ ] Verify `journalctl -b -u secubox-firstboot` shows `Static netplan in effect (.net-configured present) — skipping net-detect`

Closes #128.