### PR TITLE
fix(secubox-streamlit): v1.2.4 — strip quotes from port value (idle-check was matching nothing)

### DIFF
--- a/packages/secubox-streamlit/debian/changelog
+++ b/packages/secubox-streamlit/debian/changelog
@@ -1,3 +1,15 @@
+secubox-streamlit (1.2.4-1~bookworm1) bookworm; urgency=medium
+
+  * sbin/streamlitctl: `_app_running` + `_app_active_conns` now strip
+    double-quotes from the port value (`tr -d ' "'`), not just spaces.
+    Older `.streamlit.toml` files were written as `port = "8527"` —
+    `cut | tr -d ' '` returned the literal string `"8527"` (quotes
+    included) and `ss "sport = :\"8527\""` never matched. Result on
+    gk2: idle-check reported `active=0 idle=0 stopped=0` even with 7
+    apps listening, because every app's port-extraction failed.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Fri, 22 May 2026 06:20:00 +0000
+
 secubox-streamlit (1.2.3-1~bookworm1) bookworm; urgency=medium
 
   * Remove stale packages/secubox-streamlit/scripts/streamlitctl

--- a/packages/secubox-streamlit/sbin/streamlitctl
+++ b/packages/secubox-streamlit/sbin/streamlitctl
@@ -49,7 +49,7 @@ _idle_config() {
 # Returns 0 if the app is listening on its port INSIDE the LXC, else 1.
 _app_running() {
     local name="$1"
-    local port; port=$(grep -E "^port\s*=" "$APPS_PATH/$name/.streamlit.toml" 2>/dev/null | cut -d'=' -f2 | tr -d ' ')
+    local port; port=$(grep -E "^port\s*=" "$APPS_PATH/$name/.streamlit.toml" 2>/dev/null | cut -d'=' -f2 | tr -d ' "')
     [ -z "$port" ] && return 1
     lxc_running || return 1
     lxc-attach -n "$LXC_NAME" -- ss -tln "sport = :$port" 2>/dev/null \
@@ -59,7 +59,7 @@ _app_running() {
 # Returns the count of ESTABLISHED connections to the app's port (inside LXC).
 _app_active_conns() {
     local name="$1"
-    local port; port=$(grep -E "^port\s*=" "$APPS_PATH/$name/.streamlit.toml" 2>/dev/null | cut -d'=' -f2 | tr -d ' ')
+    local port; port=$(grep -E "^port\s*=" "$APPS_PATH/$name/.streamlit.toml" 2>/dev/null | cut -d'=' -f2 | tr -d ' "')
     [ -z "$port" ] && { echo 0; return; }
     lxc_running || { echo 0; return; }
     lxc-attach -n "$LXC_NAME" -- ss -tn state established "sport = :$port" 2>/dev/null \


### PR DESCRIPTION
## Symptom
On gk2 after v1.2.3 the idle-check sweep correctly fired but reported:

\`\`\`
idle-check: active=0 idle=0 stopped=0
\`\`\`

…even with 7 apps listening inside the LXC with a valid \`.streamlit.toml\`.

## Root cause
Older \`.streamlit.toml\` files were written as \`port = "8527"\` (with double-quotes). The port-extraction expression was:

\`\`\`bash
port=$(grep -E "^port\s*=" "$APPS_PATH/$name/.streamlit.toml" | cut -d'=' -f2 | tr -d ' ')
\`\`\`

\`tr -d ' '\` stripped spaces only, so \`port\` became the literal string \`"8527"\` (quotes preserved). The subsequent \`ss "sport = :\"8527\""\` never matched a real bind, so \`_app_running\` returned 1 for every app and idle-check's loop body never ran.

## Fix
One-character change in both \`_app_running\` and \`_app_active_conns\`:

\`\`\`bash
tr -d ' "'   # was: tr -d ' '
\`\`\`

(Same pattern as \`_idle_config\`.)

## Files
- \`packages/secubox-streamlit/sbin/streamlitctl\` (1 line × 2 places, via `replace_all`)
- \`packages/secubox-streamlit/debian/changelog\` — bump 1.2.3 → 1.2.4

## Test plan
- [ ] Deploy 1.2.4 to gk2
- [ ] `streamlitctl app idle-check` reports a non-zero active/idle count
- [ ] First state files appear in `/var/lib/secubox/streamlit/idle/`
- [ ] After 30 min idle + one timer cycle, ~5 dormant apps get stopped and `free -m` shows ~500 MB freed