### PR TITLE
feat(threat-analyst): v1.3.0 — full UI rewrite, aligned with DESIGN-CHARTER

### DIFF
--- a/packages/secubox-threat-analyst/debian/changelog
+++ b/packages/secubox-threat-analyst/debian/changelog
@@ -1,3 +1,34 @@
+secubox-threat-analyst (1.3.0-1~bookworm1) bookworm; urgency=medium
+
+  * www/threat-analyst/index.html: complete rewrite from scratch.
+    Operators reported the v1.2.x dashboard still felt broken — too
+    many panels, gradient-chip clutter, confusing error states.
+    v1.3.0 throws everything out and rebuilds against
+    .claude/DESIGN-CHARTER.md:
+      - WALL layer palette (threat-analyst is a WALL/firewall
+        module per the charter); --wall-main #9A6010 accent.
+      - Space Grotesk for display/body, JetBrains Mono for
+        monospace per the charter §Typography.
+      - Base white theme tokens: --bg / --surface / --surface2 /
+        --border / --text / --muted (all sourced from shared
+        /shared/design-tokens.css).
+      - Standard radius (14px cards, 6px swatches, 3px chips) and
+        spacing scale (XS 4 / S 8 / M 16 / L 24 / XL 40) per
+        charter §Grid System and §Spacing System.
+      - Single-column layout, plain tables for alerts/rules/
+        emancipated. No gradient text, no chip clutter under each
+        stat card.
+      - Each panel fetches independently and shows its own error
+        in plain text. No clever wrapper hiding 401s.
+      - NEW diagnostic footer table — tracks the latest fetch
+        outcome per endpoint (OK 200 / FAIL 401 / Network etc.)
+        so the operator can distinguish auth-vs-network-vs-404
+        without opening DevTools.
+      - body.module-wall set so any future shared CSS that scopes
+        by .module-wall picks up the right colour vars.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Sat, 23 May 2026 14:30:00 +0000
+
 secubox-threat-analyst (1.2.0-1~bookworm1) bookworm; urgency=medium
 
   * api/main.py: replace `from secubox_core.auth import require_jwt`

--- a/packages/secubox-threat-analyst/www/threat-analyst/index.html
+++ b/packages/secubox-threat-analyst/www/threat-analyst/index.html
@@ -1,507 +1,468 @@
 <!DOCTYPE html>
+<!--
+  v1.3.0 — clean rewrite. Aligned with .claude/DESIGN-CHARTER.md:
+    - WALL layer palette (threat-analyst is a WALL module)
+    - Space Grotesk for display/body, JetBrains Mono for code
+    - Base white theme tokens (--bg, --surface, --border, --text, --muted)
+    - Standard radius (14px cards, 6px swatches, 3px chips)
+    - Standard spacing scale (XS 4 / S 8 / M 16 / L 24 / XL 40)
+  Single-column layout, plain tables, each panel fetches independently
+  and shows its own error in plain text. No gradient tricks. No clever
+  wrappers. Easy to read and audit.
+-->
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- v1.1.3: tell browsers + intermediates not to cache this page.
-         The dashboard is a single file that we re-deploy in place;
-         a cached copy pins operators on stale JS even after dpkg
-         replaces the file on disk — which is what caused the
-         apparent regression where v1.1.2's CORS fix didn't take
-         effect for cached clients. -->
-    <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
+    <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
-    <title>SecuBox - Threat Analyst</title>
+    <title>SecuBox · Threat Analyst</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link href="https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/shared/crt-light.css">
-    <link rel="stylesheet" href="/shared/sidebar-light.css">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/shared/design-tokens.css">
+    <link rel="stylesheet" href="/shared/sidebar.css">
     <style>
         :root {
-            --p31-peak: #00dd44; --p31-mid: #009933; --p31-dim: #006622;
-            --tube-light: #e8f5e9; --tube-pale: #c8e6c9; --tube-soft: #a5d6a7;
-            --bg-card: var(--tube-pale); --border: var(--tube-soft);
-            --text: #1b3d1c; --text-dim: var(--p31-dim);
-            --primary: var(--p31-peak); --danger: #ff4466; --warning: #ffb347; --info: #4488ff;
-            /* Reserve space for the global menu bar that sidebar.js
-             * (v2.38.0+) injects at the top — without this, .main
-             * content slides under the navbar. Matches sentinelle.css
-             * and all other recent dashboards. */
             --gmb-h: 48px;
+            /* Spacing scale per charter §Spacing System */
+            --sp-xs: 4px;  --sp-s: 8px;  --sp-m: 16px;  --sp-l: 24px;  --sp-xl: 40px;
+            /* Radius per charter §Grid System */
+            --r-card: 14px;  --r-swatch: 6px;  --r-chip: 3px;
         }
         * { box-sizing: border-box; margin: 0; padding: 0; }
-        body { font-family: 'Courier Prime', monospace; background: var(--tube-light); color: var(--text); display: flex; min-height: 100vh; }
-        .main { flex: 1; margin-left: 220px; padding: calc(var(--gmb-h) + 1.5rem) 1.5rem 1.5rem; }
-        .header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 2px solid var(--border); }
-        .header h1 { font-size: 1.5rem; display: flex; align-items: center; gap: 0.5rem; }
-        .header-actions { display: flex; gap: 0.5rem; align-items: center; }
-        .badge { padding: 0.25rem 0.75rem; border-radius: 4px; font-size: 0.75rem; background: var(--tube-light); border: 1px solid var(--border); }
+        body {
+            font-family: 'Space Grotesk', system-ui, sans-serif;
+            font-size: 14px;
+            line-height: 1.6;
+            background: var(--bg);
+            color: var(--text);
+            min-height: 100vh;
+        }
+        .main {
+            margin-left: 220px;
+            padding: calc(var(--gmb-h) + var(--sp-l)) var(--sp-l) var(--sp-xl);
+            max-width: 1200px;
+        }
+        @media (max-width: 768px) { .main { margin-left: 0; padding: calc(var(--gmb-h) + var(--sp-m)) var(--sp-m) var(--sp-l); } }
 
-        /* Stats grid — one card per top-level metric, each carrying
-         * its own breakdown chips so the operator sees the
-         * distribution without leaving the page. v1.1.0 replaces
-         * the 4 ghost cards that referenced fields the backend
-         * never returns. */
-        .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
-        .stat-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.25rem; }
-        .stat-row { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; }
-        .stat-icon { font-size: 1.4rem; }
-        .stat-value { font-size: 1.9rem; font-weight: bold; color: var(--primary); line-height: 1; }
-        .stat-value.danger { color: var(--danger); }
-        .stat-value.warn { color: var(--warning); }
-        .stat-label { color: var(--text-dim); font-size: 0.8rem; }
-        .stat-breakdown { display: flex; flex-wrap: wrap; gap: 0.25rem; margin-top: 0.5rem; }
-        .chip { padding: 0.15rem 0.5rem; border-radius: 3px; font-size: 0.7rem; background: var(--tube-light); border: 1px solid var(--border); white-space: nowrap; }
-        .chip.crit { background: rgba(255,68,102,0.12); color: var(--danger); border-color: rgba(255,68,102,0.4); }
-        .chip.warn { background: rgba(255,179,71,0.12); color: var(--warning); border-color: rgba(255,179,71,0.4); }
-        .chip.ok   { background: rgba(0,221,68,0.12); color: var(--primary); border-color: rgba(0,221,68,0.4); }
+        /* ── Page header ─────────────────────────────────────── */
+        header.page {
+            display: flex; justify-content: space-between; align-items: baseline;
+            gap: var(--sp-m); margin-bottom: var(--sp-l);
+            padding-bottom: var(--sp-m); border-bottom: 1px solid var(--border);
+        }
+        header.page h1 {
+            font-size: 24px; font-weight: 600;
+            letter-spacing: -0.4px; color: var(--wall-main);
+        }
+        header.page h1 .ver {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 12px; font-weight: 400;
+            color: var(--muted); margin-left: var(--sp-s);
+        }
+        header.page .actions { display: flex; gap: var(--sp-s); }
 
-        /* Two-column body: alerts/rules (left, wide) + emancipate/IOC (right, compact) */
-        .body-grid { display: grid; grid-template-columns: 2fr 1fr; gap: 1rem; margin-bottom: 1.5rem; }
-        @media (max-width: 1024px) { .body-grid { grid-template-columns: 1fr; } }
+        /* ── Buttons ─────────────────────────────────────────── */
+        button {
+            padding: 8px 16px; font-family: inherit; font-size: 13px;
+            font-weight: 500;
+            background: var(--surface); color: var(--text);
+            border: 1px solid var(--border); border-radius: var(--r-swatch);
+            cursor: pointer; transition: filter 120ms;
+        }
+        button:hover { filter: brightness(0.96); }
+        button.primary { background: var(--wall-main); color: #fff; border-color: var(--wall-main); }
+        button.primary:hover { filter: brightness(1.08); }
+        button.danger  { background: var(--boot-main); color: #fff; border-color: var(--boot-main); }
+        button.sm { padding: 4px 10px; font-size: 12px; border-radius: var(--r-chip); }
 
-        .card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; padding: 1.25rem; margin-bottom: 1rem; }
-        .card-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; padding-bottom: 0.75rem; border-bottom: 1px solid var(--border); }
-        .card-header h2 { font-size: 1.05rem; display: flex; align-items: center; gap: 0.5rem; }
-        .card-header .actions { display: flex; gap: 0.4rem; }
+        /* ── Stats strip ─────────────────────────────────────── */
+        .stats {
+            display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: var(--sp-m); margin-bottom: var(--sp-l);
+        }
+        .stat {
+            background: var(--surface); border: 1px solid var(--border);
+            border-radius: var(--r-card); padding: var(--sp-m) var(--sp-l);
+        }
+        .stat-label {
+            font-size: 11px; font-weight: 600; text-transform: uppercase;
+            letter-spacing: 0.8px; color: var(--muted);
+        }
+        .stat-value {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 32px; font-weight: 700;
+            margin-top: var(--sp-xs);
+            color: var(--text);
+            line-height: 1.1;
+        }
+        .stat.warn .stat-value { color: var(--wall-main); }
+        .stat.crit .stat-value { color: var(--boot-main); }
 
-        .btn { padding: 0.4rem 0.8rem; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-card); color: var(--text); cursor: pointer; font-family: inherit; font-size: 0.8rem; }
-        .btn:hover { background: var(--tube-light); }
-        .btn-primary { background: var(--primary); border-color: var(--primary); color: #000; }
-        .btn-danger  { background: var(--danger);  border-color: var(--danger);  color: #fff; }
-        .btn-warn    { background: var(--warning); border-color: var(--warning); color: #000; }
-        .btn-sm { padding: 0.25rem 0.55rem; font-size: 0.75rem; }
+        .breakdown {
+            font-family: 'JetBrains Mono', monospace; font-size: 12px;
+            color: var(--muted); margin-bottom: var(--sp-l);
+            padding: var(--sp-s) var(--sp-m);
+            background: var(--surface2); border-radius: var(--r-swatch);
+        }
+        .breakdown span { margin-right: var(--sp-m); }
+        .breakdown b { color: var(--text); font-weight: 700; }
 
-        table { width: 100%; border-collapse: collapse; }
-        th, td { text-align: left; padding: 0.6rem 0.5rem; border-bottom: 1px solid var(--border); font-size: 0.85rem; vertical-align: middle; }
-        th { color: var(--text-dim); font-weight: 600; font-size: 0.72rem; text-transform: uppercase; background: var(--tube-light); }
-        td code { font-family: monospace; font-size: 0.8rem; }
+        /* ── Panels ──────────────────────────────────────────── */
+        section.panel {
+            background: var(--surface); border: 1px solid var(--border);
+            border-radius: var(--r-card);
+            padding: var(--sp-l); margin-bottom: var(--sp-l);
+        }
+        section.panel > h2 {
+            font-size: 16px; font-weight: 600; letter-spacing: -0.1px;
+            margin-bottom: var(--sp-m); padding-bottom: var(--sp-s);
+            border-bottom: 1px solid var(--border);
+            display: flex; justify-content: space-between; align-items: center; gap: var(--sp-m);
+            color: var(--wall-main);
+        }
+        section.panel > h2 .head-actions { display: flex; gap: var(--sp-s); align-items: center; }
+        section.panel > h2 select {
+            padding: 4px 8px; font-family: inherit; font-size: 12px;
+            background: var(--bg); color: var(--text);
+            border: 1px solid var(--border); border-radius: var(--r-chip);
+        }
 
-        .severity-pill { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 3px; font-size: 0.7rem; font-weight: bold; }
-        .severity-pill.critical { background: var(--danger); color: #fff; }
-        .severity-pill.high     { background: var(--warning); color: #000; }
-        .severity-pill.medium   { background: var(--info); color: #fff; }
-        .severity-pill.low      { background: var(--primary); color: #000; }
+        /* ── Tables ──────────────────────────────────────────── */
+        table { width: 100%; border-collapse: collapse; font-size: 13px; }
+        th, td {
+            text-align: left; padding: var(--sp-s) var(--sp-m);
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+        th {
+            color: var(--muted); font-size: 11px; font-weight: 700;
+            text-transform: uppercase; letter-spacing: 0.6px;
+            background: var(--surface2);
+        }
+        tr:last-child td { border-bottom: none; }
+        td code { font-family: 'JetBrains Mono', monospace; font-size: 12px; }
 
-        /* Emancipate panel: one tight row per exposed service.
-         * Channel tags color-coded by Punk Exposure verb (Tor / SSL+DNS / Mesh). */
-        .ema-list { display: flex; flex-direction: column; gap: 0.5rem; }
-        .ema-row { display: flex; flex-direction: column; gap: 0.35rem; padding: 0.6rem 0.75rem; background: var(--tube-light); border: 1px solid var(--border); border-radius: 6px; }
-        .ema-row-head { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
-        .ema-name { font-weight: 600; font-size: 0.85rem; }
-        .ema-port { font-family: monospace; font-size: 0.75rem; color: var(--text-dim); }
-        .ema-channels { display: flex; flex-wrap: wrap; gap: 0.25rem; }
-        .ema-channel { padding: 0.1rem 0.4rem; border-radius: 3px; font-size: 0.65rem; font-weight: bold; }
-        .ema-channel.tor  { background: rgba(110,64,201,0.18); color: #6e40c9; border: 1px solid rgba(110,64,201,0.4); }
-        .ema-channel.ssl  { background: rgba(68,136,255,0.15); color: var(--info); border: 1px solid rgba(68,136,255,0.4); }
-        .ema-channel.dns  { background: rgba(68,136,255,0.15); color: var(--info); border: 1px solid rgba(68,136,255,0.4); }
-        .ema-channel.mesh { background: rgba(0,221,68,0.15); color: var(--primary); border: 1px solid rgba(0,221,68,0.4); }
-        .ema-meta { font-size: 0.7rem; color: var(--text-dim); display: flex; gap: 0.75rem; }
+        /* ── Pills (severity) ─────────────────────────────────── */
+        .pill {
+            display: inline-block; padding: 2px 8px;
+            border-radius: var(--r-chip); font-size: 11px;
+            font-weight: 700; text-transform: lowercase;
+            font-family: 'JetBrains Mono', monospace;
+        }
+        .pill.critical { background: var(--boot-main); color: #fff; }
+        .pill.high     { background: var(--wall-main); color: #fff; }
+        .pill.medium   { background: var(--mesh-main); color: #fff; }
+        .pill.low      { background: var(--root-main); color: #fff; }
+        .pill.ch       { background: var(--mesh-main); color: #fff; margin-right: var(--sp-xs); }
 
-        /* Pending Rules panel */
-        .rule-row { display: flex; flex-direction: column; gap: 0.4rem; padding: 0.6rem 0.75rem; background: var(--tube-light); border: 1px solid var(--border); border-radius: 6px; margin-bottom: 0.5rem; }
-        .rule-head { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
-        .rule-meta { font-size: 0.75rem; color: var(--text-dim); }
-        .rule-actions { display: flex; gap: 0.4rem; flex-wrap: wrap; }
-        .rule-body { font-family: monospace; font-size: 0.75rem; background: var(--bg-card); padding: 0.4rem 0.6rem; border-radius: 4px; max-height: 100px; overflow: auto; }
+        /* ── Messages ────────────────────────────────────────── */
+        .msg { padding: var(--sp-s) 0; font-size: 13px; }
+        .msg-loading { color: var(--muted); font-style: italic; }
+        .msg-empty   { color: var(--muted); }
+        .msg-error   { color: var(--boot-main); font-weight: 600; }
 
-        .input-row { display: flex; gap: 0.5rem; margin-bottom: 1rem; }
-        .input-row input { flex: 1; padding: 0.5rem; border: 1px solid var(--border); border-radius: 6px; background: var(--tube-light); color: var(--text); font-family: inherit; }
-        .empty-state { text-align: center; padding: 1.5rem; color: var(--text-dim); font-size: 0.85rem; }
-        .err { color: var(--danger); font-size: 0.8rem; padding: 0.4rem 0.6rem; }
+        /* ── Analyze form ────────────────────────────────────── */
+        .analyze-form { display: flex; gap: var(--sp-s); margin-bottom: var(--sp-m); }
+        .analyze-form input {
+            flex: 1; padding: 8px 12px; font-family: inherit; font-size: 13px;
+            background: var(--bg); color: var(--text);
+            border: 1px solid var(--border); border-radius: var(--r-swatch);
+        }
+        .analyze-result {
+            font-family: 'JetBrains Mono', monospace; font-size: 12px;
+            background: var(--surface2);
+            padding: var(--sp-m); border-radius: var(--r-swatch);
+            white-space: pre-wrap; word-break: break-word;
+            max-height: 240px; overflow: auto;
+            color: var(--text);
+        }
 
-        @media (max-width: 768px) { .main { margin-left: 0; padding: 1rem; } }
+        /* ── Diagnostic footer ────────────────────────────────── */
+        /* A plain table at page bottom tracking each endpoint's
+         * latest fetch outcome. Lets the operator distinguish
+         * "auth issue" from "network down" from "404" without
+         * opening DevTools. */
+        .diag {
+            margin-top: var(--sp-xl);
+            padding: var(--sp-m) var(--sp-l);
+            background: var(--surface2); border: 1px dashed var(--border);
+            border-radius: var(--r-swatch);
+        }
+        .diag h3 {
+            font-size: 12px; font-weight: 700;
+            text-transform: uppercase; letter-spacing: 0.6px;
+            color: var(--muted); margin-bottom: var(--sp-s);
+        }
+        .diag table { font-family: 'JetBrains Mono', monospace; font-size: 12px; }
+        .diag th { background: transparent; }
+        .diag td { padding: 4px var(--sp-s); border-bottom: 1px dotted var(--border); }
+        .diag .ok  { color: var(--root-main); font-weight: 700; }
+        .diag .bad { color: var(--boot-main); font-weight: 700; }
     </style>
 </head>
-<body>
+<body class="module-wall">
     <nav class="sidebar" id="sidebar"></nav>
-    <div class="main">
-        <div class="header">
-            <h1>🕵️ Threat Analyst</h1>
-            <div class="header-actions">
-                <button class="btn btn-sm" onclick="collectNow()" title="Pull fresh alerts from CrowdSec + WAF">🔄 Collect</button>
-                <span class="badge">v1.1.0</span>
+    <main class="main">
+
+        <header class="page">
+            <h1>Threat Analyst <span class="ver">v1.3.0</span></h1>
+            <div class="actions">
+                <button onclick="collectAll()" title="Pull fresh alerts from CrowdSec + WAF">Collect</button>
+                <button class="primary" onclick="loadAll()">Refresh</button>
             </div>
+        </header>
+
+        <!-- Overview strip ─────────────────────────────────────── -->
+        <div class="stats">
+            <div class="stat">       <div class="stat-label">Alerts (24h)</div>    <div class="stat-value" id="s-alerts">—</div></div>
+            <div class="stat warn">  <div class="stat-label">Pending Rules</div>   <div class="stat-value" id="s-pending">—</div></div>
+            <div class="stat">       <div class="stat-label">Total Rules</div>     <div class="stat-value" id="s-total">—</div></div>
+            <div class="stat">       <div class="stat-label">Emancipated</div>     <div class="stat-value" id="s-ema">—</div></div>
+        </div>
+        <div class="breakdown">
+            <span>by source: <b id="b-source">—</b></span>
+            <span>by severity: <b id="b-severity">—</b></span>
         </div>
 
-        <!-- ── Metrics row ──────────────────────────────────────── -->
-        <div class="stats-grid">
-            <div class="stat-card">
-                <div class="stat-row">
-                    <div>
-                        <div class="stat-label">Alerts (24h)</div>
-                        <div class="stat-value" id="m-alerts-24h">–</div>
-                    </div>
-                    <div class="stat-icon">🚨</div>
+        <!-- Alerts ─────────────────────────────────────────────── -->
+        <section class="panel">
+            <h2>
+                Recent Alerts
+                <div class="head-actions">
+                    <select id="alerts-window" onchange="loadAlerts()">
+                        <option value="1">1h</option>
+                        <option value="6">6h</option>
+                        <option value="24" selected>24h</option>
+                        <option value="168">7d</option>
+                    </select>
                 </div>
-                <div class="stat-breakdown" id="m-alerts-by-source"></div>
-            </div>
+            </h2>
+            <div id="alerts-body"><div class="msg msg-loading">Loading…</div></div>
+        </section>
 
-            <div class="stat-card">
-                <div class="stat-row">
-                    <div>
-                        <div class="stat-label">Severity Mix</div>
-                        <div class="stat-value" id="m-severity-total">–</div>
-                    </div>
-                    <div class="stat-icon">📊</div>
-                </div>
-                <div class="stat-breakdown" id="m-alerts-by-severity"></div>
-            </div>
+        <!-- Pending Rules ──────────────────────────────────────── -->
+        <section class="panel">
+            <h2>Pending Rules</h2>
+            <div id="rules-body"><div class="msg msg-loading">Loading…</div></div>
+        </section>
 
-            <div class="stat-card">
-                <div class="stat-row">
-                    <div>
-                        <div class="stat-label">Pending Rules</div>
-                        <div class="stat-value warn" id="m-pending-rules">–</div>
-                    </div>
-                    <div class="stat-icon">⚖️</div>
-                </div>
-                <div class="stat-breakdown"><span class="chip" id="m-total-rules">total: –</span></div>
-            </div>
+        <!-- Emancipated services ────────────────────────────────── -->
+        <section class="panel">
+            <h2>Emancipated Services</h2>
+            <div id="ema-body"><div class="msg msg-loading">Loading…</div></div>
+        </section>
 
-            <div class="stat-card">
-                <div class="stat-row">
-                    <div>
-                        <div class="stat-label">Emancipated</div>
-                        <div class="stat-value" id="m-emancipated">–</div>
-                    </div>
-                    <div class="stat-icon">🔓</div>
-                </div>
-                <div class="stat-breakdown" id="m-emancipated-channels"></div>
+        <!-- IOC analyze ────────────────────────────────────────── -->
+        <section class="panel">
+            <h2>Analyze IOC</h2>
+            <div class="analyze-form">
+                <input type="text" id="ioc-input" placeholder="IP, domain, hash, URL…">
+                <button class="primary" onclick="analyzeIOC()">Analyze</button>
             </div>
+            <div id="analyze-out" class="msg msg-empty">Enter an indicator above.</div>
+        </section>
+
+        <!-- Diagnostic footer ───────────────────────────────────── -->
+        <div class="diag">
+            <h3>Endpoint status</h3>
+            <table id="diag-table">
+                <tr><td colspan="3" class="msg-loading">probing…</td></tr>
+            </table>
         </div>
 
-        <!-- ── Two-column body: Alerts/Rules + Emancipate/IOC ───── -->
-        <div class="body-grid">
-            <div>
-                <div class="card">
-                    <div class="card-header">
-                        <h2>🚨 Active Alerts</h2>
-                        <div class="actions">
-                            <select id="alerts-hours" onchange="loadAlerts()" style="padding:0.25rem 0.4rem;border:1px solid var(--border);border-radius:4px;background:var(--tube-light);font-family:inherit;font-size:0.75rem;">
-                                <option value="1">1h</option>
-                                <option value="6">6h</option>
-                                <option value="24" selected>24h</option>
-                                <option value="168">7d</option>
-                            </select>
-                            <button class="btn btn-sm" onclick="loadAlerts()">Refresh</button>
-                        </div>
-                    </div>
-                    <div id="alerts-container">
-                        <div class="empty-state">Loading…</div>
-                    </div>
-                </div>
-
-                <div class="card">
-                    <div class="card-header">
-                        <h2>⚖️ Pending Rules</h2>
-                        <button class="btn btn-sm" onclick="loadRules()">Refresh</button>
-                    </div>
-                    <div id="rules-container">
-                        <div class="empty-state">Loading…</div>
-                    </div>
-                </div>
-            </div>
-
-            <div>
-                <div class="card">
-                    <div class="card-header">
-                        <h2>🔓 Emancipated</h2>
-                        <button class="btn btn-sm" onclick="loadEmancipated()">Refresh</button>
-                    </div>
-                    <div id="emancipated-container">
-                        <div class="empty-state">Loading…</div>
-                    </div>
-                </div>
-
-                <div class="card">
-                    <div class="card-header">
-                        <h2>🔎 Analyze IOC</h2>
-                    </div>
-                    <div class="input-row" style="flex-direction:column;align-items:stretch;">
-                        <input type="text" id="ioc-input" placeholder="IP, domain, hash, URL…">
-                        <button class="btn btn-primary btn-sm" onclick="analyzeIOC()">Analyze</button>
-                    </div>
-                    <div id="analysis-result"></div>
-                </div>
-            </div>
-        </div>
-    </div>
+    </main>
 
     <script src="/shared/sidebar.js"></script>
     <script>
-        const TA  = '/api/v1/threat-analyst';
-        const EXP = '/api/v1/exposure';
-
-        // Shared HTTP wrapper. v1.1.2: dropped credentials: 'include'.
-        // The secubox nginx vhost sends `Access-Control-Allow-Origin: *`
-        // on every /api/v1/* response; browsers REJECT a wildcard ACAO
-        // when the fetch is credentialed (per the CORS spec — credentials
-        // require a specific origin). That made every call throw
-        // TypeError before reaching the response, which our catch
-        // labelled "network" — every panel showed "Network unreachable"
-        // even though the endpoints worked fine via curl. fetch's default
-        // credentials mode is 'same-origin', which still includes Authelia
-        // cookies on same-origin requests without triggering the strict
-        // CORS check.
-        async function api(base, path, method = 'GET', data = null) {
-            const token = localStorage.getItem('sbx_token');
-            const headers = { 'Content-Type': 'application/json', ...(token ? { 'Authorization': 'Bearer ' + token } : {}) };
+        // ── Tiny fetch helpers ─────────────────────────────────
+        // No clever wrapper. Returns {ok:true,data} or
+        // {ok:false,status,err}. Plain text errors. No credentials
+        // option (default same-origin already ships SSO cookies and
+        // doesn't trip CORS strictness over the nginx ACAO:* header).
+        async function get(url) {
             try {
-                const res = await fetch(base + path, {
-                    method, headers,
-                    body: data ? JSON.stringify(data) : null,
-                });
-                if (res.status === 401) {
-                    return { ok: false, status: 401, err: 'auth' };
-                }
-                if (res.status === 404) {
-                    return { ok: false, status: 404, err: 'not_found' };
-                }
-                if (!res.ok) {
-                    return { ok: false, status: res.status, err: 'http_' + res.status };
-                }
-                // Some SSO setups serve the login-challenge HTML with a
-                // 200 status (instead of 401 + redirect) so the browser
-                // doesn't follow opaquely. If we asked for JSON and got
-                // HTML, treat it as auth — otherwise res.json() would
-                // throw SyntaxError and we'd mis-label it "network".
-                const ctype = res.headers.get('content-type') || '';
-                if (!ctype.includes('json')) {
-                    return { ok: false, status: res.status, err: 'auth' };
-                }
-                const data = await res.json();
-                return { ok: true, status: res.status, data };
+                const r = await fetch(url, { headers: { Accept: 'application/json' } });
+                const ct = r.headers.get('content-type') || '';
+                if (!r.ok) return { ok: false, status: r.status, err: 'HTTP ' + r.status };
+                if (!ct.includes('json')) return { ok: false, status: r.status, err: 'Not JSON (auth?)' };
+                return { ok: true, status: r.status, data: await r.json() };
             } catch (e) {
-                return { ok: false, status: 0, err: 'network', detail: String(e) };
+                return { ok: false, status: 0, err: 'Network (' + e.message + ')' };
             }
         }
-        const ta  = (p, m, d) => api(TA,  p, m, d);
-        const exp = (p, m, d) => api(EXP, p, m, d);
-
-        // Render an error placeholder when an api() call fails.
-        // Caller passes the container element + the api() result.
-        function renderApiError(el, r, what) {
-            const map = {
-                auth:      'Auth required — log in via /auth/',
-                not_found: 'Endpoint missing on backend',
-                network:   'Network unreachable',
-            };
-            const msg = map[r.err] || ('HTTP ' + r.status);
-            el.innerHTML = `<div class="err">${what}: ${msg}</div>`;
-        }
-
-        function renderBreakdownChips(target, dict, severityColor = false) {
-            const el = document.getElementById(target);
-            if (!dict || !Object.keys(dict).length) {
-                el.innerHTML = '<span class="chip">none</span>';
-                return;
+        async function post(url, body) {
+            try {
+                const r = await fetch(url, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+                    body: body ? JSON.stringify(body) : null,
+                });
+                const ct = r.headers.get('content-type') || '';
+                if (!r.ok) return { ok: false, status: r.status, err: 'HTTP ' + r.status };
+                if (!ct.includes('json')) return { ok: false, status: r.status, err: 'Not JSON (auth?)' };
+                return { ok: true, status: r.status, data: await r.json() };
+            } catch (e) {
+                return { ok: false, status: 0, err: 'Network (' + e.message + ')' };
             }
-            el.innerHTML = Object.entries(dict)
-                .sort((a, b) => b[1] - a[1])
-                .map(([k, v]) => {
-                    let cls = '';
-                    if (severityColor) {
-                        if (k === 'critical') cls = 'crit';
-                        else if (k === 'high') cls = 'warn';
-                        else if (k === 'low') cls = 'ok';
-                    }
-                    return `<span class="chip ${cls}">${k}: ${v}</span>`;
-                }).join('');
         }
 
-        async function loadMetrics() {
-            const r = await ta('/stats');
-            if (!r.ok) {
-                // /status is auth-free — fall back so the count cards
-                // populate even when /stats 401's (browser hasn't
-                // refreshed Authelia cookie yet). Status only carries
-                // alerts_24h + pending_rules; the breakdowns stay
-                // marked with the error so the operator knows why.
-                const pub = await ta('/status');
-                document.getElementById('m-alerts-24h').textContent = pub.ok ? (pub.data.alerts_24h ?? 0) : '?';
-                document.getElementById('m-pending-rules').textContent = pub.ok ? (pub.data.pending_rules ?? 0) : '?';
-                document.getElementById('m-severity-total').textContent = '?';
-                document.getElementById('m-total-rules').textContent = 'total: ?';
-                const errLabel = r.err === 'auth' ? 'auth' : 'err';
-                document.getElementById('m-alerts-by-source').innerHTML =
-                    `<span class="chip" style="color:var(--danger);">${errLabel}</span>`;
-                document.getElementById('m-alerts-by-severity').innerHTML =
-                    `<span class="chip" style="color:var(--danger);">${errLabel}</span>`;
-                return;
-            }
-            const s = r.data;
-            document.getElementById('m-alerts-24h').textContent = s.alerts_24h ?? 0;
-            renderBreakdownChips('m-alerts-by-source', s.by_source);
-
-            const sev = s.by_severity || {};
-            const sevTotal = Object.values(sev).reduce((a, b) => a + b, 0);
-            document.getElementById('m-severity-total').textContent = sevTotal;
-            renderBreakdownChips('m-alerts-by-severity', sev, true);
-
-            document.getElementById('m-pending-rules').textContent = s.pending_rules ?? 0;
-            document.getElementById('m-total-rules').textContent   = `total: ${s.total_rules ?? 0}`;
-        }
-
-        async function loadAlerts() {
-            const hours = document.getElementById('alerts-hours').value;
-            const r = await ta(`/alerts?hours=${hours}`);
-            const c = document.getElementById('alerts-container');
-            if (!r.ok) { renderApiError(c, r, 'Alerts'); return; }
-            const d = r.data;
-            if (!d.alerts?.length) { c.innerHTML = '<div class="empty-state">No alerts in window</div>'; return; }
-            // Cap at 25 rows so the column doesn't dominate the page —
-            // the "+N more" line tells the operator there's more.
-            c.innerHTML = `
-                <table>
-                    <thead><tr><th>Time</th><th>Severity</th><th>Source</th><th>Detail</th></tr></thead>
-                    <tbody>
-                        ${d.alerts.slice(0, 25).map(a => `
-                            <tr>
-                                <td>${a.timestamp ? new Date(a.timestamp).toLocaleString() : '–'}</td>
-                                <td><span class="severity-pill ${(a.severity || 'low').toLowerCase()}">${a.severity || '?'}</span></td>
-                                <td>${a.source || '–'}</td>
-                                <td>${escapeHtml(a.description || a.scenario || a.message || '–')}</td>
-                            </tr>
-                        `).join('')}
-                    </tbody>
-                </table>
-                ${d.alerts.length > 25 ? `<div class="empty-state">…${d.alerts.length - 25} more (truncated)</div>` : ''}
-            `;
-        }
-
-        async function loadEmancipated() {
-            const r = await exp('/emancipated');
-            const c = document.getElementById('emancipated-container');
-            if (!r.ok) {
-                renderApiError(c, r, 'Emancipated');
-                document.getElementById('m-emancipated').textContent = '?';
-                document.getElementById('m-emancipated-channels').innerHTML =
-                    `<span class="chip" style="color:var(--danger);">${r.err}</span>`;
-                return;
-            }
-            const services = r.data.services || [];
-            document.getElementById('m-emancipated').textContent = services.length;
-
-            // Channel breakdown for the top-card chips. ssl+dns are
-            // the same Punk-Exposure channel so we collapse them.
-            const ch = { tor: 0, ssl: 0, mesh: 0 };
-            services.forEach(s => {
-                const cs = s.channels || [];
-                if (cs.includes('tor')) ch.tor++;
-                if (cs.includes('ssl') || cs.includes('dns')) ch.ssl++;
-                if (cs.includes('mesh')) ch.mesh++;
-            });
-            document.getElementById('m-emancipated-channels').innerHTML =
-                Object.entries(ch).filter(([_, n]) => n > 0)
-                    .map(([k, n]) => `<span class="chip">${k}: ${n}</span>`)
-                    .join('') || '<span class="chip">idle</span>';
-
-            if (!services.length) {
-                c.innerHTML = '<div class="empty-state">No services emancipated</div>';
-                return;
-            }
-            c.innerHTML = `<div class="ema-list">${services.map(s => `
-                <div class="ema-row">
-                    <div class="ema-row-head">
-                        <span class="ema-name">${escapeHtml(s.name || s.service || '?')}</span>
-                        <button class="btn btn-sm btn-danger" onclick="revokeService('${escapeHtml(s.name || s.service)}')">Revoke</button>
-                    </div>
-                    <div class="ema-meta">
-                        <span class="ema-port">:${escapeHtml(String(s.port ?? '?'))}</span>
-                        ${s.domain ? `<span>${escapeHtml(s.domain)}</span>` : ''}
-                    </div>
-                    <div class="ema-channels">
-                        ${(s.channels || []).map(ch => `<span class="ema-channel ${ch}">${ch.toUpperCase()}</span>`).join('')}
-                    </div>
-                </div>
-            `).join('')}</div>`;
-        }
-
-        async function revokeService(name) {
-            if (!confirm(`Revoke exposure for "${name}"? All channels (Tor/SSL/Mesh) will be torn down.`)) return;
-            const r = await exp('/revoke', 'POST', { name });
-            if (!r.ok || r.data?.success === false) {
-                alert('Revoke failed: ' + (r.err || r.data?.error || 'unknown'));
-                return;
-            }
-            loadEmancipated();
-        }
-
-        async function loadRules() {
-            const r = await ta('/rules?status=pending');
-            const c = document.getElementById('rules-container');
-            if (!r.ok) { renderApiError(c, r, 'Rules'); return; }
-            const rules = r.data.rules || [];
-            if (!rules.length) { c.innerHTML = '<div class="empty-state">No pending rules</div>'; return; }
-            c.innerHTML = rules.map(r => `
-                <div class="rule-row" id="rule-${r.id}">
-                    <div class="rule-head">
-                        <span><strong>${escapeHtml(r.type || '?')}</strong> · ${escapeHtml(r.name || r.id || '')}</span>
-                        <div class="rule-actions">
-                            <button class="btn btn-sm btn-primary" onclick="ruleAction('${r.id}', 'approve')">Approve</button>
-                            <button class="btn btn-sm btn-warn"    onclick="ruleAction('${r.id}', 'apply')">Apply</button>
-                            <button class="btn btn-sm btn-danger"  onclick="ruleAction('${r.id}', 'reject')">Reject</button>
-                        </div>
-                    </div>
-                    <div class="rule-meta">${escapeHtml(r.description || r.reason || '')}</div>
-                    ${r.body || r.content ? `<div class="rule-body">${escapeHtml(r.body || r.content)}</div>` : ''}
-                </div>
-            `).join('');
-        }
-
-        async function ruleAction(id, verb) {
-            const r = await ta(`/rules/${id}/${verb}`, 'POST');
-            if (!r.ok) { alert(verb + ' failed: ' + r.err); return; }
-            loadRules();
-            loadMetrics();
-        }
-
-        async function analyzeIOC() {
-            const ioc = document.getElementById('ioc-input').value.trim();
-            if (!ioc) return;
-            const r = document.getElementById('analysis-result');
-            r.innerHTML = '<div style="padding:0.5rem;text-align:center;font-size:0.8rem;">Analyzing…</div>';
-            // The backend's /analyze takes AnalysisRequest (hours + optional alert_ids).
-            // Single-IOC quick lookup: send the ioc alongside the 24h window;
-            // the backend ignores unknown keys.
-            const res = await ta('/analyze', 'POST', { ioc, hours: 24 });
-            if (!res.ok) { r.innerHTML = `<div class="err">Analysis failed: ${res.err}</div>`; return; }
-            const d = res.data;
-            r.innerHTML = `
-                <div style="padding:0.5rem;background:var(--tube-light);border-radius:6px;font-size:0.8rem;">
-                    <div><strong>${escapeHtml(ioc)}</strong></div>
-                    <div style="margin-top:0.3rem;color:var(--text-dim);">
-                        ${escapeHtml(typeof d.analysis === 'string' ? d.analysis.slice(0, 300) : JSON.stringify(d).slice(0, 300))}
-                    </div>
-                </div>
-            `;
-        }
-
-        async function collectNow() {
-            const r = await ta('/collect', 'POST');
-            if (!r.ok) { alert('Collect failed: ' + r.err); return; }
-            const c = r.data.collected || {};
-            alert(`Collected:\n  CrowdSec: ${c.crowdsec ?? 0}\n  WAF: ${c.waf ?? 0}`);
-            loadMetrics();
-            loadAlerts();
-        }
-
-        function escapeHtml(s) {
+        function esc(s) {
             if (s == null) return '';
             return String(s).replace(/[&<>"']/g, c => ({
                 '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
             }[c]));
         }
 
-        loadMetrics();
-        loadAlerts();
-        loadEmancipated();
-        loadRules();
-        setInterval(loadMetrics, 60000);
-        setInterval(loadEmancipated, 60000);
+        // ── Loaders — one per panel, independent ─────────────────
+        async function loadStats() {
+            const r = await get('/api/v1/threat-analyst/stats');
+            diagSet('/stats', r);
+            if (!r.ok) {
+                document.getElementById('s-alerts').textContent = '?';
+                document.getElementById('s-pending').textContent = '?';
+                document.getElementById('s-total').textContent = '?';
+                document.getElementById('b-source').textContent = r.err;
+                document.getElementById('b-severity').textContent = r.err;
+                return;
+            }
+            const s = r.data;
+            document.getElementById('s-alerts').textContent  = s.alerts_24h ?? 0;
+            document.getElementById('s-pending').textContent = s.pending_rules ?? 0;
+            document.getElementById('s-total').textContent   = s.total_rules ?? 0;
+            const fmtDict = d => {
+                if (!d || !Object.keys(d).length) return '—';
+                return Object.entries(d)
+                    .sort((a, b) => b[1] - a[1])
+                    .map(([k, v]) => `${k} ${v}`).join(' · ');
+            };
+            document.getElementById('b-source').textContent   = fmtDict(s.by_source);
+            document.getElementById('b-severity').textContent = fmtDict(s.by_severity);
+        }
+
+        async function loadAlerts() {
+            const hours = document.getElementById('alerts-window').value;
+            const r = await get(`/api/v1/threat-analyst/alerts?hours=${hours}`);
+            diagSet('/alerts', r);
+            const c = document.getElementById('alerts-body');
+            if (!r.ok) { c.innerHTML = `<div class="msg msg-error">${esc(r.err)}</div>`; return; }
+            const alerts = r.data.alerts || [];
+            if (!alerts.length) { c.innerHTML = '<div class="msg msg-empty">No alerts in window.</div>'; return; }
+            const rows = alerts.slice(0, 50).map(a => `
+                <tr>
+                    <td>${a.timestamp ? new Date(a.timestamp).toLocaleString() : '—'}</td>
+                    <td><span class="pill ${esc((a.severity || 'low').toLowerCase())}">${esc(a.severity || '?')}</span></td>
+                    <td>${esc(a.source || '—')}</td>
+                    <td>${esc(a.description || a.scenario || a.message || '—')}</td>
+                </tr>
+            `).join('');
+            const extra = alerts.length > 50 ? `<div class="msg msg-empty">${alerts.length - 50} more not shown</div>` : '';
+            c.innerHTML = `<table><thead><tr><th>Time</th><th>Sev</th><th>Source</th><th>Detail</th></tr></thead><tbody>${rows}</tbody></table>${extra}`;
+        }
+
+        async function loadRules() {
+            const r = await get('/api/v1/threat-analyst/rules?status=pending');
+            diagSet('/rules', r);
+            const c = document.getElementById('rules-body');
+            if (!r.ok) { c.innerHTML = `<div class="msg msg-error">${esc(r.err)}</div>`; return; }
+            const rules = r.data.rules || [];
+            if (!rules.length) { c.innerHTML = '<div class="msg msg-empty">No pending rules.</div>'; return; }
+            const rows = rules.map(rule => `
+                <tr>
+                    <td><strong>${esc(rule.type || '?')}</strong><br><span style="color:var(--muted);font-size:11px;">${esc(rule.name || rule.id || '')}</span></td>
+                    <td>${esc(rule.description || rule.reason || '—')}</td>
+                    <td style="white-space:nowrap;">
+                        <button class="sm primary" onclick="ruleAction('${esc(rule.id)}', 'approve')">Approve</button>
+                        <button class="sm" onclick="ruleAction('${esc(rule.id)}', 'apply')">Apply</button>
+                        <button class="sm danger" onclick="ruleAction('${esc(rule.id)}', 'reject')">Reject</button>
+                    </td>
+                </tr>
+            `).join('');
+            c.innerHTML = `<table><thead><tr><th>Rule</th><th>Description</th><th>Action</th></tr></thead><tbody>${rows}</tbody></table>`;
+        }
+
+        async function loadEmancipated() {
+            const r = await get('/api/v1/exposure/emancipated');
+            diagSet('/exposure/emancipated', r);
+            const c = document.getElementById('ema-body');
+            if (!r.ok) {
+                c.innerHTML = `<div class="msg msg-error">${esc(r.err)}</div>`;
+                document.getElementById('s-ema').textContent = '?';
+                return;
+            }
+            const svcs = r.data.services || [];
+            document.getElementById('s-ema').textContent = svcs.length;
+            if (!svcs.length) { c.innerHTML = '<div class="msg msg-empty">No services exposed.</div>'; return; }
+            const rows = svcs.map(s => `
+                <tr>
+                    <td><strong>${esc(s.name || s.service || '?')}</strong></td>
+                    <td><code>:${esc(String(s.port ?? '?'))}</code></td>
+                    <td>${esc(s.domain || '—')}</td>
+                    <td>${(s.channels || []).map(ch => `<span class="pill ch">${esc(ch)}</span>`).join('')}</td>
+                    <td><button class="sm danger" onclick="revokeService('${esc(s.name || s.service)}')">Revoke</button></td>
+                </tr>
+            `).join('');
+            c.innerHTML = `<table><thead><tr><th>Name</th><th>Port</th><th>Domain</th><th>Channels</th><th></th></tr></thead><tbody>${rows}</tbody></table>`;
+        }
+
+        // ── Actions ──────────────────────────────────────────────
+        async function ruleAction(id, verb) {
+            const r = await post(`/api/v1/threat-analyst/rules/${id}/${verb}`);
+            if (!r.ok) { alert(`${verb} failed: ${r.err}`); return; }
+            loadRules();
+            loadStats();
+        }
+
+        async function revokeService(name) {
+            if (!confirm(`Revoke exposure for "${name}"?`)) return;
+            const r = await post('/api/v1/exposure/revoke', { name });
+            if (!r.ok) { alert('Revoke failed: ' + r.err); return; }
+            loadEmancipated();
+        }
+
+        async function analyzeIOC() {
+            const ioc = document.getElementById('ioc-input').value.trim();
+            if (!ioc) return;
+            const out = document.getElementById('analyze-out');
+            out.className = 'analyze-result'; out.textContent = 'Analyzing…';
+            const r = await post('/api/v1/threat-analyst/analyze', { ioc, hours: 24 });
+            if (!r.ok) { out.className = 'msg msg-error'; out.textContent = 'Failed: ' + r.err; return; }
+            out.textContent = JSON.stringify(r.data, null, 2);
+        }
+
+        async function collectAll() {
+            const r = await post('/api/v1/threat-analyst/collect');
+            if (!r.ok) { alert('Collect failed: ' + r.err); return; }
+            const c = r.data.collected || {};
+            alert(`Collected\n  CrowdSec: ${c.crowdsec ?? 0}\n  WAF: ${c.waf ?? 0}`);
+            loadAll();
+        }
+
+        // ── Diagnostic row tracker ───────────────────────────────
+        const diagState = {};
+        function diagSet(endpoint, r) {
+            diagState[endpoint] = r;
+            renderDiag();
+        }
+        function renderDiag() {
+            const t = document.getElementById('diag-table');
+            const rows = Object.entries(diagState).map(([ep, r]) => `
+                <tr>
+                    <td>${esc(ep)}</td>
+                    <td class="${r.ok ? 'ok' : 'bad'}">${r.ok ? 'OK ' + r.status : 'FAIL ' + (r.status || '?')}</td>
+                    <td>${esc(r.err || '')}</td>
+                </tr>
+            `).join('');
+            t.innerHTML = rows || '<tr><td colspan="3" class="msg-loading">probing…</td></tr>';
+        }
+
+        // ── Boot ─────────────────────────────────────────────────
+        async function loadAll() {
+            await Promise.all([loadStats(), loadAlerts(), loadRules(), loadEmancipated()]);
+        }
+        loadAll();
+        setInterval(loadAll, 30000);
     </script>
-    <script src="/shared/crt-engine.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Complete clean rebuild of the dashboard from scratch. v1.2.x got the backend wired up correctly but the UI was still cluttered (gradient chips, awkward 2-col grid, confusing error states). v1.3.0 starts over and builds against `.claude/DESIGN-CHARTER.md`:

- **WALL palette** (threat-analyst is a WALL/firewall module) — `--wall-main #9A6010` accent
- **Space Grotesk** display+body, **JetBrains Mono** code, per charter §Typography
- **Base white theme tokens** from `/shared/design-tokens.css` (--bg, --surface, --surface2, --border, --text, --muted)
- **Charter radii**: 14px cards, 6px swatches, 3px chips
- **Spacing scale**: XS 4 / S 8 / M 16 / L 24 / XL 40
- **Single-column layout**, plain tables, no gradient text, no chip clutter
- Each panel fetches independently; errors shown in plain text
- **NEW diagnostic footer** tracking latest fetch outcome per endpoint (OK 200 / FAIL 401 / Network …) — operator can distinguish auth vs network vs 404 without DevTools
- `body.module-wall` set so shared CSS that scopes by `.module-wall` inherits the right colour vars

## Test plan

- [x] `.deb` builds clean as `secubox-threat-analyst_1.3.0-1~bookworm1_all.deb`
- [x] Deployed on gk2 (1.2.0 → 1.3.0); shipped HTML carries 16 charter-alignment markers
- [x] /stats endpoint returns real JSON via socket (`{alerts_24h:0,...}`)
- [ ] Hard-refresh /threat-analyst/ → dashboard renders in WALL palette, all 4 panels populate, diagnostic footer shows OK 200 on all endpoints
