### PR TITLE
fix(secubox-sentinelle-gsm): v0.2.1 — nginx SSE + postinst perms + global navbar (follow-up to #341)

### DIFF
--- a/packages/secubox-sentinelle-gsm/debian/changelog
+++ b/packages/secubox-sentinelle-gsm/debian/changelog
@@ -1,3 +1,23 @@
+secubox-sentinelle-gsm (0.2.1-1~bookworm1) bookworm; urgency=medium
+
+  * nginx/sentinelle-webui.conf: stop including secubox-proxy.conf in
+    the SSE override block — the snippet declares proxy_http_version,
+    proxy_buffering, proxy_cache, proxy_read_timeout AND proxy_send_timeout,
+    all of which collide with our timeout overrides (nginx refuses with
+    "duplicate directive"). The override now inlines a strict subset of
+    the snippet plus the SSE-specific 24h timeouts.
+  * debian/postinst: chown the seeded trusted.json to secubox:secubox
+    (was root:secubox 0640 — the service user couldn't truncate the file
+    on add/delete and POST /trusted returned 500 with PermissionError).
+  * www/sentinelle/index.html: inject the canonical SecuBox global menu
+    bar via `<nav class="sidebar" id="sidebar"></nav>` + `<script
+    src="/shared/sidebar.js"></script>`. The local per-module navigation
+    aside was renamed from class="sidebar" to class="local-nav" (CSS
+    selectors updated accordingly) so /shared/sidebar.js can claim
+    `.sidebar` without colliding with our local styles.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Fri, 22 May 2026 12:00:00 +0000
+
 secubox-sentinelle-gsm (0.2.0-1~bookworm1) bookworm; urgency=medium
 
   * v0.2.0 — Local alerts persistence + trusted-phones whitelist +

--- a/packages/secubox-sentinelle-gsm/debian/postinst
+++ b/packages/secubox-sentinelle-gsm/debian/postinst
@@ -39,6 +39,19 @@ case "$1" in
             chown secubox:secubox /var/lib/secubox/sentinelle-gsm/mode
         fi
 
+        # v0.2 — trusted phones registry: create dir + seed empty registry
+        # so the FastAPI app can read/write trusted.json on first start.
+        # The service runs as `secubox` and rewrites this file on every
+        # add/delete, so the FILE must be writable by the service user.
+        # We give the file to secubox:secubox (not root:secubox 0640 —
+        # group-read isn't enough for python's path.write_text() truncate).
+        install -d -m 0750 -o root -g secubox /etc/secubox/sentinelle-gsm
+        if [ ! -f /etc/secubox/sentinelle-gsm/trusted.json ]; then
+            echo '{"phones": []}' > /etc/secubox/sentinelle-gsm/trusted.json
+        fi
+        chown secubox:secubox /etc/secubox/sentinelle-gsm/trusted.json
+        chmod 0640 /etc/secubox/sentinelle-gsm/trusted.json
+
         # Reload nginx + udev
         if systemctl is-active --quiet nginx 2>/dev/null; then
             nginx -t >/dev/null 2>&1 && systemctl reload nginx 2>/dev/null || true

--- a/packages/secubox-sentinelle-gsm/nginx/sentinelle-webui.conf
+++ b/packages/secubox-sentinelle-gsm/nginx/sentinelle-webui.conf
@@ -25,12 +25,24 @@ location /sentinelle/ {
 location ^~ /api/v1/sensor/gsm/alerts/stream {
     rewrite ^/api/v1/sensor/gsm/(.*)$ /$1 break;
     proxy_pass http://unix:/run/secubox/sentinelle-gsm.sock;
-    include /etc/nginx/snippets/secubox-proxy.conf;
 
-    # SSE: long-lived connection, no buffering, no idle timeout.
+    # SSE long-poll requires DIFFERENT timeouts than the default
+    # secubox-proxy.conf snippet (30s read), so we inline ONLY the
+    # directives we actually need instead of including the snippet —
+    # otherwise every directive we'd want to tweak (read_timeout,
+    # send_timeout) would collide with the snippet and nginx refuses
+    # with "duplicate directive". The inlined set below is a strict
+    # subset of the snippet (Host + Connection + buffering off + auth)
+    # plus the SSE-specific 24h timeouts.
     proxy_http_version 1.1;
-    proxy_buffering off;
-    proxy_cache off;
+    proxy_set_header   Host              $host;
+    proxy_set_header   X-Real-IP         $remote_addr;
+    proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_set_header   Connection        "";
+    proxy_set_header   Authorization     $http_authorization;
+    proxy_buffering    off;
+    proxy_cache        off;
     proxy_read_timeout 24h;
     proxy_send_timeout 24h;
 }

--- a/packages/secubox-sentinelle-gsm/www/sentinelle/index.html
+++ b/packages/secubox-sentinelle-gsm/www/sentinelle/index.html
@@ -20,19 +20,24 @@
 </head>
 <body>
 
-<aside class="sidebar" aria-label="Sentinelle navigation">
-  <div class="sidebar-brand">
+<!-- Canonical SecuBox global menu bar — injected by /shared/sidebar.js
+     (position:fixed, top:0, height:48px, z-index:998). The CSS already
+     reserves --gmb-h = 48px of top-padding for .main below. -->
+<nav class="sidebar" id="sidebar"></nav>
+
+<aside class="local-nav" aria-label="Sentinelle navigation">
+  <div class="local-nav-brand">
     <div class="brand-tag">MIND</div>
     <div class="brand-name">sentinelle-gsm</div>
     <div class="brand-sub">passive rogue-BTS sensor</div>
   </div>
-  <nav class="sidebar-nav">
+  <nav class="local-nav-list">
     <a href="#status" class="nav-link">Status</a>
     <a href="#alerts" class="nav-link">Alerts</a>
     <a href="#trusted" class="nav-link">Trusted phones</a>
     <a href="#actions" class="nav-link">Actions</a>
   </nav>
-  <div class="sidebar-foot">
+  <div class="local-nav-foot">
     <a href="/" class="back-hub">← hub</a>
   </div>
 </aside>
@@ -181,6 +186,7 @@
 <!-- Toast banner ------------------------------------------------------- -->
 <div id="toast" class="toast" role="status" aria-live="polite"></div>
 
+<script src="/shared/sidebar.js"></script>
 <script defer src="sentinelle.js"></script>
 </body>
 </html>

--- a/packages/secubox-sentinelle-gsm/www/sentinelle/sentinelle.css
+++ b/packages/secubox-sentinelle-gsm/www/sentinelle/sentinelle.css
@@ -66,7 +66,7 @@ a { color: var(--mind-violet-lt); text-decoration: none; }
 a:hover { color: var(--text-primary); }
 
 /* ── sidebar ──────────────────────────────────────────────────────────── */
-.sidebar {
+.local-nav {
   position: fixed;
   top: 0; left: 0;
   width: var(--sidebar-w);
@@ -81,7 +81,7 @@ a:hover { color: var(--text-primary); }
   z-index: 100;
 }
 
-.sidebar-brand .brand-tag {
+.local-nav-brand .brand-tag {
   display: inline-block;
   font-family: 'JetBrains Mono', monospace;
   font-size: 10px;
@@ -93,19 +93,19 @@ a:hover { color: var(--text-primary); }
   color: #fff;
   margin-bottom: 0.5rem;
 }
-.sidebar-brand .brand-name {
+.local-nav-brand .brand-name {
   font-size: 1.05rem;
   font-weight: 600;
   letter-spacing: -0.01em;
   color: var(--text-primary);
 }
-.sidebar-brand .brand-sub {
+.local-nav-brand .brand-sub {
   font-size: 11px;
   color: var(--text-muted);
   margin-top: 0.15rem;
 }
 
-.sidebar-nav {
+.local-nav-list {
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
@@ -127,7 +127,7 @@ a:hover { color: var(--text-primary); }
   border-left-color: var(--mind-violet-lt);
 }
 
-.sidebar-foot {
+.local-nav-foot {
   margin-top: auto;
   padding-top: 1rem;
   border-top: 1px solid var(--border);
@@ -480,18 +480,18 @@ a:hover { color: var(--text-primary); }
 /* ── responsive ───────────────────────────────────────────────────────── */
 @media (max-width: 900px) {
   body { flex-direction: column; }
-  .sidebar {
+  .local-nav {
     position: static;
     width: 100%;
     height: auto;
     padding: calc(var(--gmb-h) + 0.75rem) 1rem 0.75rem;
   }
   .main { margin-left: 0; padding: 1rem; }
-  .sidebar-nav { flex-direction: row; flex-wrap: wrap; }
+  .local-nav-list { flex-direction: row; flex-wrap: wrap; }
   .nav-link { padding: 0.4rem 0.7rem; border-left: 0; border-bottom: 2px solid transparent; }
   .nav-link:hover { border-left: 0; border-bottom-color: var(--mind-violet-lt); }
   .status-strip { grid-template-columns: 1fr 1fr; }
-  .sidebar-foot { display: none; }
+  .local-nav-foot { display: none; }
 }
 
 @media (max-width: 520px) {


### PR DESCRIPTION
## Symptom
After PR #341 (v0.2.0) was merged + deployed live on gk2, three immediate bugs surfaced :

1. \`nginx -t\` refused the reload with **\`"proxy_http_version" directive is duplicate\`** (and then \`proxy_cache\`, then \`proxy_read_timeout\`) — the included \`secubox-proxy.conf\` snippet declares all of these, and my SSE override re-declared the same names to tweak the timeout values.

2. \`POST /api/v1/sensor/gsm/trusted\` returned **500 Internal Server Error**. Service log:
   \`\`\`
   PermissionError: [Errno 13] Permission denied: '/etc/secubox/sentinelle-gsm/trusted.json'
   \`\`\`
   The seed file was \`-rw-r----- root:secubox\` (group read only). The \`secubox\` service user couldn't truncate it via \`path.write_text()\`.

3. The standalone \`/sentinelle/\` page rendered without the **canonical SecuBox global menu bar** (the 6-charter navbar). My HTML used \`class="sidebar"\` for the local in-page nav but never included \`/shared/sidebar.js\` to inject the global bar.

## Fix
1. **nginx**: drop the \`include\` in the SSE block, inline a strict subset (Host + Connection \`""\` + buffering off + auth) plus the 24h timeouts. nginx -t now passes.
2. **postinst**: \`chown secubox:secubox /etc/secubox/sentinelle-gsm/trusted.json\` (was root:secubox), service can now truncate.
3. **HTML**: add \`<nav class="sidebar" id="sidebar"></nav>\` placeholder + \`<script src="/shared/sidebar.js"></script>\`. Rename our local per-module aside class \`sidebar\` → \`local-nav\` (CSS selectors updated) so /shared/sidebar.js can claim \`.sidebar\` without collision.

## Live validation on gk2 (already deployed)
- [x] \`nginx -t\` → ok, systemctl reload nginx clean
- [x] \`GET /sentinelle/\` → 200
- [x] \`POST /alerts/test\` → 200, alert in history, SSE chunk dispatched
- [x] \`POST /trusted\` → 200 with hash \`a5b4429ce97abd66\`, plaintext IMSI (\`208201234567890\`) NOT on disk
- [x] /shared/sidebar.js accessible (200)
- [ ] Visual confirmation in browser: top global navbar visible

## Files
- \`nginx/sentinelle-webui.conf\` — inline SSE settings, drop include
- \`debian/postinst\` — chown trusted.json to secubox:secubox
- \`www/sentinelle/index.html\` — global navbar injection + local-nav rename
- \`www/sentinelle/sentinelle.css\` — \`.sidebar*\` → \`.local-nav*\`
- \`debian/changelog\` — bump 0.2.0 → 0.2.1

Follow-up to #341 / #340.