### PR TITLE
fix(sentinelle-gsm): v0.3.4 — gr-gsm shim + AF_NETLINK + serverport+1 (closes #353, #354)

### DIFF
--- a/packages/secubox-sentinelle-gsm/api/main.py
+++ b/packages/secubox-sentinelle-gsm/api/main.py
@@ -655,11 +655,14 @@ class ScanStartBody(BaseModel):
     gain: Optional[float] = None
     samp_rate: Optional[str] = None
     ppm: Optional[float] = None
-    # gr-osmosdr device-args. Default rtl=0 forces the RTL-SDR backend
-    # (osmosdr's default loads UHD/USRP and fails when none is plugged).
-    # Operators can override to experiment with alternative syntaxes
-    # while we figure out why livemon rejects what scanner accepts.
-    args: str = "rtl=0"
+    # v0.3.3: gr-osmosdr device-args, opt-in only. Default None → no --args
+    # flag passed; gr-osmosdr auto-picks the first RTL-SDR (the form gkerma's
+    # IMSI-catcher project uses). Set explicitly when you need to override.
+    args: Optional[str] = None
+    # v0.3.3: GSMTAP UDP port for the livemon child. None → 4729 (grgsm
+    # default, the port the listener binds). Override when multiplexing
+    # several runners across 4730/4731/… for multi-cell capture.
+    serverport: Optional[int] = None
 
 
 def _scan_status_payload(st) -> dict:
@@ -697,6 +700,7 @@ async def scan_start(body: ScanStartBody) -> dict:
             samp_rate=body.samp_rate,
             ppm=body.ppm,
             args=body.args,
+            serverport=body.serverport,
         )
     except RuntimeError as e:
         # runner refused (already running) — undo the listener bind

--- a/packages/secubox-sentinelle-gsm/api/tests/test_livemon_runner.py
+++ b/packages/secubox-sentinelle-gsm/api/tests/test_livemon_runner.py
@@ -38,13 +38,19 @@ async def test_initial_status_not_running():
 
 
 @pytest.mark.asyncio
-async def test_start_spawns_with_rtl_args():
+async def test_start_default_no_args_flag():
+    """v0.3.3: with no `args` kwarg, argv must NOT contain any --args=*.
+    The IMSI-catcher scan-and-livemon pattern proves this is the
+    canonical invocation — livemon rejects the same syntax scanner
+    accepts (different code paths in gnuradio)."""
     r = LivemonRunner()
     fake = _make_fake_proc()      # never exits
     with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)) as mck:
         s = await r.start("925.4M")
     args = mck.call_args[0]
-    assert "--args=rtl=0" in args
+    assert not any(a.startswith("--args=") for a in args), (
+        f"v0.3.3 fix: no --args flag in default invocation, got {args}"
+    )
     assert "-f" in args and "925.4M" in args
     assert s.running is True
     assert s.pid == 12345
@@ -129,15 +135,44 @@ async def test_start_passes_gain_samp_rate_ppm():
 
 @pytest.mark.asyncio
 async def test_start_custom_args_override():
-    """v0.3.2: gr-osmosdr args can be overridden from the caller."""
+    """v0.3.2: gr-osmosdr args can be overridden from the caller.
+    v0.3.3: opt-in only (default is None — see test_start_default_no_args_flag)."""
     r = LivemonRunner()
     fake = _make_fake_proc()
     with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)) as mck:
         await r.start("925.4M", args="numchan=1,rtl=0")
     args = mck.call_args[0]
     assert "--args=numchan=1,rtl=0" in args
-    # Default rtl=0 should NOT be in argv when overridden
+    # The override is the only --args= token; no leftover default rtl=0.
     assert "--args=rtl=0" not in args
+
+
+@pytest.mark.asyncio
+async def test_start_serverport_kwarg():
+    """v0.3.3: --serverport is passed through. Enables multi-cell capture
+    where N runners multiplex onto 4730/4731/… (the IMSI-catcher
+    scan-and-livemon pattern)."""
+    r = LivemonRunner()
+    fake = _make_fake_proc()
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)) as mck:
+        await r.start("925.4M", serverport=4731)
+    args = mck.call_args[0]
+    assert "--serverport=4731" in args
+
+
+@pytest.mark.asyncio
+async def test_start_no_serverport_omits_flag():
+    """v0.3.3: default serverport=None means the flag is not emitted —
+    grgsm uses its own default (4729, also where the listener binds), so
+    single-cell capture remains the no-flag path."""
+    r = LivemonRunner()
+    fake = _make_fake_proc()
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)) as mck:
+        await r.start("925.4M")
+    args = mck.call_args[0]
+    assert not any(a.startswith("--serverport=") for a in args), (
+        f"default serverport must omit flag, got {args}"
+    )
 
 
 @pytest.mark.asyncio

--- a/packages/secubox-sentinelle-gsm/api/tests/test_livemon_runner.py
+++ b/packages/secubox-sentinelle-gsm/api/tests/test_livemon_runner.py
@@ -161,18 +161,32 @@ async def test_start_serverport_kwarg():
 
 
 @pytest.mark.asyncio
-async def test_start_no_serverport_omits_flag():
-    """v0.3.3: default serverport=None means the flag is not emitted —
-    grgsm uses its own default (4729, also where the listener binds), so
-    single-cell capture remains the no-flag path."""
+async def test_start_default_serverport_is_gsmtap_plus_one():
+    """v0.3.4: default --serverport must be one above the listener's
+    GSMTAP port (gsmtap_port=4729 default → --serverport=4730). grgsm
+    BINDS its --serverport, so leaving it at the grgsm built-in default
+    (4729) collides with our listener and crashes the child with
+    `RuntimeError: bind: Address already in use`. The IMSI-catcher
+    scan-and-livemon project dodges this the same way."""
     r = LivemonRunner()
     fake = _make_fake_proc()
     with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)) as mck:
         await r.start("925.4M")
     args = mck.call_args[0]
-    assert not any(a.startswith("--serverport=") for a in args), (
-        f"default serverport must omit flag, got {args}"
+    assert "--serverport=4730" in args, (
+        f"default serverport must be gsmtap_port+1=4730, got {args}"
     )
+
+
+@pytest.mark.asyncio
+async def test_start_default_serverport_follows_custom_gsmtap_port():
+    """v0.3.4: a non-default GSMTAP port still drives --serverport+1."""
+    r = LivemonRunner(gsmtap_port=5000)
+    fake = _make_fake_proc()
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)) as mck:
+        await r.start("925.4M")
+    args = mck.call_args[0]
+    assert "--serverport=5001" in args, args
 
 
 @pytest.mark.asyncio

--- a/packages/secubox-sentinelle-gsm/debian/changelog
+++ b/packages/secubox-sentinelle-gsm/debian/changelog
@@ -16,6 +16,25 @@ secubox-sentinelle-gsm (0.3.4-1~bookworm1) bookworm; urgency=medium
     shim's CLI is identical to the upstream's (runpy passes argv
     through), so no other Runner state changes.
   * debian/rules: install the shim into /usr/libexec/secubox/.
+  * debian/secubox-sentinelle-gsm.service: add AF_NETLINK to
+    RestrictAddressFamilies. libusb 1.0 / libudev subscribe to kernel
+    uevents over netlink; without it, libusb_init() aborts (proved on
+    gk2 by elimination — relaxing MDWE + SystemCallFilter via a
+    transient drop-in did NOT unblock scans). One token, every other
+    CSPN-relevant restriction intact (NoNewPrivileges, ProtectSystem,
+    ProtectHome, CapabilityBoundingSet=, MemoryDenyWriteExecute=true,
+    SystemCallFilter=@system-service).
+  * lib/sentinelle_gsm/livemon_runner.py: --serverport now defaults to
+    `gsmtap_port + 1` (= 4730 with the standard 4729 listener) instead
+    of letting grgsm pick its built-in default of 4729. grgsm BINDS
+    --serverport (not connects to it), so leaving the default collided
+    with our listener and crashed the child with `RuntimeError: bind:
+    Address already in use`. The IMSI-catcher scan-and-livemon project
+    avoids the same collision (serverport=4730+i). Callers can still
+    override.
+  * tests: replace test_start_no_serverport_omits_flag with two new
+    tests covering the default+1 behavior and the custom-gsmtap-port
+    case. 71/71 sweep.
   * Validated on gk2 (kernel 6.12.85, gr-gsm 1.0.0~20220727-1+b3,
     libgnuradio-osmosdr0.2.0 0.2.4-1): gr-osmosdr finds the
     RTL2838UHIDIR (`Using device #0 Realtek RTL2838UHIDIR SN:

--- a/packages/secubox-sentinelle-gsm/debian/changelog
+++ b/packages/secubox-sentinelle-gsm/debian/changelog
@@ -1,3 +1,27 @@
+secubox-sentinelle-gsm (0.3.3-1~bookworm1) bookworm; urgency=medium
+
+  * lib/sentinelle_gsm/livemon_runner.py: drop the `--args=rtl=0` default
+    that v0.3.2 emitted unconditionally. gr-osmosdr's livemon code path
+    rejected it with "Wrong rtlsdr device index given" — different from
+    grgsm_scanner, which accepts the same syntax. The canonical form
+    proven by gkerma/IMSI-catcher's scan-and-livemon is the bare
+    `-f FREQ` invocation: gr-osmosdr auto-picks the first RTL-SDR. The
+    `args` kwarg is still available as opt-in for overrides.
+  * lib/sentinelle_gsm/livemon_runner.py: new optional `serverport`
+    kwarg → passes `--serverport=N` through to grgsm. Used for
+    multi-cell capture, where N runners multiplex onto 4730/4731/…
+    while the listener demuxes (same pattern as scan-and-livemon).
+  * api/main.py: ScanStartBody — `args` is now `Optional[str] = None`
+    (was `"rtl=0"`); added `serverport: Optional[int] = None`. POST
+    /scan/start passes both through.
+  * api/tests/test_livemon_runner.py: rename `test_start_spawns_with_rtl_args`
+    → `test_start_default_no_args_flag` (inverted assertion: argv must
+    NOT contain any `--args=*`); add `test_start_serverport_kwarg` +
+    `test_start_no_serverport_omits_flag`. 11/11 sweep.
+  * Closes #353. Refs #351.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Fri, 22 May 2026 19:30:00 +0000
+
 secubox-sentinelle-gsm (0.3.2-1~bookworm1) bookworm; urgency=medium
 
   * lib/sentinelle_gsm/livemon_runner.py: NEW watcher task awaits the

--- a/packages/secubox-sentinelle-gsm/debian/changelog
+++ b/packages/secubox-sentinelle-gsm/debian/changelog
@@ -1,3 +1,30 @@
+secubox-sentinelle-gsm (0.3.4-1~bookworm1) bookworm; urgency=medium
+
+  * sbin/secubox-grgsm-livemon-shim: NEW thin Python wrapper that
+    monkey-patches gnuradio.gsm.device.match() before runpy()-ing
+    grgsm_livemon_headless. Closes the actual root cause of every
+    livemon crash since v0.3.0: gr-gsm 1.0.0 (Debian bookworm) calls
+    `k in dev` and `dev[k]` against an osmosdr.device_t, but
+    libgnuradio-osmosdr 0.2.4 ships device_t as opaque (only
+    to_string() works), so every invocation crashes with
+    `TypeError: argument of type 'osmosdr.osmosdr_python.device_t'
+    is not iterable`. The shim parses to_string() into a dict and
+    runs the original matching logic against that.
+  * lib/sentinelle_gsm/livemon_runner.py: LivemonRunner now prefers
+    /usr/libexec/secubox/secubox-grgsm-livemon-shim when present,
+    falls back to /usr/bin/grgsm_livemon_headless otherwise. The
+    shim's CLI is identical to the upstream's (runpy passes argv
+    through), so no other Runner state changes.
+  * debian/rules: install the shim into /usr/libexec/secubox/.
+  * Validated on gk2 (kernel 6.12.85, gr-gsm 1.0.0~20220727-1+b3,
+    libgnuradio-osmosdr0.2.0 0.2.4-1): gr-osmosdr finds the
+    RTL2838UHIDIR (`Using device #0 Realtek RTL2838UHIDIR SN:
+    00000001`) and begins sample capture (`Allocating 15 zero-copy
+    buffers`).
+  * Closes #354. Refs #353 #351.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Fri, 22 May 2026 21:00:00 +0000
+
 secubox-sentinelle-gsm (0.3.3-1~bookworm1) bookworm; urgency=medium
 
   * lib/sentinelle_gsm/livemon_runner.py: drop the `--args=rtl=0` default

--- a/packages/secubox-sentinelle-gsm/debian/rules
+++ b/packages/secubox-sentinelle-gsm/debian/rules
@@ -12,6 +12,9 @@ override_dh_auto_install:
 	# CTL
 	install -d debian/secubox-sentinelle-gsm/usr/sbin
 	install -m 755 sbin/sentinellectl debian/secubox-sentinelle-gsm/usr/sbin/sentinellectl
+	# gr-gsm device.py monkey-patch shim (#354)
+	install -d debian/secubox-sentinelle-gsm/usr/libexec/secubox
+	install -m 755 sbin/secubox-grgsm-livemon-shim debian/secubox-sentinelle-gsm/usr/libexec/secubox/secubox-grgsm-livemon-shim
 	# Menu entry
 	install -d debian/secubox-sentinelle-gsm/usr/share/secubox/menu.d
 	[ -d menu.d ] && cp -r menu.d/. debian/secubox-sentinelle-gsm/usr/share/secubox/menu.d/ || true

--- a/packages/secubox-sentinelle-gsm/debian/secubox-sentinelle-gsm.service
+++ b/packages/secubox-sentinelle-gsm/debian/secubox-sentinelle-gsm.service
@@ -26,7 +26,13 @@ NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true
-RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+# AF_NETLINK added in v0.3.4: libusb 1.0 / libudev subscribe to kernel
+# uevents over netlink; without it, gr-osmosdr's libusb_init() aborts
+# with `AssertionError: libusb_init(&_context) == 0` and every scan
+# dies before reaching the RTL-SDR backend. Adding netlink keeps all
+# other CSPN-relevant restrictions intact (the diagnostic on gk2
+# proved dropping MDWE+SystemCallFilter alone did NOT unblock scans).
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
 MemoryDenyWriteExecute=true
 SystemCallFilter=@system-service
 CapabilityBoundingSet=

--- a/packages/secubox-sentinelle-gsm/lib/sentinelle_gsm/livemon_runner.py
+++ b/packages/secubox-sentinelle-gsm/lib/sentinelle_gsm/livemon_runner.py
@@ -142,7 +142,18 @@ class LivemonRunner:
         if self._proc is not None and not self._done:
             raise RuntimeError("scan already running — stop first")
 
-        argv = [self._bin, "-f", freq]
+        # v0.3.4: default grgsm to bind one port above our GSMTAP listener.
+        # grgsm's `network.socket_pdu('UDP_SERVER', '127.0.0.1', serverport,
+        # ...)` block BINDS --serverport (default 4729 — same as our
+        # listener), then sends GSMTAP packets out from there. Without an
+        # explicit override, both processes race for 4729 and grgsm dies
+        # with `RuntimeError: bind: Address already in use`. The
+        # IMSI-catcher project's scan-and-livemon dodges this the same way
+        # (serverport starts at 4730 and increments). Callers can still
+        # override via the kwarg (e.g. for multi-cell with 4731, 4732, …).
+        effective_serverport = serverport if serverport is not None else self.gsmtap_port + 1
+
+        argv = [self._bin, "-f", freq, f"--serverport={effective_serverport}"]
         if args is not None:
             argv += [f"--args={args}"]
         if gain is not None:
@@ -151,8 +162,6 @@ class LivemonRunner:
             argv += ["-s", str(samp_rate)]
         if ppm is not None:
             argv += ["-p", str(ppm)]
-        if serverport is not None:
-            argv += [f"--serverport={serverport}"]
 
         self._proc = await asyncio.create_subprocess_exec(
             *argv,

--- a/packages/secubox-sentinelle-gsm/lib/sentinelle_gsm/livemon_runner.py
+++ b/packages/secubox-sentinelle-gsm/lib/sentinelle_gsm/livemon_runner.py
@@ -84,7 +84,19 @@ class LivemonRunner:
         # `_done` is True once the watcher observes the child exited.
         self._watcher_task: Optional[asyncio.Task] = None
         self._done: bool = False
-        self._bin = shutil.which("grgsm_livemon_headless") or "/usr/bin/grgsm_livemon_headless"
+        # v0.3.4: prefer the gr-gsm device.py monkey-patch shim shipped by
+        # this package (closes #354 — upstream gr-gsm 1.0.0 device.py is
+        # incompatible with libgnuradio-osmosdr 0.2.4, both crash with
+        # `TypeError: argument of type 'osmosdr.device_t' is not iterable`).
+        # Falls back to the upstream binary on systems where the shim isn't
+        # installed (dev, tests, future versions that don't need the patch).
+        # The shim is a thin runpy.run_path() wrapper, so its CLI is
+        # identical to the upstream's — no other Runner state changes.
+        shim = "/usr/libexec/secubox/secubox-grgsm-livemon-shim"
+        if os.path.isfile(shim) and os.access(shim, os.X_OK):
+            self._bin = shim
+        else:
+            self._bin = shutil.which("grgsm_livemon_headless") or "/usr/bin/grgsm_livemon_headless"
 
     def status(self) -> ScanStatus:
         # v0.3.2 fix: "running" now means proc exists AND watcher hasn't

--- a/packages/secubox-sentinelle-gsm/lib/sentinelle_gsm/livemon_runner.py
+++ b/packages/secubox-sentinelle-gsm/lib/sentinelle_gsm/livemon_runner.py
@@ -106,7 +106,8 @@ class LivemonRunner:
         gain: Optional[float] = None,
         samp_rate: Optional[str] = None,
         ppm: Optional[float] = None,
-        args: str = "rtl=0",
+        args: Optional[str] = None,
+        serverport: Optional[int] = None,
     ) -> ScanStatus:
         """Spawn grgsm_livemon_headless on the given frequency.
 
@@ -115,20 +116,31 @@ class LivemonRunner:
             (let grgsm use its default).
         samp_rate: optional sample rate string ('2.0M'). None = grgsm default.
         ppm: optional clock offset in ppm. None = grgsm default (0).
-        args: gr-osmosdr device args. Default 'rtl=0' forces the RTL-SDR
-            backend (otherwise osmosdr loads UHD/USRP by default and
-            crashes when no USRP is plugged in).
+        args: gr-osmosdr device args. v0.3.3: default is None — gkerma's
+            IMSI-catcher project (scan-and-livemon) proves the bare `-f FREQ`
+            form is canonical; gr-osmosdr auto-picks the first RTL-SDR.
+            v0.3.2 defaulted to 'rtl=0' which triggered "Wrong rtlsdr device
+            index given" inside livemon (different code path than
+            grgsm_scanner, which accepts the same syntax). Pass a value here
+            only to override the auto-pick.
+        serverport: optional GSMTAP UDP port (default 4729 inside grgsm).
+            Used for multi-cell capture: spawn N runners on 4730/4731/…
+            and demux on the listener side.
         """
         if self._proc is not None and not self._done:
             raise RuntimeError("scan already running — stop first")
 
-        argv = [self._bin, f"--args={args}", "-f", freq]
+        argv = [self._bin, "-f", freq]
+        if args is not None:
+            argv += [f"--args={args}"]
         if gain is not None:
             argv += ["-g", str(gain)]
         if samp_rate is not None:
             argv += ["-s", str(samp_rate)]
         if ppm is not None:
             argv += ["-p", str(ppm)]
+        if serverport is not None:
+            argv += [f"--serverport={serverport}"]
 
         self._proc = await asyncio.create_subprocess_exec(
             *argv,

--- a/packages/secubox-sentinelle-gsm/sbin/secubox-grgsm-livemon-shim
+++ b/packages/secubox-sentinelle-gsm/sbin/secubox-grgsm-livemon-shim
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+SecuBox-Deb :: secubox-grgsm-livemon-shim
+
+Monkey-patches gr-gsm 1.0.0's gnuradio.gsm.device.match() so it works
+against libgnuradio-osmosdr 0.2.4's opaque osmosdr.device_t, then
+exec()s grgsm_livemon_headless in-process.
+
+Why: the Debian bookworm packaging of gr-gsm assumes device_t is dict-
+like (does `k in dev`, `dev[k]`), but osmosdr 0.2.4 exposes device_t as
+an opaque object whose only useful method is to_string() (a comma-
+separated "key=value,…" string). Result: every grgsm_livemon_headless
+invocation crashes with `TypeError: argument of type
+'osmosdr.osmosdr_python.device_t' is not iterable`. Patching at runtime
+is the cleanest path — no dpkg-divert, no system-file modification.
+
+Validated on gk2 (kernel 6.12.85, libgnuradio-osmosdr0.2.0 0.2.4-1,
+gr-gsm 1.0.0~20220727-1+b3): gr-osmosdr finds the RTL2838UHIDIR and
+begins sample capture (`Using device #0 Realtek RTL2838UHIDIR SN:
+00000001`, `Allocating 15 zero-copy buffers`).
+
+Closes #354. Refs #353 #351.
+"""
+
+import gnuradio.gsm.device as _gsm_device
+
+
+def _patched_match(dev, filters):
+    """Replacement for gnuradio.gsm.device.match() that operates on
+    dev.to_string() instead of subscripting dev directly. Same matching
+    semantics (every k/v in every filter must match in the dev's args)."""
+    try:
+        raw = dev.to_string()
+    except AttributeError:
+        return False
+    kv = {}
+    for item in raw.split(","):
+        if "=" not in item:
+            continue
+        k, v = item.split("=", 1)
+        kv[k.strip()] = v.strip().strip("'\"")
+    for f in filters:
+        for k, v in f.items():
+            if k not in kv or kv[k] != v:
+                break
+        else:
+            return True
+    return False
+
+
+_gsm_device.match = _patched_match
+
+
+import runpy
+runpy.run_path("/usr/bin/grgsm_livemon_headless", run_name="__main__")


### PR DESCRIPTION
## Summary

Three independent bugs were stacked under what looked like the "gr-osmosdr arg mystery" since v0.3.0. This PR ships v0.3.3 + v0.3.4 together (v0.3.3 was on a separate branch but its commit is rebased into this one).

1. **gr-gsm 1.0.0 `device.py` is incompatible with libgnuradio-osmosdr 0.2.4** — `match()` treats `osmosdr.device_t` as a Python dict (`k in dev`, `dev[k]`) but the bookworm-packaged osmosdr exposes `device_t` as opaque; only `to_string()` works. Confirmed by running `grgsm_livemon_headless -f 925.4M` directly as root: same crash, no sandbox involved.
   - **Fix:** ship `/usr/libexec/secubox/secubox-grgsm-livemon-shim` — a thin Python wrapper that monkey-patches `gnuradio.gsm.device.match()` (parses `dev.to_string()` into a dict, then runs the original matching logic) before `runpy.run_path('/usr/bin/grgsm_livemon_headless')`. LivemonRunner prefers the shim when present, falls back to the upstream binary otherwise. No `dpkg-divert`, no system-file modification.

2. **systemd `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX` blocks libudev** — libusb 1.0 / libudev subscribe to kernel uevents over `AF_NETLINK`; without it, `libusb_init()` aborts with `AssertionError: libusb_init(&_context) == 0` before reaching the RTL-SDR backend. Proved on gk2 by elimination — a transient drop-in that disabled `MemoryDenyWriteExecute=` + `SystemCallFilter=` did NOT unblock scans, but adding `AF_NETLINK` did.
   - **Fix:** `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK` in the `.service`. Every other CSPN-relevant restriction intact (`NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome=true`, `CapabilityBoundingSet=`, `MemoryDenyWriteExecute=true`, `SystemCallFilter=@system-service`).

3. **grgsm's default `--serverport=4729` collides with our listener** — `network.socket_pdu('UDP_SERVER', '127.0.0.1', serverport, ...)` at line 71 of `grgsm_livemon_headless` BINDS the port (does not connect), and the built-in default is the same 4729 that our `GsmtapListener` already binds. Child crashes with `RuntimeError: bind: Address already in use`. The gkerma/IMSI-catcher project's `scan-and-livemon` script dodges this the same way (\`serverport = 4730\` and increments).
   - **Fix:** `LivemonRunner.start` now defaults \`--serverport\` to \`gsmtap_port + 1\` (= 4730). Callers can still override (useful for multi-cell capture: 4730/4731/…).

Also includes the v0.3.3 commit that drops the broken \`--args=rtl=0\` default (the IMSI-catcher pattern uses bare \`-f FREQ\` and lets gr-osmosdr auto-pick). That fix is necessary but not sufficient — without the three additional fixes above, every scan died for a different reason.

## Test plan

- [x] 71/71 unit-test sweep green
- [x] \`.deb\` builds clean as \`secubox-sentinelle-gsm_0.3.4-1~bookworm1_all.deb\`
- [x] Deployed on gk2 (kernel 6.12.85, gr-gsm 1.0.0~20220727-1+b3, libgnuradio-osmosdr0.2.0 0.2.4-1) — full hardening unit
- [x] \`POST /scan/start {"freq": "925.4M"}\` → \`running=true\` at @10s/@25s/@45s/@60s (60s sustained, never died)
- [x] stderr_tail shows \`Using device #0 Realtek RTL2838UHIDIR SN: 00000001\` + \`Allocating 15 zero-copy buffers\` + \`OOO\` overruns = data flowing into the decoder
- [x] \`POST /scan/stop\` returns clean status with \`running=false\`
- [x] Service restored to full hardening baseline (\`MemoryDenyWriteExecute=yes\`, \`SystemCallFilter=@system-service\`, \`CapabilityBoundingSet=\`)

0 sightings @ 925.4M is a tuning question (no decodable GSM traffic on that ARFCN at our location), not a pipeline failure. Pick a stronger freq via grgsm_scanner discovery — that's the v0.3.5 multi-cell scope.

## Out of scope (follow-up)

- Multi-cell orchestration — \`grgsm_scanner\` discovery → spawn N livemons on \`--serverport=4730+i\` (the full IMSI-catcher pattern). Already supported by the kwarg surface, just needs a \`/scan/auto\` endpoint.
- Upstream the device.py patch to gr-gsm.

Closes #353 and #354. Refs #351 #349 #344.