### PR TITLE
feat(threat-analyst): v1.2.0 — local no-op require_jwt (align with stack pattern)

### DIFF
--- a/packages/secubox-threat-analyst/api/main.py
+++ b/packages/secubox-threat-analyst/api/main.py
@@ -22,8 +22,27 @@ from fastapi import FastAPI, Depends, HTTPException, BackgroundTasks
 from pydantic import BaseModel, Field
 import httpx
 
-from secubox_core.auth import require_jwt
 from secubox_core.config import get_config
+
+
+# v1.2.0: local no-op `require_jwt`. The previous import from
+# secubox_core.auth demanded an HTTP `Authorization: Bearer` header on
+# every gated endpoint — but the threat-analyst frontend runs inside
+# the Authelia-SSO'd admin vhost where the operator only carries SSO
+# cookies, never a JWT in localStorage. Result: every /stats, /alerts,
+# /rules call returned 401 and the dashboard showed "?".
+#
+# Every other module in this stack (sentinelle-gsm, etc.) already uses
+# this no-op pattern. The actual security perimeter is nginx + the unix
+# socket at /run/secubox/threat-analyst.sock — the FastAPI never listens
+# on TCP and the socket is bound 0660 root:secubox by systemd, so
+# nothing outside the trust boundary can reach this code. The
+# `Depends(require_jwt)` decorators are kept for forward compatibility
+# (if a future deploy ever exposes the API on TCP, swapping this stub
+# for the real check is one line).
+def require_jwt() -> dict:
+    """Pass-through; security comes from nginx + unix socket perms."""
+    return {"sub": "secubox-internal"}
 
 # Configuration
 CONFIG_PATH = Path("/etc/secubox/threat-analyst.toml")

--- a/packages/secubox-threat-analyst/debian/changelog
+++ b/packages/secubox-threat-analyst/debian/changelog
@@ -1,3 +1,23 @@
+secubox-threat-analyst (1.2.0-1~bookworm1) bookworm; urgency=medium
+
+  * api/main.py: replace `from secubox_core.auth import require_jwt`
+    with a local no-op stub, matching the pattern every other SecuBox
+    module already uses (secubox-sentinelle-gsm, etc.). The real
+    secubox_core.require_jwt demanded an HTTP `Authorization: Bearer`
+    header on every gated endpoint, but the threat-analyst dashboard
+    runs inside the Authelia-SSO'd admin vhost where the operator only
+    carries SSO cookies, never a JWT in localStorage. Every /stats,
+    /alerts, /rules call therefore returned 401 and the dashboard
+    rendered "?" across every metric.
+    The actual security perimeter is nginx + the unix socket — the
+    FastAPI never listens on TCP, the socket is bound 0660 root:secubox
+    by systemd. The `Depends(require_jwt)` decorators are kept for
+    forward compatibility; if a future deploy exposes the API on TCP,
+    swapping the stub for the real check is one line.
+  * User-authorized 2026-05-23.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Sat, 23 May 2026 13:45:00 +0000
+
 secubox-threat-analyst (1.1.3-1~bookworm1) bookworm; urgency=medium
 
   * www/threat-analyst/index.html: add no-cache <meta> directives.


### PR DESCRIPTION
Replaces the import of secubox_core.auth.require_jwt with a 4-line local no-op stub. Matches the pattern every other SecuBox module already uses (sentinelle-gsm, etc.).

The threat-analyst dashboard runs inside the Authelia-SSO'd admin vhost; operators carry SSO cookies, not Bearer JWTs in localStorage. Every /stats, /alerts, /rules call therefore returned 401 from secubox_core's strict check, and the dashboard rendered "?" across every metric.

Security perimeter remains:
- nginx (TLS + Authelia auth_request on the /api/v1/threat-analyst/ route)
- Unix socket at /run/secubox/threat-analyst.sock, 0660 root:secubox, systemd-bound, no TCP listener
- Depends(require_jwt) decorators kept for forward compatibility (swap the stub for the real check is one line)

Live-validated on gk2: /stats now returns real JSON. User-authorized 2026-05-23.