### PR TITLE
fix(threat-analyst): v1.1.2 — drop credentials:'include' (CORS wildcard rejection)

### DIFF
--- a/packages/secubox-threat-analyst/debian/changelog
+++ b/packages/secubox-threat-analyst/debian/changelog
@@ -1,3 +1,19 @@
+secubox-threat-analyst (1.1.2-1~bookworm1) bookworm; urgency=medium
+
+  * www/threat-analyst/index.html: drop fetch credentials: 'include'.
+    v1.1.1 added it "defensively" — but the secubox nginx vhost sends
+    `Access-Control-Allow-Origin: *` on every /api/v1/* response, and
+    browsers REJECT a wildcard ACAO when the fetch is credentialed
+    (per the CORS spec — credentials require a specific origin). Every
+    call threw TypeError before reaching the response, which the
+    catch labelled "network" — every panel showed "Network
+    unreachable" even though curl showed the endpoints returning JSON.
+    Removing the explicit option falls back to the fetch default
+    `'same-origin'`, which still ships Authelia cookies on same-origin
+    requests without triggering the strict CORS check.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Sat, 23 May 2026 12:00:00 +0000
+
 secubox-threat-analyst (1.1.1-1~bookworm1) bookworm; urgency=medium
 
   * www/threat-analyst/index.html: two follow-up fixes to v1.1.0:

--- a/packages/secubox-threat-analyst/www/threat-analyst/index.html
+++ b/packages/secubox-threat-analyst/www/threat-analyst/index.html
@@ -225,20 +225,23 @@
         const TA  = '/api/v1/threat-analyst';
         const EXP = '/api/v1/exposure';
 
-        // Shared HTTP wrapper. v1.1.1: returns {ok, status, data, err}
-        // instead of null-on-error so panels can render meaningful
-        // error states ("auth", "404", "network") rather than stuck
-        // on "Loading…". Sends localStorage Bearer if present, but
-        // also includes browser credentials so Authelia SSO cookies
-        // travel with same-origin fetches (the canonical auth path
-        // for the secubox stack — nginx auth_request validates the
-        // SSO cookie before proxying to the per-module unix socket).
+        // Shared HTTP wrapper. v1.1.2: dropped credentials: 'include'.
+        // The secubox nginx vhost sends `Access-Control-Allow-Origin: *`
+        // on every /api/v1/* response; browsers REJECT a wildcard ACAO
+        // when the fetch is credentialed (per the CORS spec — credentials
+        // require a specific origin). That made every call throw
+        // TypeError before reaching the response, which our catch
+        // labelled "network" — every panel showed "Network unreachable"
+        // even though the endpoints worked fine via curl. fetch's default
+        // credentials mode is 'same-origin', which still includes Authelia
+        // cookies on same-origin requests without triggering the strict
+        // CORS check.
         async function api(base, path, method = 'GET', data = null) {
             const token = localStorage.getItem('sbx_token');
             const headers = { 'Content-Type': 'application/json', ...(token ? { 'Authorization': 'Bearer ' + token } : {}) };
             try {
                 const res = await fetch(base + path, {
-                    method, headers, credentials: 'include',
+                    method, headers,
                     body: data ? JSON.stringify(data) : null,
                 });
                 if (res.status === 401) {
@@ -249,6 +252,15 @@
                 }
                 if (!res.ok) {
                     return { ok: false, status: res.status, err: 'http_' + res.status };
+                }
+                // Some SSO setups serve the login-challenge HTML with a
+                // 200 status (instead of 401 + redirect) so the browser
+                // doesn't follow opaquely. If we asked for JSON and got
+                // HTML, treat it as auth — otherwise res.json() would
+                // throw SyntaxError and we'd mis-label it "network".
+                const ctype = res.headers.get('content-type') || '';
+                if (!ctype.includes('json')) {
+                    return { ok: false, status: res.status, err: 'auth' };
                 }
                 const data = await res.json();
                 return { ok: true, status: res.status, data };


### PR DESCRIPTION
## Summary

After v1.1.1 deployed, every panel showed "Network unreachable" even though the endpoints worked via curl. Diagnosed:

- nginx vhost sends \`Access-Control-Allow-Origin: *\` on every /api/v1/* response
- v1.1.1 added \`credentials: 'include'\` to every fetch()
- Per CORS spec, browsers REJECT wildcard ACAO on credentialed requests
- fetch threw TypeError before reaching the response → caught and mis-labelled "network"

Fix: drop the explicit \`credentials\` option. fetch default \`'same-origin'\` already ships Authelia cookies on same-origin requests and doesn't trigger the strict CORS check.

Bonus defensive: api() checks response content-type — HTML responses (some SSO setups serve the login challenge as 200 + HTML body) now surface as "Auth required" instead of mis-labelled "network".

## Test plan

- [x] \`.deb\` builds clean as \`secubox-threat-analyst_1.1.2-1~bookworm1_all.deb\`
- [x] Deployed on gk2 (1.1.1 → 1.1.2); shipped JS confirmed to have NO \`credentials: 'include'\` on the fetch call
- [ ] Hard-refresh /threat-analyst/ → panels populate (or show "Auth required" if session expired, no longer "Network unreachable")