### PR TITLE
fix(kernel-build): install build-essential to satisfy dpkg-checkbuilddeps (ref #319 #326)

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -39,7 +39,13 @@ jobs:
       - name: Install cross toolchain + build deps
         run: |
           sudo apt-get update -qq
+          # build-essential is needed because bindeb-pkg auto-generates a
+          # debian/control that lists `build-essential:native` in
+          # Build-Depends; dpkg-checkbuilddeps fails the run without it
+          # even though every individual binary it pulls in (gcc, g++,
+          # libc-dev, make) is independently installable.
           sudo apt-get install -y --no-install-recommends \
+            build-essential \
             gcc-aarch64-linux-gnu make bc flex bison \
             libssl-dev libelf-dev wget xz-utils \
             kmod cpio rsync debhelper dpkg-dev fakeroot \


### PR DESCRIPTION
## Why
Kernel build #5 cleared the ZRAM choice sed fix (PR #326) and reached the bindeb-pkg step, then failed:

\`\`\`
dpkg-checkbuilddeps: error: Unmet build dependencies:
  build-essential:native libssl-dev
make[2]: *** [scripts/Makefile.package:126: bindeb-pkg] Error 3
\`\`\`

\`bindeb-pkg\` auto-generates a \`debian/control\` that \`Build-Depends\` on \`build-essential:native\`. The previous install list pulled in gcc / make / libc-dev individually but never the meta-package, so \`dpkg-checkbuilddeps\` rejected the build.

\`libssl-dev\` is listed in the same error line but is already installed — once \`build-essential\` lands, checkbuilddeps re-resolves the full graph in one pass and that secondary complaint clears.

## Fix
Single-line addition to the \`apt-get install\` list in \`.github/workflows/build-kernel.yml\`.

## Test plan
- [x] CI workflow run on this branch reaches the \"Build kernel .deb\" step
- [ ] bindeb-pkg produces \`linux-image-6.12.85-2secubox_*_arm64.deb\` + \`linux-headers-*\` + \`linux-libc-dev*\`
- [ ] Upload step finds artifacts, retention 30 days