### PR TITLE
fix(secubox-zigbee): v2.5.7 — udev RUN+= uses correct lxc-device -n zigbee add syntax

### DIFF
--- a/packages/secubox-zigbee/debian/changelog
+++ b/packages/secubox-zigbee/debian/changelog
@@ -1,3 +1,15 @@
+secubox-zigbee (2.5.7-1~bookworm1) bookworm; urgency=medium
+
+  * lib/zigbee/install-lxc.sh: udev RUN+= now invokes
+    `lxc-device -n zigbee add /dev/%k` instead of the wrong
+    `lxc-device add zigbee /dev/%k` form shipped by v2.5.5. The
+    v2.5.5 syntax made lxc-device parse `add` as the container name
+    ("Container add is not running" was the actual error seen on
+    the live board), so hotplug events silently failed and a
+    re-plugged dongle never landed in the running LXC.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Fri, 22 May 2026 06:05:00 +0000
+
 secubox-zigbee (2.5.6-1~bookworm1) bookworm; urgency=medium
 
   * lib/zigbee/install-lxc.sh: zigbee2mqtt.service gains two

--- a/packages/secubox-zigbee/lib/zigbee/install-lxc.sh
+++ b/packages/secubox-zigbee/lib/zigbee/install-lxc.sh
@@ -376,17 +376,17 @@ install_udev_rule() {
 SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", \
     ATTRS{product}=="SONOFF Dongle Lite MG21", \
     SYMLINK+="secubox-zgb", MODE="0660", GROUP="dialout", \
-    RUN+="/bin/sh -c '/usr/bin/lxc-device add zigbee /dev/%k || true'"
+    RUN+="/bin/sh -c '/usr/bin/lxc-device -n zigbee add /dev/%k || true'"
 
 # Sonoff Zigbee 3.0 USB Plus (CC2652P)
 SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="55d4", \
     SYMLINK+="secubox-zgb", MODE="0660", GROUP="dialout", \
-    RUN+="/bin/sh -c '/usr/bin/lxc-device add zigbee /dev/%k || true'"
+    RUN+="/bin/sh -c '/usr/bin/lxc-device -n zigbee add /dev/%k || true'"
 
 # ConBee II (fallback)
 SUBSYSTEM=="tty", ATTRS{idVendor}=="1cf1", ATTRS{idProduct}=="0030", \
     SYMLINK+="secubox-zgb", MODE="0660", GROUP="dialout", \
-    RUN+="/bin/sh -c '/usr/bin/lxc-device add zigbee /dev/%k || true'"
+    RUN+="/bin/sh -c '/usr/bin/lxc-device -n zigbee add /dev/%k || true'"
 
 # Generic CP210x without the SONOFF descriptor — secondary symlink only
 SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", \


### PR DESCRIPTION
## Why
v2.5.5 (PR #332) shipped a udev RUN+= line that called \`lxc-device add zigbee /dev/%k\` to push hotplug events into the running LXC. The correct lxc-device(1) syntax is \`lxc-device -n <container> add <path>\` — the v2.5.5 form makes lxc-device parse the word \`add\` as the container name and exits with \`Container add is not running\`.

Confirmed empirically on the live board during the v2.5.5 hotfix recovery:

\`\`\`bash
# v2.5.5 form — fails
$ lxc-device add zigbee /dev/ttyUSB0
lxc-device: add: ../src/lxc/tools/lxc_device.c: main: 128 Container add is not running

# correct form
$ lxc-device -n zigbee add /dev/ttyUSB0
# ok
\`\`\`

Without this fix the hotplug branch silently no-ops — a re-plugged dongle stays invisible inside the LXC and z2m crash-loops again until an operator reboots the container.

## Files
- \`packages/secubox-zigbee/lib/zigbee/install-lxc.sh\` — 3 occurrences (SONOFF MG21, Sonoff USB Plus, ConBee II)
- \`packages/secubox-zigbee/debian/changelog\` — bump 2.5.6 → 2.5.7

## Test plan
- [ ] Rebuild .deb, install on gk2
- [ ] Unplug dongle, replug, verify \`/dev/ttyUSB0\` appears inside the LXC without restart (\`lxc-attach -n zigbee -- ls /dev/ttyUSB0\`)
- [ ] z2m \`Restart=always\` cycle picks it up automatically thanks to PR #333's ExecStartPre chmod

Follow-up to #332 and #333.