### PR TITLE
fix(secubox-sentinelle-gsm): v0.2.3 — SSE first-byte heartbeat (unstucks browser CONNECTING)

### DIFF
--- a/packages/secubox-sentinelle-gsm/api/main.py
+++ b/packages/secubox-sentinelle-gsm/api/main.py
@@ -306,10 +306,22 @@ async def _journal_stream() -> "AsyncIterator[str]":  # noqa: F821
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.DEVNULL,
     )
+    # Emit a `: subscribed` SSE comment IMMEDIATELY so browsers transition
+    # EventSource from CONNECTING to OPEN even if the journal happens to
+    # be idle. Then loop with a 30 s heartbeat that pings the connection
+    # alive across HAProxy/mitmproxy/nginx idle timeouts.
+    yield ": subscribed\n\n"
+    HEARTBEAT_SEC = 30.0
     try:
         assert proc.stdout is not None
         while True:
-            line = await proc.stdout.readline()
+            try:
+                line = await asyncio.wait_for(
+                    proc.stdout.readline(), timeout=HEARTBEAT_SEC
+                )
+            except asyncio.TimeoutError:
+                yield ": ping\n\n"
+                continue
             if not line:
                 break
             try:

--- a/packages/secubox-sentinelle-gsm/api/tests/test_alert_sink.py
+++ b/packages/secubox-sentinelle-gsm/api/tests/test_alert_sink.py
@@ -53,16 +53,22 @@ async def test_subscribe_receives_new_alerts(sink):
 
 
 @pytest.mark.asyncio
-async def test_stream_emits_sse_format(sink):
-    """One alert written, one SSE chunk yielded."""
-    async def collect_one():
-        gen = sink.stream()
-        return await asyncio.wait_for(gen.__anext__(), timeout=1.0)
-    task = asyncio.create_task(collect_one())
-    await asyncio.sleep(0.05)  # let subscribe() register
+async def test_stream_emits_subscribed_then_alert(sink):
+    """First SSE chunk is the `: subscribed` comment (forces EventSource
+    open), then the next chunk is the alert event."""
+    gen = sink.stream()
+    # First chunk must be the immediate subscribed comment so the
+    # browser transitions EventSource readyState CONNECTING → OPEN
+    # even when the alert queue is empty.
+    first = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+    assert first == ": subscribed\n\n"
+
+    # Now write an alert and consume the next chunk — it should be the
+    # alert event in proper SSE format.
     sink.write(Alert(cell_id="208-01-100-77777", arfcn=88, score=91, reason="identity_request_abuse"))
-    chunk = await task
+    chunk = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
     assert chunk.startswith("event: alert\n")
     data_line = next(l for l in chunk.split("\n") if l.startswith("data: "))
     payload = json.loads(data_line[len("data: "):])
     assert payload["cell_id"] == "208-01-100-77777"
+    await gen.aclose()

--- a/packages/secubox-sentinelle-gsm/debian/changelog
+++ b/packages/secubox-sentinelle-gsm/debian/changelog
@@ -1,3 +1,20 @@
+secubox-sentinelle-gsm (0.2.3-1~bookworm1) bookworm; urgency=medium
+
+  * lib/sentinelle_gsm/alert_sink.py: AlertSink.stream() now emits a
+    `: subscribed` SSE comment IMMEDIATELY on subscribe, then a `: ping`
+    heartbeat every 30 s. Without the initial comment chunk the response
+    body stayed empty until the first alert was written, and browsers
+    kept EventSource.readyState in CONNECTING (0) forever — the webui
+    showed "SSE stream: connecting…" until manually triggered.
+  * api/main.py: _journal_stream() gets the same treatment (defensive —
+    catches the idle-journal edge case + keeps the long-poll alive
+    across HAProxy/mitmproxy/nginx idle timeouts).
+  * api/tests/test_alert_sink.py: updated test to consume the initial
+    subscribed comment then the alert event in sequence (5/5 still pass).
+  * Full pytest sweep 29/29 still green.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Fri, 22 May 2026 15:00:00 +0000
+
 secubox-sentinelle-gsm (0.2.2-1~bookworm1) bookworm; urgency=medium
 
   * api/main.py: new GET /journal/stream endpoint streaming the service's

--- a/packages/secubox-sentinelle-gsm/lib/sentinelle_gsm/alert_sink.py
+++ b/packages/secubox-sentinelle-gsm/lib/sentinelle_gsm/alert_sink.py
@@ -106,11 +106,28 @@ class AlertSink:
             pass
 
     async def stream(self) -> AsyncIterator[str]:
-        """Yield SSE-formatted text/event-stream chunks."""
+        """Yield SSE-formatted text/event-stream chunks.
+
+        Emits a `: subscribed` SSE comment IMMEDIATELY so browsers see
+        the first response body byte and transition `EventSource.readyState`
+        from CONNECTING (0) to OPEN (1). Without this, the response would
+        hang on `q.get()` until the first alert is written — browsers stay
+        in CONNECTING and the UI shows "connecting…" forever.
+
+        Also emits a `: ping` heartbeat every 30 s so intermediate proxies
+        (HAProxy, mitmproxy, nginx) keep the long-poll connection alive.
+        """
         q = self.subscribe()
+        # SSE comments — browsers + EventSource ignore lines starting with ":"
+        yield ": subscribed\n\n"
+        HEARTBEAT_SEC = 30.0
         try:
             while True:
-                alert = await q.get()
+                try:
+                    alert = await asyncio.wait_for(q.get(), timeout=HEARTBEAT_SEC)
+                except asyncio.TimeoutError:
+                    yield ": ping\n\n"
+                    continue
                 yield "event: alert\ndata: " + json.dumps(asdict(alert)) + "\n\n"
         finally:
             self.unsubscribe(q)


### PR DESCRIPTION
## Symptom (caught live on gk2 right after PR #343 deploy)

The webui at /sentinelle/ showed permanent "**SSE stream: connecting…**" — the "live" status pill never appeared. POSTing a test alert via curl wrote the alert to history (GET /alerts confirmed it), but the row didn't appear in the live feed unless the user hit "Refresh history" manually.

Browser dev tools (had they been opened) would show \`EventSource.readyState === 0\` (CONNECTING) staying that way forever, while the same endpoint returns 200 + \`text/event-stream\` to curl. The journal stream worked because it bootstraps with \`journalctl -n 50\` (50 lines yielded immediately).

## Root cause

\`AlertSink.stream()\` blocked on \`await q.get()\` until the first alert was written. FastAPI \`StreamingResponse\` waits for the first yield from the async generator before flushing the response body — only headers go out, body stays empty. Browsers don't transition \`EventSource\` readyState CONNECTING → OPEN until the first body byte arrives, regardless of whether the response status is 200.

## Fix

1. \`AlertSink.stream()\` emits \`: subscribed\\n\\n\` (SSE comment, ignored by the browser per spec) **immediately** on subscribe. Browsers see the body byte → readyState transitions to OPEN → my JS "open" handler fires → status pill flips to "live".
2. The same loop wraps \`q.get()\` in \`asyncio.wait_for\` with a 30 s timeout that emits \`: ping\\n\\n\` heartbeats. Keeps the long-poll alive across HAProxy / mitmproxy / nginx idle timeouts.
3. Same defensive pattern applied to \`_journal_stream()\` in api/main.py — although the journal stream usually works (journalctl bootstrap), the heartbeat covers the rare idle-journal edge case + same idle-proxy concern.

## Test plan
- [x] \`pytest api/tests/test_alert_sink.py -v\` → 5/5 (existing test updated to consume \`: subscribed\` first, then the alert event)
- [x] Full sweep \`pytest api/tests/ tests/\` → 29/29 still green
- [x] dpkg-buildpackage clean; .deb ships the patched alert_sink.py + api/main.py
- [ ] Live on gk2: load /sentinelle/, SSE status pill flips to "live" within ~200 ms even with no alerts in queue
- [ ] POST /alerts/test → row appears in live feed table within ~100 ms, browser desktop notif fires

Closes the "SSE stuck CONNECTING" symptom reported on the v0.2.2 deploy.