### PR TITLE
fix(secubox-sentinelle-gsm): v0.3.2 — LivemonRunner natural-exit watcher + scan tuning params (closes #351)

### DIFF
--- a/packages/secubox-sentinelle-gsm/api/main.py
+++ b/packages/secubox-sentinelle-gsm/api/main.py
@@ -649,6 +649,17 @@ def set_mode(payload: dict = Body(...)) -> dict:
 
 class ScanStartBody(BaseModel):
     freq: str
+    # v0.3.2: optional tuning. Each falls back to grgsm_livemon_headless's
+    # own default when None. Mostly useful when the carrier RF environment
+    # needs more gain or the dongle's crystal needs a ppm correction.
+    gain: Optional[float] = None
+    samp_rate: Optional[str] = None
+    ppm: Optional[float] = None
+    # gr-osmosdr device-args. Default rtl=0 forces the RTL-SDR backend
+    # (osmosdr's default loads UHD/USRP and fails when none is plugged).
+    # Operators can override to experiment with alternative syntaxes
+    # while we figure out why livemon rejects what scanner accepts.
+    args: str = "rtl=0"
 
 
 def _scan_status_payload(st) -> dict:
@@ -680,7 +691,13 @@ async def scan_start(body: ScanStartBody) -> dict:
     except OSError as e:
         raise HTTPException(500, f"listener bind failed: {e}")
     try:
-        status = await runner.start(body.freq)
+        status = await runner.start(
+            body.freq,
+            gain=body.gain,
+            samp_rate=body.samp_rate,
+            ppm=body.ppm,
+            args=body.args,
+        )
     except RuntimeError as e:
         # runner refused (already running) — undo the listener bind
         await listener.stop()

--- a/packages/secubox-sentinelle-gsm/api/tests/test_livemon_runner.py
+++ b/packages/secubox-sentinelle-gsm/api/tests/test_livemon_runner.py
@@ -9,6 +9,26 @@ from unittest.mock import patch, AsyncMock, MagicMock
 from sentinelle_gsm.livemon_runner import LivemonRunner, ScanStatus
 
 
+def _make_fake_proc(wait_returns: int | None = None):
+    """Build a MagicMock asyncio Process. If `wait_returns` is None, wait()
+    blocks forever (simulates a still-running child). Otherwise it
+    resolves with the given returncode (simulates natural exit)."""
+    fake = MagicMock(spec=asyncio.subprocess.Process)
+    fake.pid = 12345
+    fake.returncode = None
+    fake.stderr = AsyncMock()
+    fake.stderr.read = AsyncMock(return_value=b"")
+    fake.terminate = MagicMock()
+    if wait_returns is None:
+        # Never resolves while the test holds it.
+        fake.wait = AsyncMock(side_effect=lambda: asyncio.Future())
+    else:
+        async def _wait():
+            return wait_returns
+        fake.wait = AsyncMock(side_effect=_wait)
+    return fake
+
+
 @pytest.mark.asyncio
 async def test_initial_status_not_running():
     r = LivemonRunner()
@@ -20,12 +40,8 @@ async def test_initial_status_not_running():
 @pytest.mark.asyncio
 async def test_start_spawns_with_rtl_args():
     r = LivemonRunner()
-    fake_proc = MagicMock(spec=asyncio.subprocess.Process)
-    fake_proc.pid = 12345
-    fake_proc.returncode = None
-    fake_proc.stderr = AsyncMock()
-    fake_proc.stderr.read = AsyncMock(return_value=b"")
-    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake_proc)) as mck:
+    fake = _make_fake_proc()      # never exits
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)) as mck:
         s = await r.start("925.4M")
     args = mck.call_args[0]
     assert "--args=rtl=0" in args
@@ -37,9 +53,8 @@ async def test_start_spawns_with_rtl_args():
 @pytest.mark.asyncio
 async def test_start_refuses_double_start():
     r = LivemonRunner()
-    fake_proc = MagicMock(); fake_proc.pid = 12345; fake_proc.returncode = None
-    fake_proc.stderr = AsyncMock(); fake_proc.stderr.read = AsyncMock(return_value=b"")
-    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake_proc)):
+    fake = _make_fake_proc()      # never exits → "still running"
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)):
         await r.start("925.4M")
         with pytest.raises(RuntimeError, match="already running"):
             await r.start("947.4M")
@@ -48,14 +63,26 @@ async def test_start_refuses_double_start():
 @pytest.mark.asyncio
 async def test_stop_sends_sigterm_then_clears_state():
     r = LivemonRunner()
-    fake_proc = MagicMock(); fake_proc.pid = 12345; fake_proc.returncode = None
-    fake_proc.stderr = AsyncMock(); fake_proc.stderr.read = AsyncMock(return_value=b"")
-    fake_proc.terminate = MagicMock()
-    fake_proc.wait = AsyncMock(return_value=0)
-    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake_proc)):
+    fake = _make_fake_proc()      # never exits naturally → terminate path
+    # When stop() calls terminate, proc.wait() must then resolve so the
+    # caller doesn't block forever. Switch wait() to a resolving variant
+    # after terminate is called.
+    resolve_event = asyncio.Event()
+
+    async def waiting():
+        await resolve_event.wait()
+        return 0
+
+    fake.wait = AsyncMock(side_effect=waiting)
+
+    def on_terminate():
+        resolve_event.set()
+    fake.terminate.side_effect = on_terminate
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)):
         await r.start("925.4M")
         s = await r.stop()
-    fake_proc.terminate.assert_called_once()
+    fake.terminate.assert_called_once()
     assert s.running is False
 
 
@@ -64,3 +91,69 @@ async def test_stop_when_not_running_is_noop():
     r = LivemonRunner()
     s = await r.stop()
     assert s.running is False
+
+
+# ── v0.3.2 NEW TESTS ───────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watcher_marks_done_on_natural_exit():
+    """Bug v0.3.1 → v0.3.2 fix: a grgsm crash must flip status.running
+    to False without anyone calling stop(). The watcher task awaits
+    proc.wait() and sets _done."""
+    r = LivemonRunner()
+    fake = _make_fake_proc(wait_returns=42)    # natural exit code=42
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)):
+        s = await r.start("925.4M")
+        # Right after start, the watcher hasn't run yet
+        assert s.running is True
+        # Yield to the event loop so the watcher's wait() resolves
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        # status() must now report running=False (watcher set _done)
+        s2 = r.status()
+    assert s2.running is False
+
+
+@pytest.mark.asyncio
+async def test_start_passes_gain_samp_rate_ppm():
+    """v0.3.2: optional tuning params appear in the argv."""
+    r = LivemonRunner()
+    fake = _make_fake_proc()
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)) as mck:
+        await r.start("925.4M", gain=45, samp_rate="2.4M", ppm=10)
+    args = mck.call_args[0]
+    assert "-g" in args and "45" in args
+    assert "-s" in args and "2.4M" in args
+    assert "-p" in args and "10" in args
+
+
+@pytest.mark.asyncio
+async def test_start_custom_args_override():
+    """v0.3.2: gr-osmosdr args can be overridden from the caller."""
+    r = LivemonRunner()
+    fake = _make_fake_proc()
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)) as mck:
+        await r.start("925.4M", args="numchan=1,rtl=0")
+    args = mck.call_args[0]
+    assert "--args=numchan=1,rtl=0" in args
+    # Default rtl=0 should NOT be in argv when overridden
+    assert "--args=rtl=0" not in args
+
+
+@pytest.mark.asyncio
+async def test_double_start_after_natural_exit_is_allowed():
+    """v0.3.2 fix: once the child exits naturally, start() must accept
+    a new scan without an explicit stop() first."""
+    r = LivemonRunner()
+    fake1 = _make_fake_proc(wait_returns=1)   # crashes immediately
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake1)):
+        await r.start("925.4M")
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+    # First child exited via watcher. status() should report not running.
+    assert r.status().running is False
+    # Second start with a fresh proc — should succeed, NOT raise.
+    fake2 = _make_fake_proc()
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake2)):
+        s = await r.start("947.4M")
+    assert s.running is True

--- a/packages/secubox-sentinelle-gsm/debian/changelog
+++ b/packages/secubox-sentinelle-gsm/debian/changelog
@@ -1,3 +1,29 @@
+secubox-sentinelle-gsm (0.3.2-1~bookworm1) bookworm; urgency=medium
+
+  * lib/sentinelle_gsm/livemon_runner.py: NEW watcher task awaits the
+    subprocess natural exit and flips `_done=True`. Status.running now
+    reflects "child still alive" correctly even when grgsm crashes
+    silently (gr-osmosdr "Wrong rtlsdr device index given" was the
+    trigger on gk2). Without this, /scan/status reported running=true
+    long after the child was dead and /scan/start kept returning 409
+    "already running" until an explicit /scan/stop or service restart.
+  * lib/sentinelle_gsm/livemon_runner.py: start() gains optional `gain`,
+    `samp_rate`, `ppm`, and `args` kwargs passed as -g/-s/-p/--args=
+    flags to grgsm. All None by default → identical CLI to v0.3.1.
+    Operators can now tune RF params without redeploy.
+  * lib/sentinelle_gsm/livemon_runner.py: stop() is now idempotent and
+    skips SIGTERM if the child already exited; still produces a clean
+    ScanStatus with stderr_tail for diagnostics.
+  * api/main.py: POST /scan/start accepts gain/samp_rate/ppm/args body
+    fields (all optional). Same behavior as v0.3.1 when omitted.
+  * api/tests/test_livemon_runner.py: 4 new tests (watcher, tuning
+    args, custom args, restart-after-natural-exit) + the 5 existing
+    refactored to use a `_make_fake_proc()` helper that lets each test
+    pick whether proc.wait() blocks or resolves. Full sweep 86/86.
+  * Closes #351. Refs #349 #344.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Fri, 22 May 2026 18:00:00 +0000
+
 secubox-sentinelle-gsm (0.3.1-1~bookworm1) bookworm; urgency=medium
 
   * lib/sentinelle_gsm/l3_decode.py: NEW — pure-Python TLV parser for

--- a/packages/secubox-sentinelle-gsm/lib/sentinelle_gsm/livemon_runner.py
+++ b/packages/secubox-sentinelle-gsm/lib/sentinelle_gsm/livemon_runner.py
@@ -78,10 +78,20 @@ class LivemonRunner:
         self._started_at: Optional[float] = None
         self._stderr_buf = bytearray()
         self._stderr_task: Optional[asyncio.Task] = None
+        # v0.3.2: watcher task — awaits proc.wait() so we detect natural
+        # exit (e.g. gr-osmosdr crash) without relying on the caller
+        # polling proc.returncode. Set in start(), cleared in stop().
+        # `_done` is True once the watcher observes the child exited.
+        self._watcher_task: Optional[asyncio.Task] = None
+        self._done: bool = False
         self._bin = shutil.which("grgsm_livemon_headless") or "/usr/bin/grgsm_livemon_headless"
 
     def status(self) -> ScanStatus:
-        running = self._proc is not None and self._proc.returncode is None
+        # v0.3.2 fix: "running" now means proc exists AND watcher hasn't
+        # observed exit. Without this, a crashed grgsm child left
+        # proc.returncode=None forever (since nobody awaited proc.wait()),
+        # so status().running stayed True and /scan/start kept 409-ing.
+        running = self._proc is not None and not self._done
         return ScanStatus(
             running=running,
             pid=self._proc.pid if running else None,
@@ -90,44 +100,93 @@ class LivemonRunner:
             stderr_tail=self._stderr_buf.decode(errors="replace")[-2000:],
         )
 
-    async def start(self, freq: str) -> ScanStatus:
+    async def start(
+        self,
+        freq: str,
+        gain: Optional[float] = None,
+        samp_rate: Optional[str] = None,
+        ppm: Optional[float] = None,
+        args: str = "rtl=0",
+    ) -> ScanStatus:
         """Spawn grgsm_livemon_headless on the given frequency.
 
         freq: anything grgsm_livemon_headless accepts, e.g. '925.4M', '947.4e6'.
+        gain: optional RF gain (dB). grgsm default = 30. None = pass nothing
+            (let grgsm use its default).
+        samp_rate: optional sample rate string ('2.0M'). None = grgsm default.
+        ppm: optional clock offset in ppm. None = grgsm default (0).
+        args: gr-osmosdr device args. Default 'rtl=0' forces the RTL-SDR
+            backend (otherwise osmosdr loads UHD/USRP by default and
+            crashes when no USRP is plugged in).
         """
-        if self._proc is not None and self._proc.returncode is None:
+        if self._proc is not None and not self._done:
             raise RuntimeError("scan already running — stop first")
 
-        # gr-osmosdr default device is UHD; force RTL-SDR via --args=rtl=0
+        argv = [self._bin, f"--args={args}", "-f", freq]
+        if gain is not None:
+            argv += ["-g", str(gain)]
+        if samp_rate is not None:
+            argv += ["-s", str(samp_rate)]
+        if ppm is not None:
+            argv += ["-p", str(ppm)]
+
         self._proc = await asyncio.create_subprocess_exec(
-            self._bin,
-            "--args=rtl=0",
-            "-f", freq,
+            *argv,
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.PIPE,
         )
         self._freq = freq
         self._started_at = time.time()
         self._stderr_buf = bytearray()
+        self._done = False
         self._stderr_task = asyncio.create_task(self._drain_stderr())
+        self._watcher_task = asyncio.create_task(self._watch_exit())
         return self.status()
 
-    async def stop(self, timeout: float = 5.0) -> ScanStatus:
-        """SIGTERM the child; SIGKILL if it doesn't exit within timeout."""
-        if self._proc is None or self._proc.returncode is not None:
-            return self.status()
-        self._proc.terminate()
+    async def _watch_exit(self) -> None:
+        """Set self._done as soon as the child exits naturally (crash or
+        clean stop). Keeps stderr_buf intact for diagnostics."""
+        if self._proc is None:
+            return
         try:
-            await asyncio.wait_for(self._proc.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
-            self._proc.kill()
             await self._proc.wait()
-        if self._stderr_task:
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._done = True
+
+    async def stop(self, timeout: float = 5.0) -> ScanStatus:
+        """SIGTERM the child; SIGKILL if it doesn't exit within timeout.
+
+        Idempotent: if the child already exited naturally (the watcher
+        has observed self._done=True), stop() captures the stderr_tail
+        in the returned ScanStatus and clears the slot.
+        """
+        if self._proc is None:
+            return self.status()
+        # Child still alive — send SIGTERM, then SIGKILL on timeout.
+        if not self._done:
+            self._proc.terminate()
+            try:
+                await asyncio.wait_for(self._proc.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                self._proc.kill()
+                await self._proc.wait()
+        # At this point the child has exited. Cancel the helpers and
+        # produce a final status with stderr_tail BEFORE clearing _proc.
+        if self._stderr_task and not self._stderr_task.done():
             self._stderr_task.cancel()
+        if self._watcher_task and not self._watcher_task.done():
+            self._watcher_task.cancel()
+        final = ScanStatus(
+            running=False, pid=None, freq=None, started_at=None,
+            stderr_tail=self._stderr_buf.decode(errors="replace")[-2000:],
+        )
         self._proc = None
         self._freq = None
         self._started_at = None
-        return self.status()
+        self._done = False
+        return final
 
     async def _drain_stderr(self) -> None:
         assert self._proc is not None and self._proc.stderr is not None


### PR DESCRIPTION
## Bugs (both caught during v0.3.1 live deploy on gk2)

### Bug 1 — \`LivemonRunner.status()\` reported running=True forever after grgsm crash
Symptom: \`grgsm_livemon_headless\` crashed with \`RuntimeError: Wrong rtlsdr device index given\`, but \`/scan/status\` kept saying \`running:true\` for minutes. \`/scan/start\` returned \`409\` on every retry. Only an explicit \`/scan/stop\` or service restart cleared the state.

Root cause: \`status()\` checked \`self._proc.returncode is None\`, but \`returncode\` is only set when SOMEONE awaits \`proc.wait()\` — the v0.3.0 runner had NO watcher task, only a stderr drainer.

Fix: \`asyncio.create_task(_watch_exit())\` in \`start()\`. The watcher awaits \`proc.wait()\` and sets \`self._done=True\` on natural exit. \`status().running\` is now \`self._proc is not None AND not self._done\` — flips to False the instant the child crashes, with NO caller involvement.

### Bug 2 — gr-osmosdr / RF params couldn't be tuned without redeploying

Fix: \`start()\` gains optional \`gain\`, \`samp_rate\`, \`ppm\`, \`args\` kwargs. POST /scan/start body exposes them. Defaults None → identical CLI to v0.3.1 (no behavior change for existing callers). Operators can now experiment with \`{"args": "numchan=1,rtl=0"}\` etc. while we figure out the gr-osmosdr quirk that makes livemon reject what scanner accepts.

\`stop()\` becomes idempotent: skips SIGTERM if the child already exited, still emits clean \`ScanStatus\` with the captured stderr_tail.

## Tests
- 9 livemon_runner tests (5 refactored with a \`_make_fake_proc()\` helper that picks whether \`proc.wait()\` blocks or resolves + 4 new: watcher detection, tuning args wiring, custom args override, restart after natural exit)
- Full sweep **86/86 passing** (82 baseline + 4 new)
- dpkg-buildpackage clean; 0.3.2 .deb ships the patched livemon_runner.py + main.py

## Deferred to v0.3.3
- gr-osmosdr device-selection deep-dive — figure out why \`--args=rtl=0\` works for grgsm_scanner but fails for grgsm_livemon_headless on the same dongle, same kernel. Likely needs \`numchan=1,direct_samp=2\` or similar tuning, which the new \`args\` kwarg now lets us experiment with from the API without rebuild

Closes #351. Refs #349 #344.