### PR TITLE
fix(secubox-zigbee): v2.5.6 — ExecStartPre chmod 0666 on /dev/tty{USB,ACM}0 (follow-up to v2.5.5)

### DIFF
--- a/packages/secubox-zigbee/debian/changelog
+++ b/packages/secubox-zigbee/debian/changelog
@@ -1,3 +1,18 @@
+secubox-zigbee (2.5.6-1~bookworm1) bookworm; urgency=medium
+
+  * lib/zigbee/install-lxc.sh: zigbee2mqtt.service gains two
+    ExecStartPre `chmod 0666` lines for /dev/ttyUSB0 and /dev/ttyACM0.
+    Bind-mounted tty nodes inherit the host's root:dialout 0660 perms;
+    the host `dialout` GID does NOT map to the LXC's `zigbee2mqtt`
+    user (different user namespace), so without the chmod the z2m
+    user can't open the device even though the node exists. This was
+    the v2.5.5 follow-up gotcha — the live board needed `chmod 666`
+    on the device after lxc-device add for z2m to actually come up.
+    Idempotent; `|| true` keeps the unit healthy when the dongle is
+    unplugged.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Fri, 22 May 2026 05:35:00 +0000
+
 secubox-zigbee (2.5.5-1~bookworm1) bookworm; urgency=medium
 
   * lib/zigbee/install-lxc.sh: bind /dev/ttyUSB0 and /dev/ttyACM0 into

--- a/packages/secubox-zigbee/lib/zigbee/install-lxc.sh
+++ b/packages/secubox-zigbee/lib/zigbee/install-lxc.sh
@@ -245,6 +245,13 @@ StandardOutput=journal
 StandardError=journal
 Restart=always
 RestartSec=10
+# Bind-mounted /dev/tty* nodes land inside the LXC as root:root with
+# the host's 0660 perms. The host's `dialout` GID doesn't map to the
+# LXC's `zigbee2mqtt` user (different user namespace), so without
+# this chmod the z2m user can't open the device. Idempotent + cheap;
+# `|| true` survives the dongle-absent case. See secubox-zigbee #zigbee-prod-502.
+ExecStartPre=/bin/sh -c '[ -e /dev/ttyUSB0 ] && /bin/chmod 0666 /dev/ttyUSB0 || true'
+ExecStartPre=/bin/sh -c '[ -e /dev/ttyACM0 ] && /bin/chmod 0666 /dev/ttyACM0 || true'
 ExecStart=/usr/bin/node /opt/zigbee2mqtt/node_modules/zigbee2mqtt/index.js
 
 NoNewPrivileges=true


### PR DESCRIPTION
## Why
v2.5.5 bind-mounted the tty device nodes into the LXC, which fixed the ENOENT crash. But the nodes inherited the host's `root:dialout 0660` perms and the host \`dialout\` GID does **not** map to the LXC's \`zigbee2mqtt\` user (separate user namespace), so z2m still couldn't open the device. On the live board the recovery needed an extra \`chmod 666 /dev/ttyUSB0\` before z2m would come up.

## Fix
Two \`ExecStartPre\` lines on the z2m systemd unit, idempotent, with \`|| true\` so the unit stays healthy when the dongle is unplugged:

\`\`\`ini
ExecStartPre=/bin/sh -c '[ -e /dev/ttyUSB0 ] && /bin/chmod 0666 /dev/ttyUSB0 || true'
ExecStartPre=/bin/sh -c '[ -e /dev/ttyACM0 ] && /bin/chmod 0666 /dev/ttyACM0 || true'
\`\`\`

Fires every z2m start including the dongle-replug → \`Restart=always\` cycle.

## Files
- \`packages/secubox-zigbee/lib/zigbee/install-lxc.sh\` — emit the two ExecStartPre lines
- \`packages/secubox-zigbee/debian/changelog\` — bump 2.5.5 → 2.5.6

## Test plan
- [x] Live board verified (manual \`chmod 666\` then z2m active, port 8080 LISTEN, zigbee.gk2.secubox.in 302 → SSO → 200)
- [ ] Fresh reinstall via \`zigbeectl install --reprovision\` lands the new unit
- [ ] Reboot the board; z2m comes up clean without manual chmod
- [ ] Unplug + replug the dongle; z2m restart cycle picks up the perms

Follow-up to #332.