### PR TITLE
feat(secubox-sentinelle-gsm): v0.2.2 — live logs panel (SSE journalctl stream)

### DIFF
--- a/packages/secubox-sentinelle-gsm/api/main.py
+++ b/packages/secubox-sentinelle-gsm/api/main.py
@@ -283,6 +283,75 @@ async def delete_trusted(phone_id: str) -> dict:
     return {"ok": True}
 
 
+# ── JOURNAL STREAMING (v0.2.2) ─────────────────────────────────────────
+# Read-only SSE feed of `journalctl -u secubox-sentinelle-gsm -f -o json`.
+# The service user is in the systemd-journal group via postinst so no
+# elevated privileges are needed at runtime. The async generator runs
+# `journalctl` as a child process and yields each JSON line as an SSE
+# `event: log` chunk.
+
+async def _journal_stream() -> "AsyncIterator[str]":  # noqa: F821
+    import asyncio
+    import json as _json
+    import shutil
+
+    journalctl = shutil.which("journalctl") or "/usr/bin/journalctl"
+    proc = await asyncio.create_subprocess_exec(
+        journalctl,
+        "-u", "secubox-sentinelle-gsm",
+        "-f",                # follow
+        "-n", "50",          # bootstrap with the last 50 lines
+        "-o", "json",
+        "--no-pager",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    try:
+        assert proc.stdout is not None
+        while True:
+            line = await proc.stdout.readline()
+            if not line:
+                break
+            try:
+                entry = _json.loads(line)
+            except _json.JSONDecodeError:
+                continue
+            # Keep only the fields the UI actually needs — message + ts.
+            payload = {
+                "ts": float(entry.get("__REALTIME_TIMESTAMP", 0)) / 1_000_000,
+                "priority": int(entry.get("PRIORITY", 6)),
+                "message": entry.get("MESSAGE", ""),
+                "syslog_id": entry.get("SYSLOG_IDENTIFIER", ""),
+            }
+            yield "event: log\ndata: " + _json.dumps(payload) + "\n\n"
+    finally:
+        if proc.returncode is None:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=2.0)
+            except asyncio.TimeoutError:
+                proc.kill()
+
+
+@app.get("/journal/stream", dependencies=[Depends(require_jwt)])
+async def stream_journal() -> StreamingResponse:
+    """Server-Sent Events live feed of this service's systemd journal.
+
+    Reads `journalctl -u secubox-sentinelle-gsm -f -o json` and forwards
+    each entry as an SSE `event: log` chunk with the message + priority
+    + RFC3339 timestamp. Uses the existing systemd-journal group
+    membership (set in postinst).
+    """
+    headers = {
+        "Cache-Control": "no-cache",
+        "X-Accel-Buffering": "no",
+        "Connection": "keep-alive",
+    }
+    return StreamingResponse(
+        _journal_stream(), media_type="text/event-stream", headers=headers
+    )
+
+
 @app.post("/mode")
 def set_mode(payload: dict = Body(...)) -> dict:
     """Flip between PROD ↔ LAB.

--- a/packages/secubox-sentinelle-gsm/debian/changelog
+++ b/packages/secubox-sentinelle-gsm/debian/changelog
@@ -1,3 +1,22 @@
+secubox-sentinelle-gsm (0.2.2-1~bookworm1) bookworm; urgency=medium
+
+  * api/main.py: new GET /journal/stream endpoint streaming the service's
+    own systemd-journal entries as Server-Sent Events. Reads
+    `journalctl -u secubox-sentinelle-gsm -f -o json` via an asyncio
+    subprocess and yields one SSE `event: log` chunk per entry with
+    {ts, priority, message, syslog_id}. Read-only — the service user
+    is already in the systemd-journal group via the existing postinst.
+  * nginx/sentinelle-webui.conf: add the matching SSE-tuned ^~ location
+    block for /api/v1/sensor/gsm/journal/stream alongside the existing
+    /alerts/stream one (same 24h timeouts, no buffering, no cache).
+  * www/sentinelle/: new "Live logs" panel — auto-scrolling monospace
+    <pre> consumes /journal/stream via EventSource. Per-line color by
+    syslog priority (err/warn/info/debug). Auto-scroll toggle + clear
+    button. Capped at 500 lines in-DOM to keep memory flat on long
+    sessions.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Fri, 22 May 2026 14:00:00 +0000
+
 secubox-sentinelle-gsm (0.2.1-1~bookworm1) bookworm; urgency=medium
 
   * nginx/sentinelle-webui.conf: stop including secubox-proxy.conf in

--- a/packages/secubox-sentinelle-gsm/nginx/sentinelle-webui.conf
+++ b/packages/secubox-sentinelle-gsm/nginx/sentinelle-webui.conf
@@ -22,18 +22,32 @@ location /sentinelle/ {
 # SSE-tuned override for the alerts stream endpoint.
 # The existing /api/v1/sensor/gsm/ proxy is provided by sentinelle-gsm.conf;
 # this deeper, literal-prefix match wins and keeps the connection open.
+# Shared SSE-tuned block, used by both /alerts/stream and /journal/stream.
+# SSE long-poll requires DIFFERENT timeouts than the default
+# secubox-proxy.conf snippet (30s read), so we inline ONLY the directives
+# we actually need instead of including the snippet — otherwise every
+# directive we'd want to tweak (read_timeout, send_timeout) would
+# collide with the snippet and nginx refuses with "duplicate directive".
+
 location ^~ /api/v1/sensor/gsm/alerts/stream {
     rewrite ^/api/v1/sensor/gsm/(.*)$ /$1 break;
     proxy_pass http://unix:/run/secubox/sentinelle-gsm.sock;
+    proxy_http_version 1.1;
+    proxy_set_header   Host              $host;
+    proxy_set_header   X-Real-IP         $remote_addr;
+    proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_set_header   Connection        "";
+    proxy_set_header   Authorization     $http_authorization;
+    proxy_buffering    off;
+    proxy_cache        off;
+    proxy_read_timeout 24h;
+    proxy_send_timeout 24h;
+}
 
-    # SSE long-poll requires DIFFERENT timeouts than the default
-    # secubox-proxy.conf snippet (30s read), so we inline ONLY the
-    # directives we actually need instead of including the snippet —
-    # otherwise every directive we'd want to tweak (read_timeout,
-    # send_timeout) would collide with the snippet and nginx refuses
-    # with "duplicate directive". The inlined set below is a strict
-    # subset of the snippet (Host + Connection + buffering off + auth)
-    # plus the SSE-specific 24h timeouts.
+location ^~ /api/v1/sensor/gsm/journal/stream {
+    rewrite ^/api/v1/sensor/gsm/(.*)$ /$1 break;
+    proxy_pass http://unix:/run/secubox/sentinelle-gsm.sock;
     proxy_http_version 1.1;
     proxy_set_header   Host              $host;
     proxy_set_header   X-Real-IP         $remote_addr;

--- a/packages/secubox-sentinelle-gsm/www/sentinelle/index.html
+++ b/packages/secubox-sentinelle-gsm/www/sentinelle/index.html
@@ -35,6 +35,7 @@
     <a href="#status" class="nav-link">Status</a>
     <a href="#alerts" class="nav-link">Alerts</a>
     <a href="#trusted" class="nav-link">Trusted phones</a>
+    <a href="#logs" class="nav-link">Live logs</a>
     <a href="#actions" class="nav-link">Actions</a>
   </nav>
   <div class="local-nav-foot">
@@ -127,6 +128,25 @@
     </div>
     <p class="hint">
       IMSI values are HMAC-hashed at registration. Plaintext IMSI is never stored.
+    </p>
+  </section>
+
+  <!-- LIVE LOGS panel (v0.2.2) ------------------------------------------- -->
+  <section id="logs" class="panel">
+    <div class="panel-head">
+      <h2>Live logs <span class="badge" id="logs-count">0</span></h2>
+      <div class="panel-actions">
+        <label class="inline-toggle">
+          <input type="checkbox" id="toggle-autoscroll" checked>
+          auto-scroll
+        </label>
+        <button class="btn" id="btn-clear-logs" type="button">Clear</button>
+      </div>
+    </div>
+    <pre id="logs-pre" class="logs-pre" role="log" aria-live="polite" aria-label="Service journal stream">waiting for journal stream…</pre>
+    <p class="hint">
+      Tail of <code>journalctl -u secubox-sentinelle-gsm -f</code>. The
+      stream auto-reconnects on transient network errors.
     </p>
   </section>
 

--- a/packages/secubox-sentinelle-gsm/www/sentinelle/sentinelle.css
+++ b/packages/secubox-sentinelle-gsm/www/sentinelle/sentinelle.css
@@ -477,6 +477,41 @@ a:hover { color: var(--text-primary); }
 .toast.warn  { border-color: var(--warn); color: var(--warn); }
 .toast.err   { border-color: var(--crit); color: var(--crit); }
 
+/* ── live logs panel (v0.2.2) ─────────────────────────────────────────── */
+.inline-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.inline-toggle input[type="checkbox"] {
+  accent-color: var(--mind-violet);
+}
+.logs-pre {
+  margin: 0;
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid var(--mind-violet-dim);
+  border-radius: 6px;
+  padding: 0.75rem 0.9rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: var(--text-muted);
+  height: 320px;
+  max-height: 50vh;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  scrollbar-color: var(--mind-violet-dim) transparent;
+}
+.log-line { display: inline; }
+.log-line.log-err   { color: var(--crit); }
+.log-line.log-warn  { color: var(--warn); }
+.log-line.log-info  { color: var(--text-primary); }
+.log-line.log-debug { color: var(--text-muted); opacity: 0.7; }
+
 /* ── responsive ───────────────────────────────────────────────────────── */
 @media (max-width: 900px) {
   body { flex-direction: column; }

--- a/packages/secubox-sentinelle-gsm/www/sentinelle/sentinelle.js
+++ b/packages/secubox-sentinelle-gsm/www/sentinelle/sentinelle.js
@@ -37,6 +37,10 @@
     btnTest:       document.getElementById("btn-test-alert"),
     btnNotif:      document.getElementById("btn-request-notif"),
     btnMute:       document.getElementById("btn-mute-beep"),
+    logsPre:       document.getElementById("logs-pre"),
+    logsCount:     document.getElementById("logs-count"),
+    toggleAutoscroll: document.getElementById("toggle-autoscroll"),
+    btnClearLogs:  document.getElementById("btn-clear-logs"),
     muteLabel:     document.getElementById("mute-label"),
     modal:         document.getElementById("modal-add"),
     modalForm:     document.getElementById("form-add-trusted"),
@@ -298,6 +302,72 @@
     return es;
   }
 
+  // ── journal live stream (v0.2.2) ────────────────────────────────────
+  const LOGS_MAX_LINES = 500;     // cap memory usage on long sessions
+  const _logsState = {
+    es: null,
+    count: 0,
+    autoscroll: true,
+  };
+
+  function _priorityClass(prio) {
+    // syslog: 0 emerg, 1 alert, 2 crit, 3 err, 4 warn, 5 notice, 6 info, 7 debug
+    if (prio <= 3) return "log-err";
+    if (prio === 4) return "log-warn";
+    if (prio === 7) return "log-debug";
+    return "log-info";
+  }
+
+  function _formatLogTs(ts) {
+    if (!ts) return "—";
+    const d = new Date(ts * 1000);
+    const pad = n => String(n).padStart(2, "0");
+    return pad(d.getHours()) + ":" + pad(d.getMinutes()) + ":" + pad(d.getSeconds());
+  }
+
+  function appendLogLine(entry) {
+    const pre = els.logsPre;
+    if (!pre) return;
+    if (_logsState.count === 0) pre.textContent = "";
+    const line = document.createElement("span");
+    line.className = "log-line " + _priorityClass(entry.priority || 6);
+    line.textContent = "[" + _formatLogTs(entry.ts) + "] " + (entry.message || "");
+    pre.appendChild(line);
+    pre.appendChild(document.createTextNode("\n"));
+    _logsState.count += 1;
+    if (els.logsCount) els.logsCount.textContent = _logsState.count;
+
+    // Trim the head if we exceed the cap, keeping the tail.
+    while (_logsState.count > LOGS_MAX_LINES) {
+      pre.removeChild(pre.firstChild);            // span
+      if (pre.firstChild && pre.firstChild.nodeType === Node.TEXT_NODE) {
+        pre.removeChild(pre.firstChild);          // the newline text
+      }
+      _logsState.count -= 1;
+    }
+    if (_logsState.autoscroll) pre.scrollTop = pre.scrollHeight;
+  }
+
+  function startJournalStream() {
+    if (_logsState.es) try { _logsState.es.close(); } catch (e) { /* ignore */ }
+    const es = new EventSource(API + "/journal/stream");
+    es.addEventListener("log", (e) => {
+      let entry;
+      try { entry = JSON.parse(e.data); }
+      catch (err) { return; }
+      appendLogLine(entry);
+    });
+    es.onerror = () => { /* auto-reconnect; no UI noise */ };
+    _logsState.es = es;
+    return es;
+  }
+
+  function clearLogs() {
+    if (els.logsPre) els.logsPre.textContent = "(cleared)";
+    _logsState.count = 0;
+    if (els.logsCount) els.logsCount.textContent = "0";
+  }
+
   // ── trusted phones ──────────────────────────────────────────────────
   function buildTrustedRow(phone) {
     const tr = document.createElement("tr");
@@ -426,6 +496,15 @@
     });
 
     els.btnMute.addEventListener("click", toggleMute);
+
+    if (els.toggleAutoscroll) {
+      els.toggleAutoscroll.addEventListener("change", (e) => {
+        _logsState.autoscroll = !!e.target.checked;
+      });
+    }
+    if (els.btnClearLogs) {
+      els.btnClearLogs.addEventListener("click", clearLogs);
+    }
   }
 
   // ── init ────────────────────────────────────────────────────────────
@@ -436,6 +515,7 @@
     loadAlertHistory();
     loadTrusted();
     startAlertStream();
+    startJournalStream();
   }
 
   if (document.readyState === "loading") {


### PR DESCRIPTION
## What
A new "Live logs" panel in the standalone SENTINELLE-GSM webui that streams the service's own systemd-journal via Server-Sent Events.

## Why
You can already see anomaly **alerts** at /sentinelle/ (the v0.2.0 panel). v0.2.2 lets you see what the service is doing **internally** in real time — same page, no SSH needed.

## Pipeline
\`\`\`
journalctl -u secubox-sentinelle-gsm -f -o json   (async subprocess)
        ↓
api.main._journal_stream()                        (parses each JSON line)
        ↓
GET /api/v1/sensor/gsm/journal/stream             (FastAPI SSE)
        ↓
new EventSource(...).addEventListener("log", …)   (browser)
        ↓
Live <pre> panel, auto-scroll, colour by priority
\`\`\`

## Privacy / privilege
Read-only. The service user is already in \`systemd-journal\` group via the existing v0.1 postinst — confirmed on gk2 :
\`\`\`
$ id secubox
…,999(systemd-journal),…
\`\`\`
No \`sudo\`, no new udev rules, no PrivilegeEscalation flags.

## Files
- \`api/main.py\` — \`_journal_stream()\` async generator + \`GET /journal/stream\` route
- \`nginx/sentinelle-webui.conf\` — second SSE-tuned \`^~\` location block for \`/journal/stream\` mirroring \`/alerts/stream\` (24h timeouts, no buffering, no cache)
- \`www/sentinelle/index.html\` — new \`<section id="logs">\` panel + sidebar link
- \`www/sentinelle/sentinelle.js\` — \`startJournalStream()\` + \`appendLogLine()\` with 500-line cap, autoscroll toggle, clear button
- \`www/sentinelle/sentinelle.css\` — \`.logs-pre\` block + per-priority colour classes
- \`debian/changelog\` — bump 0.2.1 → 0.2.2

## Why no live deploy in this PR description
The GSM 900 sweep launched earlier ([PID 530590](sweep ARFCNs 0-124 + 975-1023) is currently using the RTL-SDR, and the v0.2 service holds the device when started (the known v0.3 release-lifecycle bug). Once the sweep finishes I'll redeploy + verify the logs panel live on https://admin.gk2.secubox.in/sentinelle/.

## Test plan
- [x] \`dpkg-buildpackage\` clean; .deb ships api/main.py + the new HTML/CSS/JS + the updated nginx conf
- [ ] live on gk2: load /sentinelle/, scroll to "Live logs" panel, see real-time \`journalctl\` lines flowing
- [ ] kill the service via SSH, watch the panel show the "Deactivated successfully" line within 1 s
- [ ] toggle autoscroll, confirm scroll position holds when off