### PR TITLE
fix(threat-analyst): v1.1.3 — no-cache meta directives to prevent stale-HTML traps

### DIFF
--- a/packages/secubox-threat-analyst/debian/changelog
+++ b/packages/secubox-threat-analyst/debian/changelog
@@ -1,3 +1,17 @@
+secubox-threat-analyst (1.1.3-1~bookworm1) bookworm; urgency=medium
+
+  * www/threat-analyst/index.html: add no-cache <meta> directives.
+    v1.1.2 fixed the CORS-credentials trap on disk but operators
+    still saw the stale "Network unreachable" output because the
+    browser cached the v1.1.1 HTML. Adding `Cache-Control:
+    no-store, no-cache, must-revalidate` + `Pragma: no-cache` +
+    `Expires: 0` <meta> tags so future re-deploys force a reload.
+    Doesn't help the currently-cached page (operator still has to
+    hard-refresh once) but prevents the same trap on the next
+    redeploy.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Sat, 23 May 2026 13:00:00 +0000
+
 secubox-threat-analyst (1.1.2-1~bookworm1) bookworm; urgency=medium
 
   * www/threat-analyst/index.html: drop fetch credentials: 'include'.

--- a/packages/secubox-threat-analyst/www/threat-analyst/index.html
+++ b/packages/secubox-threat-analyst/www/threat-analyst/index.html
@@ -3,6 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- v1.1.3: tell browsers + intermediates not to cache this page.
+         The dashboard is a single file that we re-deploy in place;
+         a cached copy pins operators on stale JS even after dpkg
+         replaces the file on disk — which is what caused the
+         apparent regression where v1.1.2's CORS fix didn't take
+         effect for cached clients. -->
+    <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     <title>SecuBox - Threat Analyst</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
Adds Cache-Control no-store + Pragma no-cache + Expires 0 meta tags so future re-deploys force a browser reload. v1.1.2's CORS fix landed on disk but operators reported the same Network unreachable output because their browser served the cached v1.1.1 HTML. Closes that trap for everyone except the currently-cached browser (one-time hard-refresh still required).