### PR TITLE
fix(secubox-zigbee): v2.5.5 — bind /dev/ttyUSB0+ttyACM0 into LXC, udev hotplug (closes prod 502)

### DIFF
--- a/packages/secubox-zigbee/debian/changelog
+++ b/packages/secubox-zigbee/debian/changelog
@@ -1,3 +1,22 @@
+secubox-zigbee (2.5.5-1~bookworm1) bookworm; urgency=medium
+
+  * lib/zigbee/install-lxc.sh: bind /dev/ttyUSB0 and /dev/ttyACM0 into
+    the zigbee LXC. The existing config bound /dev/secubox-zgb and
+    /dev/serial/by-id (symlinks) plus cgroup major 188/166, but the
+    underlying tty device NODES were not bind-mounted — so the kernel
+    followed the symlinks inside the container and the open(2) failed
+    with ENOENT. zigbee2mqtt crash-looped 4500+ times on gk2 today;
+    https://zigbee.gk2.secubox.in/ returned 502 because port 8080 in
+    the LXC was never opened.
+  * lib/zigbee/install-lxc.sh: udev rule now emits a RUN+= that calls
+    `lxc-device add zigbee /dev/<kernel>` on hotplug, so re-plugging
+    the dongle while the LXC is running pushes the new device node
+    in immediately instead of waiting for an LXC restart.
+  * Bumps v2.4.2 hardware fixes back into the install path. Closes the
+    https://zigbee.gk2.secubox.in/ 502 reported in chat.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Fri, 22 May 2026 05:30:00 +0000
+
 secubox-zigbee (2.5.4-1~bookworm1) bookworm; urgency=medium
 
   * nginx/zigbee-vhost.conf: @sbx_auth_login redirects to

--- a/packages/secubox-zigbee/lib/zigbee/install-lxc.sh
+++ b/packages/secubox-zigbee/lib/zigbee/install-lxc.sh
@@ -120,6 +120,14 @@ lxc.mount.entry = /dev/secubox-zgb dev/secubox-zgb none bind,create=file,optiona
 # Without this, the configuration.yaml port: must be the bare /dev/secubox-zgb
 # AND z2m must match by USB VID/PID alone — which v2.10+ doesn't always do.
 lxc.mount.entry = /dev/serial/by-id dev/serial/by-id none bind,create=dir,optional 0 0
+# CRITICAL: bind the actual /dev/tty{USB,ACM}* device nodes. The symlinks in
+# /dev/secubox-zgb and /dev/serial/by-id all *resolve* to /dev/ttyUSB0 or
+# /dev/ttyACM0 — if those nodes don't exist inside the container, z2m opens
+# the symlink, the kernel follows it, and the open(2) fails with ENOENT and
+# z2m crash-loops (4500+ restarts observed in the wild). The `optional`
+# flag means the LXC still starts when the dongle is unplugged.
+lxc.mount.entry = /dev/ttyUSB0 dev/ttyUSB0 none bind,create=file,optional 0 0
+lxc.mount.entry = /dev/ttyACM0 dev/ttyACM0 none bind,create=file,optional 0 0
 lxc.cgroup2.devices.allow = c 188:* rwm
 lxc.cgroup2.devices.allow = c 166:* rwm
 EOF
@@ -336,23 +344,42 @@ install_udev_rule() {
     log "Installing udev rule for Zigbee dongles ..."
     cat > "$rule_file" <<'UDEV'
 # /etc/udev/rules.d/99-secubox-zigbee.rules
-# Installed by secubox-zigbee (#241, updated v2.4.1 for SONOFF MG21).
+# Installed by secubox-zigbee (#241, updated v2.4.2 for hotplug → LXC).
 # Order matters: ATTRS{product} filter MUST come before the generic CP210x
 # rule below, otherwise the SONOFF MG21 would land as -alt and z2m's adapter
 # discovery wouldn't pick it up.
+#
+# What the SYMLINK lines do:
+#   * Create /dev/secubox-zgb pointing at the zigbee radio kernel device.
+#   * The LXC config bind-mounts BOTH /dev/secubox-zgb AND the underlying
+#     /dev/ttyUSB0 / /dev/ttyACM0 nodes, so the symlinks actually resolve
+#     to a real device inside the container.
+#
+# What the RUN line does (NEW in v2.4.2):
+#   * On a hotplug event (dongle re-inserted after the LXC was already
+#     running), `lxc-device add zigbee /dev/<kernel>` pushes the device
+#     node into the running container AND adds the cgroup permission.
+#     Without this, a replugged dongle stays invisible inside the LXC
+#     until the container restarts — which is the failure mode that
+#     produced 4500+ crash-loop restarts of zigbee2mqtt on gk2.
+#   * `|| true` keeps udev's overall ruleset healthy when the LXC is
+#     stopped (lxc-device exits non-zero in that case).
 
 # SONOFF Dongle Lite MG21 (Silicon Labs EFR32MG21 behind a CP210x bridge)
 SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", \
     ATTRS{product}=="SONOFF Dongle Lite MG21", \
-    SYMLINK+="secubox-zgb", MODE="0660", GROUP="dialout"
+    SYMLINK+="secubox-zgb", MODE="0660", GROUP="dialout", \
+    RUN+="/bin/sh -c '/usr/bin/lxc-device add zigbee /dev/%k || true'"
 
 # Sonoff Zigbee 3.0 USB Plus (CC2652P)
 SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="55d4", \
-    SYMLINK+="secubox-zgb", MODE="0660", GROUP="dialout"
+    SYMLINK+="secubox-zgb", MODE="0660", GROUP="dialout", \
+    RUN+="/bin/sh -c '/usr/bin/lxc-device add zigbee /dev/%k || true'"
 
 # ConBee II (fallback)
 SUBSYSTEM=="tty", ATTRS{idVendor}=="1cf1", ATTRS{idProduct}=="0030", \
-    SYMLINK+="secubox-zgb", MODE="0660", GROUP="dialout"
+    SYMLINK+="secubox-zgb", MODE="0660", GROUP="dialout", \
+    RUN+="/bin/sh -c '/usr/bin/lxc-device add zigbee /dev/%k || true'"
 
 # Generic CP210x without the SONOFF descriptor — secondary symlink only
 SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", \


### PR DESCRIPTION
## Symptom (chat report)
\`https://zigbee.gk2.secubox.in/\` → 502. zigbee2mqtt inside the \`zigbee\` LXC crash-looped 4528+ times. Port 8080 in the LXC never opened.

## Root cause
The LXC config bound \`/dev/secubox-zgb\` and \`/dev/serial/by-id\` (both **symlinks**) plus cgroup major 188/166 — but the underlying \`/dev/ttyUSB0\` device node was never bind-mounted into the container.

\`\`\`
Host:  /dev/secubox-zgb -> ttyUSB0   ← symlink, bind-mounted
       /dev/ttyUSB0                  ← real device, NOT bind-mounted
LXC:   /dev/secubox-zgb -> ttyUSB0   ← symlink resolves to nothing
       open("/dev/secubox-zgb") -> ENOENT -> z2m crash
\`\`\`

## Fix
1. **\`install-lxc.sh\`** — add two new bind entries with the \`optional\` flag so the LXC starts even when the dongle is absent:

   \`\`\`
   lxc.mount.entry = /dev/ttyUSB0 dev/ttyUSB0 none bind,create=file,optional 0 0
   lxc.mount.entry = /dev/ttyACM0 dev/ttyACM0 none bind,create=file,optional 0 0
   \`\`\`

2. **udev rule** gains \`RUN+="/bin/sh -c '/usr/bin/lxc-device add zigbee /dev/%k || true'"\` on every Zigbee-dongle match. A re-plugged dongle now lands in the running container immediately instead of waiting for an LXC restart.

## Files
- \`packages/secubox-zigbee/lib/zigbee/install-lxc.sh\`
- \`packages/secubox-zigbee/debian/changelog\` — bump 2.5.4 → 2.5.5

## Live-board recovery (separate, manual)
The deployed \`/data/lxc/zigbee/config\` was written by an older install-lxc.sh and needs the same two bind entries. Operator runs (under user authorization):

\`\`\`bash
ssh root@192.168.1.200 'sed -i "/c 166:\\\* rwm/a\\\\nlxc.mount.entry = /dev/ttyUSB0 dev/ttyUSB0 none bind,create=file,optional 0 0\\nlxc.mount.entry = /dev/ttyACM0 dev/ttyACM0 none bind,create=file,optional 0 0" /data/lxc/zigbee/config && lxc-device add zigbee /dev/ttyUSB0 && lxc-attach -n zigbee -- systemctl restart zigbee2mqtt'
\`\`\`

## Test plan
- [ ] Build & install on gk2; verify \`lxc-attach -n zigbee -- ls -la /dev/ttyUSB0\` returns a char device
- [ ] Verify \`lxc-attach -n zigbee -- systemctl is-active zigbee2mqtt\` returns \`active\` (not \`activating\`)
- [ ] Verify \`curl -sk -I -H 'Host: zigbee.gk2.secubox.in' http://127.0.0.1/\` → 302 to SSO and after auth → 200
- [ ] Unplug+replug the dongle; verify the running LXC still sees it without restart

Closes #zigbee-prod-502.