### PR TITLE
fix(image): VT102-safe banner — replace emojis in /etc/issue + add local kernel build script

### DIFF
--- a/image/build-image.sh
+++ b/image/build-image.sh
@@ -1235,12 +1235,12 @@ printf '%b' "\e[38;5;29m
        ██ ██      ██      ██    ██ ██   ██ ██    ██  ██ ██
   ███████ ███████  ██████  ██████  ██████   ██████  ██   ██
 \e[0m
-\e[38;5;45m  ⚡ CyberMind Security Platform\e[0m  \e[38;5;82mv${SECUBOX_VERSION}\e[0m  \e[38;5;242m\\\\l @ \\\\n\e[0m
+\e[38;5;45m  >> CyberMind Security Platform\e[0m  \e[38;5;82mv${SECUBOX_VERSION}\e[0m  \e[38;5;242m\\\\l @ \\\\n\e[0m
 \e[38;5;242m  Build: ${BUILD_TIMESTAMP}\e[0m
 
-\e[38;5;250m  🔐 Default: \e[38;5;214mroot\e[38;5;250m / \e[38;5;214msecubox\e[0m
-\e[38;5;250m  🌐 Web UI: \e[38;5;45mhttps://<IP>:9443\e[0m
-\e[38;5;250m  📡 SSH:    \e[38;5;45mport 22\e[0m
+\e[38;5;250m  [user] Default: \e[38;5;214mroot\e[38;5;250m / \e[38;5;214msecubox\e[0m
+\e[38;5;250m  [web]  Web UI: \e[38;5;45mhttps://<IP>:9443\e[0m
+\e[38;5;250m  [ssh]  SSH:    \e[38;5;45mport 22\e[0m
 
 \e[38;5;242m─────────────────────────────────────────────────────────────\e[0m
 

--- a/scripts/build-kernel-local.sh
+++ b/scripts/build-kernel-local.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# scripts/build-kernel-local.sh — local kernel cross-build for fast iteration
+#
+# Replicates .github/workflows/build-kernel.yml step-by-step on the dev box,
+# so we don't pay 20 min/round-trip on GitHub Actions.
+#
+# Usage:
+#   bash scripts/build-kernel-local.sh                   # default 6.12.85, 2secubox
+#   bash scripts/build-kernel-local.sh 6.12.85 3secubox  # override
+#
+# Output:
+#   .debs land in /tmp/secubox-kernel-build/ (linux-image-*, linux-headers-*).
+#
+# Iteration tip: the tarball + olddefconfig are slow; once the build tree exists,
+# subsequent runs reuse it (skip download + re-run merge from scratch). To force
+# a clean rebuild from scratch, `rm -rf /tmp/secubox-kernel-build`.
+
+set -euo pipefail
+
+KERNEL_VERSION="${1:-6.12.85}"
+REVISION="${2:-2secubox}"
+KDEB_PKGVERSION="${KERNEL_VERSION}-${REVISION}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_ROOT="/tmp/secubox-kernel-build"
+SRC_DIR="$BUILD_ROOT/linux-${KERNEL_VERSION}"
+
+export DEBFULLNAME="${DEBFULLNAME:-SecuBox Builder}"
+export DEBEMAIL="${DEBEMAIL:-devel@cybermind.fr}"
+
+log() { printf '\033[1;36m[%s] %s\033[0m\n' "$(date '+%H:%M:%S')" "$*"; }
+fail() { printf '\033[1;31m[%s] FAIL: %s\033[0m\n' "$(date '+%H:%M:%S')" "$*" >&2; exit 1; }
+
+# ── 1. download upstream tarball if absent ──────────────────────────────────
+mkdir -p "$BUILD_ROOT"
+cd "$BUILD_ROOT"
+if [ ! -d "$SRC_DIR" ]; then
+    log "downloading linux-${KERNEL_VERSION}.tar.xz"
+    MAJOR="$(echo "$KERNEL_VERSION" | cut -d. -f1)"
+    wget -q "https://cdn.kernel.org/pub/linux/kernel/v${MAJOR}.x/linux-${KERNEL_VERSION}.tar.xz"
+    log "extracting"
+    tar xf "linux-${KERNEL_VERSION}.tar.xz"
+else
+    log "src tree already at $SRC_DIR — reusing (rm -rf $BUILD_ROOT to force clean)"
+fi
+cd "$SRC_DIR"
+
+# ── 2. apply SecuBox patches ────────────────────────────────────────────────
+PATCH_DIR="$REPO_ROOT/kernel-build/patches"
+if [ -d "$PATCH_DIR" ]; then
+    for p in "$PATCH_DIR"/*.patch; do
+        [ -f "$p" ] || continue
+        log "applying patch $(basename "$p")"
+        patch -p1 -N --dry-run < "$p" >/dev/null 2>&1 \
+            && patch -p1 -N < "$p" >/dev/null \
+            || log "  (already applied or fails dry-run — skipping)"
+    done
+fi
+
+# ── 3. defconfig + merge config fragments ───────────────────────────────────
+log "make ARCH=arm64 defconfig"
+make ARCH=arm64 defconfig >/dev/null
+
+log "merge_config.sh -m .config + fragments"
+scripts/kconfig/merge_config.sh -m .config \
+    "$REPO_ROOT/board/mochabin/kernel/config-6.12-openwrt-merged.fragment" \
+    "$REPO_ROOT/board/mochabin/kernel/config-6.12.85-secubox-zram.fragment" \
+    >/dev/null
+
+# ── 4. enable supporting non-choice symbols ─────────────────────────────────
+log "scripts/config: enable ZSMALLOC + CRYPTO_{ZSTD,LZ4,LZO}"
+scripts/config --enable ZSMALLOC \
+               --enable CRYPTO_ZSTD \
+               --enable CRYPTO_LZ4 \
+               --enable CRYPTO_LZO
+
+log "make ARCH=arm64 olddefconfig"
+make ARCH=arm64 olddefconfig >/dev/null
+
+# ── 5. sed override for the ZRAM choice (post-olddefconfig) ─────────────────
+if ! grep -q '^CONFIG_ZRAM_DEF_COMP_ZSTD=y' .config; then
+    log "ZRAM choice fell back to LZORLE — sed forcing ZSTD"
+    sed -i 's/^CONFIG_ZRAM_DEF_COMP_LZORLE=y/# CONFIG_ZRAM_DEF_COMP_LZORLE is not set/' .config
+    sed -i 's/^# CONFIG_ZRAM_DEF_COMP_ZSTD is not set/CONFIG_ZRAM_DEF_COMP_ZSTD=y/' .config
+    grep -q 'ZRAM_DEF_COMP_ZSTD' .config || echo 'CONFIG_ZRAM_DEF_COMP_ZSTD=y' >> .config
+fi
+
+# ── 6. sanity check ─────────────────────────────────────────────────────────
+log "asserting required configs landed"
+grep -q '^CONFIG_LEDS_IS31FL319X=m' .config        || fail "LED module missing"
+grep -q '^CONFIG_ZRAM=m' .config                   || fail "ZRAM module missing"
+grep -q '^CONFIG_ZRAM_DEF_COMP_ZSTD=y' .config     || fail "ZRAM zstd default missing"
+
+# ── 7. cross-build the .deb via bindeb-pkg ──────────────────────────────────
+log "bindeb-pkg starts (j$(nproc)) — this is the long step (~10-15 min on amd64)"
+# KBUILD_PKG_DPKG_OPTS=-d → pass -d to dpkg-buildpackage, skipping
+# checkbuilddeps. Cross-build only needs libssl-dev:amd64 (host-side
+# sign-file), not libssl-dev:arm64.
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+     -j"$(nproc)" \
+     KDEB_PKGVERSION="${KDEB_PKGVERSION}" \
+     KBUILD_PKG_DPKG_OPTS="-d" \
+     bindeb-pkg
+
+# ── 8. collect ──────────────────────────────────────────────────────────────
+log "collecting .deb artifacts to $BUILD_ROOT"
+ls -la "$BUILD_ROOT"/linux-{image,headers,libc-dev}-*.deb 2>/dev/null || fail "no .deb produced"
+
+log "DONE. Image: $(ls $BUILD_ROOT/linux-image-*_arm64.deb 2>/dev/null | head -1)"


### PR DESCRIPTION
## Symptom
Console série Minicom VT102 sur gk2 affiche \`�\` (replacement char) à la fin des lignes du banner /etc/issue :

\`\`\`
[ssh] CyberMind Security Platform  v1.9.0  ttyS0 @ gk2  �
[user] Default: root / secubox  �
[web]  Web UI: https://<IP>:9443  �
\`\`\`

Minicom en VT102 ne sait pas décoder les emojis 4-byte UTF-8.

## Fix
Remplacer les 4 emojis qui posent problème par des tags ASCII safe :
- \`⚡\` → \`>>\`
- \`🔐\` → \`[user]\`
- \`🌐\` → \`[web]\`
- \`📡\` → \`[ssh]\`

Les caractères \`█\` U+2588 (Full Block) sont **gardés** — ils rendent correctement en VT102+UTF-8 ET ils forment le wordmark SECUBOX, donc on perd rien visuellement.

\`/etc/motd\` (post-login SSH) n'est PAS touché — les sessions SSH ont des terminaux UTF-8 complets, les emojis y sont fine.

## Bonus
- \`scripts/build-kernel-local.sh\` — script de build kernel local qu'on a écrit aujourd'hui pour itérer sur #255 sans ping-ponger 20 min sur GH Actions. Documenté, réutilisable.

## Test plan
- [x] Pre-deploy live sur gk2 via sed : \`/etc/issue\` n'a plus de \`�\` au tail des lignes
- [ ] Image rebuild via \`build-image.sh\` produit le banner clean