### PR TITLE
fix(secubox-hub): v1.4.1 — SOC dashboard metric numbers visible (closes #360)

### DIFF
--- a/packages/secubox-hub/debian/changelog
+++ b/packages/secubox-hub/debian/changelog
@@ -1,3 +1,19 @@
+secubox-hub (1.4.1-1~bookworm1) bookworm; urgency=medium
+
+  * www/shared/hybrid-skin.css: drop the "gradient text" trick
+    (`-webkit-text-fill-color: transparent` + `background-clip: text`)
+    on `.card-metric` and `.page-title`. The rule had no `color`
+    fallback, so any render path where the gradient/background-clip
+    didn't take collapsed to the browser default colour over the
+    dark panel background — invisible black-on-black big numbers on
+    /soc/ (Threats 24h, MB/s Throughput, Active Services, etc.). User
+    reported regression; almost certainly a live hot-fix on gk2 was
+    overwritten by a later package deploy. Replace with solid `#ffffff`
+    on `.card-metric` and `var(--text-dark)` (#E8E6E0 cream) on
+    `.page-title`. Closes #360.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Sat, 23 May 2026 09:00:00 +0000
+
 secubox-hub (1.4.0-1~bookworm1) bookworm; urgency=medium
 
   * api/main.py: CATEGORY_META rewritten to the 6 SecuBox charter

--- a/packages/secubox-hub/www/shared/hybrid-skin.css
+++ b/packages/secubox-hub/www/shared/hybrid-skin.css
@@ -76,9 +76,10 @@ html body.hybrid-skin {
     font-size: 28px;
     font-weight: 600;
     margin-bottom: var(--space-xs, 4px);
-    background: linear-gradient(90deg, var(--text-dark), var(--root-light));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
+    /* Solid colour — same gradient-text fragility as .card-metric
+     * (closes #360). var(--text-dark) = #E8E6E0 cream, kept for
+     * brand consistency with .page-subtitle just below. */
+    color: var(--text-dark);
 }
 
 .page-subtitle {
@@ -208,9 +209,10 @@ html body.hybrid-skin {
     font-family: var(--font-mono);
     line-height: 1;
     margin-bottom: var(--space-s, 8px);
-    background: linear-gradient(90deg, var(--text-dark), var(--muted-dark));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
+    /* Solid white — the gradient + -webkit-text-fill-color: transparent
+     * trick used here originally collapsed to invisible black-on-black
+     * whenever the gradient render path failed (closes #360). */
+    color: #ffffff;
 }
 
 .card-label {


### PR DESCRIPTION
## Summary

\`.card-metric\` and \`.page-title\` in \`www/shared/hybrid-skin.css\` used the gradient-text trick (\`-webkit-text-fill-color: transparent\` + \`background-clip: text\`) with no \`color\` fallback. Any render path where the gradient/background-clip didn't take left the text invisible (transparent fill stays in effect) → black-on-black on /soc/.

Replaced with solid \`color: #ffffff\` on \`.card-metric\` and \`color: var(--text-dark)\` (#E8E6E0) on \`.page-title\`.

User reported regression matched a live hot-fix on gk2 that was overwritten by a later package deploy. This commit lands the fix in source so it survives re-deploys.

## Test plan

- [x] \`.deb\` builds clean as \`secubox-hub_1.4.1-1~bookworm1_all.deb\`
- [x] Deployed on gk2 (1.3.3 → 1.4.1); CSS on disk confirmed to carry the solid-color rule
- [ ] Hard-refresh /soc/ → big numbers visible in white

Closes #360.