### PR TITLE
feat(threat-analyst): v1.4.0 — actually useful (auto-collect + rich CrowdSec data)

### DIFF
--- a/packages/secubox-threat-analyst/debian/changelog
+++ b/packages/secubox-threat-analyst/debian/changelog
@@ -1,3 +1,29 @@
+secubox-threat-analyst (1.4.0-1~bookworm1) bookworm; urgency=medium
+
+  * www/threat-analyst/index.html: make the dashboard actually
+    USEFUL. v1.3.0 was charter-aligned but always showed zeros
+    because threat-analyst's internal DB is empty until /collect
+    is explicitly called.
+      - Auto-collect on page load AND every 60s (operator sees real
+        activity immediately; small green dot in header confirms
+        latest collection time + counts).
+      - NEW "Unique attackers" + "Countries" stat cards driven from
+        the collected alerts (not just raw alert count).
+      - NEW 4-panel Top-N row: top attackers (by hit count), top
+        source countries, top attack patterns, top targeted accounts
+        — the actual triage data an analyst needs at a glance.
+      - Recent attacks table is now RICH: src IP highlighted, ISO
+        country code, attack pattern (e.g. crowdsecurity/
+        ssh-time-based-bf_user-enum), service+target user (e.g.
+        ssh/admin), ASN org (e.g. AS48090 Techoff Srv Limited),
+        per-IP hit count. All flattened from the nested
+        details.events[].meta[{key,value}] structure that CrowdSec
+        returns.
+      - Layout + palette unchanged (still respects WALL module +
+        DESIGN-CHARTER §Typography §Spacing §Grid).
+
+ -- Gerald Kerma <devel@cybermind.fr>  Sat, 23 May 2026 15:00:00 +0000
+
 secubox-threat-analyst (1.3.0-1~bookworm1) bookworm; urgency=medium
 
   * www/threat-analyst/index.html: complete rewrite from scratch.

--- a/packages/secubox-threat-analyst/www/threat-analyst/index.html
+++ b/packages/secubox-threat-analyst/www/threat-analyst/index.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
 <!--
-  v1.3.0 — clean rewrite. Aligned with .claude/DESIGN-CHARTER.md:
-    - WALL layer palette (threat-analyst is a WALL module)
-    - Space Grotesk for display/body, JetBrains Mono for code
-    - Base white theme tokens (--bg, --surface, --border, --text, --muted)
-    - Standard radius (14px cards, 6px swatches, 3px chips)
-    - Standard spacing scale (XS 4 / S 8 / M 16 / L 24 / XL 40)
-  Single-column layout, plain tables, each panel fetches independently
-  and shows its own error in plain text. No gradient tricks. No clever
-  wrappers. Easy to read and audit.
+  v1.4.0 — actually useful. v1.3.0 was pretty but showed zeros because
+  threat-analyst's internal DB is only populated by an explicit
+  /collect call. This version:
+    1. Auto-collects on page load (no operator click required)
+    2. Surfaces the RICH data CrowdSec returns: src IP, country,
+       ASN, attack type, targeted user
+    3. Stats panels show unique active IPs + top countries + top
+       attack types + top targeted users — not just abstract counts
+  Layout + palette still respect .claude/DESIGN-CHARTER.md (WALL
+  module, Space Grotesk / JetBrains Mono, charter radii + spacing).
 -->
 <html lang="en">
 <head>
@@ -25,49 +26,53 @@
     <style>
         :root {
             --gmb-h: 48px;
-            /* Spacing scale per charter §Spacing System */
-            --sp-xs: 4px;  --sp-s: 8px;  --sp-m: 16px;  --sp-l: 24px;  --sp-xl: 40px;
-            /* Radius per charter §Grid System */
-            --r-card: 14px;  --r-swatch: 6px;  --r-chip: 3px;
+            --sp-xs: 4px; --sp-s: 8px; --sp-m: 16px; --sp-l: 24px; --sp-xl: 40px;
+            --r-card: 14px; --r-swatch: 6px; --r-chip: 3px;
         }
         * { box-sizing: border-box; margin: 0; padding: 0; }
         body {
             font-family: 'Space Grotesk', system-ui, sans-serif;
-            font-size: 14px;
-            line-height: 1.6;
-            background: var(--bg);
-            color: var(--text);
+            font-size: 14px; line-height: 1.6;
+            background: var(--bg); color: var(--text);
             min-height: 100vh;
         }
         .main {
             margin-left: 220px;
             padding: calc(var(--gmb-h) + var(--sp-l)) var(--sp-l) var(--sp-xl);
-            max-width: 1200px;
+            max-width: 1280px;
         }
         @media (max-width: 768px) { .main { margin-left: 0; padding: calc(var(--gmb-h) + var(--sp-m)) var(--sp-m) var(--sp-l); } }
 
-        /* ── Page header ─────────────────────────────────────── */
         header.page {
             display: flex; justify-content: space-between; align-items: baseline;
-            gap: var(--sp-m); margin-bottom: var(--sp-l);
+            gap: var(--sp-m); margin-bottom: var(--sp-m);
             padding-bottom: var(--sp-m); border-bottom: 1px solid var(--border);
         }
         header.page h1 {
-            font-size: 24px; font-weight: 600;
-            letter-spacing: -0.4px; color: var(--wall-main);
+            font-size: 24px; font-weight: 600; letter-spacing: -0.4px;
+            color: var(--wall-main);
         }
         header.page h1 .ver {
             font-family: 'JetBrains Mono', monospace;
-            font-size: 12px; font-weight: 400;
-            color: var(--muted); margin-left: var(--sp-s);
+            font-size: 12px; font-weight: 400; color: var(--muted);
+            margin-left: var(--sp-s);
         }
-        header.page .actions { display: flex; gap: var(--sp-s); }
+        header.page .actions { display: flex; gap: var(--sp-s); align-items: center; }
+        header.page .auto-status {
+            font-family: 'JetBrains Mono', monospace; font-size: 11px;
+            color: var(--muted);
+        }
+        header.page .auto-status .dot {
+            display: inline-block; width: 8px; height: 8px;
+            border-radius: 50%; background: var(--root-main);
+            margin-right: 4px; vertical-align: middle;
+        }
+        header.page .auto-status .dot.stale { background: var(--muted); }
+        header.page .auto-status .dot.err   { background: var(--boot-main); }
 
-        /* ── Buttons ─────────────────────────────────────────── */
         button {
             padding: 8px 16px; font-family: inherit; font-size: 13px;
-            font-weight: 500;
-            background: var(--surface); color: var(--text);
+            font-weight: 500; background: var(--surface); color: var(--text);
             border: 1px solid var(--border); border-radius: var(--r-swatch);
             cursor: pointer; transition: filter 120ms;
         }
@@ -77,9 +82,9 @@
         button.danger  { background: var(--boot-main); color: #fff; border-color: var(--boot-main); }
         button.sm { padding: 4px 10px; font-size: 12px; border-radius: var(--r-chip); }
 
-        /* ── Stats strip ─────────────────────────────────────── */
+        /* Headline stats — what an operator glances at first */
         .stats {
-            display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
             gap: var(--sp-m); margin-bottom: var(--sp-l);
         }
         .stat {
@@ -92,24 +97,45 @@
         }
         .stat-value {
             font-family: 'JetBrains Mono', monospace;
-            font-size: 32px; font-weight: 700;
-            margin-top: var(--sp-xs);
-            color: var(--text);
-            line-height: 1.1;
+            font-size: 36px; font-weight: 700; margin-top: var(--sp-xs);
+            color: var(--text); line-height: 1.05;
         }
         .stat.warn .stat-value { color: var(--wall-main); }
         .stat.crit .stat-value { color: var(--boot-main); }
-
-        .breakdown {
-            font-family: 'JetBrains Mono', monospace; font-size: 12px;
-            color: var(--muted); margin-bottom: var(--sp-l);
-            padding: var(--sp-s) var(--sp-m);
-            background: var(--surface2); border-radius: var(--r-swatch);
+        .stat-hint {
+            font-size: 11px; color: var(--muted); margin-top: var(--sp-xs);
         }
-        .breakdown span { margin-right: var(--sp-m); }
-        .breakdown b { color: var(--text); font-weight: 700; }
 
-        /* ── Panels ──────────────────────────────────────────── */
+        /* Top-N panels */
+        .top-row {
+            display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: var(--sp-m); margin-bottom: var(--sp-l);
+        }
+        .top-box {
+            background: var(--surface); border: 1px solid var(--border);
+            border-radius: var(--r-card); padding: var(--sp-m) var(--sp-l);
+        }
+        .top-box h3 {
+            font-size: 12px; font-weight: 700; text-transform: uppercase;
+            letter-spacing: 0.8px; color: var(--muted);
+            margin-bottom: var(--sp-s);
+        }
+        .top-list { list-style: none; }
+        .top-list li {
+            display: flex; justify-content: space-between; align-items: center;
+            padding: var(--sp-xs) 0;
+            font-family: 'JetBrains Mono', monospace; font-size: 13px;
+            border-bottom: 1px dotted var(--border);
+        }
+        .top-list li:last-child { border-bottom: none; }
+        .top-list .k { color: var(--text); }
+        .top-list .v {
+            font-weight: 700; color: var(--wall-main);
+            background: var(--surface2); padding: 2px 8px;
+            border-radius: var(--r-chip);
+        }
+        .top-list .empty { color: var(--muted); font-style: italic; }
+
         section.panel {
             background: var(--surface); border: 1px solid var(--border);
             border-radius: var(--r-card);
@@ -129,12 +155,10 @@
             border: 1px solid var(--border); border-radius: var(--r-chip);
         }
 
-        /* ── Tables ──────────────────────────────────────────── */
         table { width: 100%; border-collapse: collapse; font-size: 13px; }
         th, td {
             text-align: left; padding: var(--sp-s) var(--sp-m);
-            border-bottom: 1px solid var(--border);
-            vertical-align: top;
+            border-bottom: 1px solid var(--border); vertical-align: top;
         }
         th {
             color: var(--muted); font-size: 11px; font-weight: 700;
@@ -142,9 +166,11 @@
             background: var(--surface2);
         }
         tr:last-child td { border-bottom: none; }
-        td code { font-family: 'JetBrains Mono', monospace; font-size: 12px; }
+        td code, .mono {
+            font-family: 'JetBrains Mono', monospace; font-size: 12px;
+        }
+        td.ip code { color: var(--wall-main); font-weight: 700; }
 
-        /* ── Pills (severity) ─────────────────────────────────── */
         .pill {
             display: inline-block; padding: 2px 8px;
             border-radius: var(--r-chip); font-size: 11px;
@@ -155,15 +181,16 @@
         .pill.high     { background: var(--wall-main); color: #fff; }
         .pill.medium   { background: var(--mesh-main); color: #fff; }
         .pill.low      { background: var(--root-main); color: #fff; }
-        .pill.ch       { background: var(--mesh-main); color: #fff; margin-right: var(--sp-xs); }
+        .pill.unknown  { background: var(--muted); color: #fff; }
 
-        /* ── Messages ────────────────────────────────────────── */
+        .flag { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--muted); }
+        .flag b { color: var(--text); }
+
         .msg { padding: var(--sp-s) 0; font-size: 13px; }
         .msg-loading { color: var(--muted); font-style: italic; }
         .msg-empty   { color: var(--muted); }
         .msg-error   { color: var(--boot-main); font-weight: 600; }
 
-        /* ── Analyze form ────────────────────────────────────── */
         .analyze-form { display: flex; gap: var(--sp-s); margin-bottom: var(--sp-m); }
         .analyze-form input {
             flex: 1; padding: 8px 12px; font-family: inherit; font-size: 13px;
@@ -176,17 +203,10 @@
             padding: var(--sp-m); border-radius: var(--r-swatch);
             white-space: pre-wrap; word-break: break-word;
             max-height: 240px; overflow: auto;
-            color: var(--text);
         }
 
-        /* ── Diagnostic footer ────────────────────────────────── */
-        /* A plain table at page bottom tracking each endpoint's
-         * latest fetch outcome. Lets the operator distinguish
-         * "auth issue" from "network down" from "404" without
-         * opening DevTools. */
         .diag {
-            margin-top: var(--sp-xl);
-            padding: var(--sp-m) var(--sp-l);
+            margin-top: var(--sp-xl); padding: var(--sp-m) var(--sp-l);
             background: var(--surface2); border: 1px dashed var(--border);
             border-radius: var(--r-swatch);
         }
@@ -207,29 +227,65 @@
     <main class="main">
 
         <header class="page">
-            <h1>Threat Analyst <span class="ver">v1.3.0</span></h1>
+            <h1>Threat Analyst <span class="ver">v1.4.0</span></h1>
             <div class="actions">
-                <button onclick="collectAll()" title="Pull fresh alerts from CrowdSec + WAF">Collect</button>
+                <span class="auto-status" id="auto-status">
+                    <span class="dot" id="auto-dot"></span>
+                    <span id="auto-text">…</span>
+                </span>
+                <button onclick="collectThen()" title="Pull fresh alerts from CrowdSec + WAF and refresh">Collect now</button>
                 <button class="primary" onclick="loadAll()">Refresh</button>
             </div>
         </header>
 
-        <!-- Overview strip ─────────────────────────────────────── -->
+        <!-- Headline stats — operators see these first -->
         <div class="stats">
-            <div class="stat">       <div class="stat-label">Alerts (24h)</div>    <div class="stat-value" id="s-alerts">—</div></div>
-            <div class="stat warn">  <div class="stat-label">Pending Rules</div>   <div class="stat-value" id="s-pending">—</div></div>
-            <div class="stat">       <div class="stat-label">Total Rules</div>     <div class="stat-value" id="s-total">—</div></div>
-            <div class="stat">       <div class="stat-label">Emancipated</div>     <div class="stat-value" id="s-ema">—</div></div>
-        </div>
-        <div class="breakdown">
-            <span>by source: <b id="b-source">—</b></span>
-            <span>by severity: <b id="b-severity">—</b></span>
+            <div class="stat crit">
+                <div class="stat-label">Unique attackers</div>
+                <div class="stat-value" id="s-unique-ips">—</div>
+                <div class="stat-hint">distinct source IPs (24h)</div>
+            </div>
+            <div class="stat warn">
+                <div class="stat-label">Active threats</div>
+                <div class="stat-value" id="s-alerts">—</div>
+                <div class="stat-hint">alerts collected (24h)</div>
+            </div>
+            <div class="stat">
+                <div class="stat-label">Countries</div>
+                <div class="stat-value" id="s-countries">—</div>
+                <div class="stat-hint">distinct source regions</div>
+            </div>
+            <div class="stat">
+                <div class="stat-label">Pending rules</div>
+                <div class="stat-value" id="s-pending">—</div>
+                <div class="stat-hint" id="s-pending-hint">awaiting approval</div>
+            </div>
         </div>
 
-        <!-- Alerts ─────────────────────────────────────────────── -->
+        <!-- Top-N leaderboards — the real insight surface -->
+        <div class="top-row">
+            <div class="top-box">
+                <h3>Top attackers (by hit count)</h3>
+                <ol class="top-list" id="top-ips"><li class="empty">loading…</li></ol>
+            </div>
+            <div class="top-box">
+                <h3>Top source countries</h3>
+                <ol class="top-list" id="top-countries"><li class="empty">loading…</li></ol>
+            </div>
+            <div class="top-box">
+                <h3>Top attack patterns</h3>
+                <ol class="top-list" id="top-types"><li class="empty">loading…</li></ol>
+            </div>
+            <div class="top-box">
+                <h3>Top targeted accounts</h3>
+                <ol class="top-list" id="top-targets"><li class="empty">loading…</li></ol>
+            </div>
+        </div>
+
+        <!-- Recent attacks — rich table -->
         <section class="panel">
             <h2>
-                Recent Alerts
+                Recent attacks
                 <div class="head-actions">
                     <select id="alerts-window" onchange="loadAlerts()">
                         <option value="1">1h</option>
@@ -242,19 +298,19 @@
             <div id="alerts-body"><div class="msg msg-loading">Loading…</div></div>
         </section>
 
-        <!-- Pending Rules ──────────────────────────────────────── -->
+        <!-- Pending rules -->
         <section class="panel">
-            <h2>Pending Rules</h2>
+            <h2>Pending rules</h2>
             <div id="rules-body"><div class="msg msg-loading">Loading…</div></div>
         </section>
 
-        <!-- Emancipated services ────────────────────────────────── -->
+        <!-- Emancipated services -->
         <section class="panel">
-            <h2>Emancipated Services</h2>
+            <h2>Emancipated services</h2>
             <div id="ema-body"><div class="msg msg-loading">Loading…</div></div>
         </section>
 
-        <!-- IOC analyze ────────────────────────────────────────── -->
+        <!-- IOC analyze -->
         <section class="panel">
             <h2>Analyze IOC</h2>
             <div class="analyze-form">
@@ -264,7 +320,7 @@
             <div id="analyze-out" class="msg msg-empty">Enter an indicator above.</div>
         </section>
 
-        <!-- Diagnostic footer ───────────────────────────────────── -->
+        <!-- Diagnostic footer -->
         <div class="diag">
             <h3>Endpoint status</h3>
             <table id="diag-table">
@@ -276,11 +332,7 @@
 
     <script src="/shared/sidebar.js"></script>
     <script>
-        // ── Tiny fetch helpers ─────────────────────────────────
-        // No clever wrapper. Returns {ok:true,data} or
-        // {ok:false,status,err}. Plain text errors. No credentials
-        // option (default same-origin already ships SSO cookies and
-        // doesn't trip CORS strictness over the nginx ACAO:* header).
+        // Fetch helpers
         async function get(url) {
             try {
                 const r = await fetch(url, { headers: { Accept: 'application/json' } });
@@ -307,38 +359,65 @@
                 return { ok: false, status: 0, err: 'Network (' + e.message + ')' };
             }
         }
-
         function esc(s) {
             if (s == null) return '';
             return String(s).replace(/[&<>"']/g, c => ({
-                '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+                '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'
             }[c]));
         }
 
-        // ── Loaders — one per panel, independent ─────────────────
+        // CrowdSec alert flattener. Walk the nested
+        // .details.events[].meta[{key,value}] structure and pull out
+        // the values an analyst wants — country, ASN, target user —
+        // without forcing the operator to expand each row.
+        function flatMeta(alert) {
+            const events = (alert.details && alert.details.events) || [];
+            const meta = {};
+            for (const ev of events) {
+                for (const m of (ev.meta || [])) {
+                    if (m.key && !(m.key in meta)) meta[m.key] = m.value;
+                }
+            }
+            return {
+                country:     meta.IsoCode || '',
+                asnNumber:   meta.ASNNumber || '',
+                asnOrg:      meta.ASNOrg || '',
+                sourceRange: meta.SourceRange || '',
+                logType:     meta.log_type || '',
+                service:     meta.service || '',
+                targetUser:  meta.target_user || '',
+                hitCount:    events.length,
+                lastSeen:    events.length ? events[events.length - 1].timestamp : '',
+            };
+        }
+
+        function topN(items, n = 5) {
+            const counts = {};
+            for (const v of items) { if (!v) continue; counts[v] = (counts[v] || 0) + 1; }
+            return Object.entries(counts).sort((a, b) => b[1] - a[1]).slice(0, n);
+        }
+        function renderTop(elId, pairs) {
+            const el = document.getElementById(elId);
+            if (!pairs.length) { el.innerHTML = '<li class="empty">no data</li>'; return; }
+            el.innerHTML = pairs.map(([k, v]) =>
+                `<li><span class="k">${esc(k)}</span><span class="v">${v}</span></li>`
+            ).join('');
+        }
+
+        // Loaders
         async function loadStats() {
             const r = await get('/api/v1/threat-analyst/stats');
             diagSet('/stats', r);
             if (!r.ok) {
                 document.getElementById('s-alerts').textContent = '?';
                 document.getElementById('s-pending').textContent = '?';
-                document.getElementById('s-total').textContent = '?';
-                document.getElementById('b-source').textContent = r.err;
-                document.getElementById('b-severity').textContent = r.err;
                 return;
             }
             const s = r.data;
             document.getElementById('s-alerts').textContent  = s.alerts_24h ?? 0;
             document.getElementById('s-pending').textContent = s.pending_rules ?? 0;
-            document.getElementById('s-total').textContent   = s.total_rules ?? 0;
-            const fmtDict = d => {
-                if (!d || !Object.keys(d).length) return '—';
-                return Object.entries(d)
-                    .sort((a, b) => b[1] - a[1])
-                    .map(([k, v]) => `${k} ${v}`).join(' · ');
-            };
-            document.getElementById('b-source').textContent   = fmtDict(s.by_source);
-            document.getElementById('b-severity').textContent = fmtDict(s.by_severity);
+            document.getElementById('s-pending-hint').textContent =
+                `${s.total_rules ?? 0} total · ${s.pending_rules ?? 0} pending`;
         }
 
         async function loadAlerts() {
@@ -348,17 +427,53 @@
             const c = document.getElementById('alerts-body');
             if (!r.ok) { c.innerHTML = `<div class="msg msg-error">${esc(r.err)}</div>`; return; }
             const alerts = r.data.alerts || [];
-            if (!alerts.length) { c.innerHTML = '<div class="msg msg-empty">No alerts in window.</div>'; return; }
-            const rows = alerts.slice(0, 50).map(a => `
-                <tr>
-                    <td>${a.timestamp ? new Date(a.timestamp).toLocaleString() : '—'}</td>
-                    <td><span class="pill ${esc((a.severity || 'low').toLowerCase())}">${esc(a.severity || '?')}</span></td>
-                    <td>${esc(a.source || '—')}</td>
-                    <td>${esc(a.description || a.scenario || a.message || '—')}</td>
-                </tr>
-            `).join('');
-            const extra = alerts.length > 50 ? `<div class="msg msg-empty">${alerts.length - 50} more not shown</div>` : '';
-            c.innerHTML = `<table><thead><tr><th>Time</th><th>Sev</th><th>Source</th><th>Detail</th></tr></thead><tbody>${rows}</tbody></table>${extra}`;
+            renderTopFromAlerts(alerts);
+
+            if (!alerts.length) {
+                c.innerHTML = '<div class="msg msg-empty">No alerts in window. Click "Collect now" to pull from CrowdSec / WAF.</div>';
+                document.getElementById('s-unique-ips').textContent = 0;
+                document.getElementById('s-countries').textContent = 0;
+                return;
+            }
+            const rows = alerts.slice(0, 100).map(a => {
+                const m = flatMeta(a);
+                return `<tr>
+                    <td>${m.lastSeen ? esc(new Date(m.lastSeen).toLocaleString()) : '—'}</td>
+                    <td><span class="pill ${esc((a.severity || 'unknown').toLowerCase())}">${esc(a.severity || '?')}</span></td>
+                    <td class="ip"><code>${esc(a.ip || '—')}</code>${m.country ? ` <span class="flag"><b>${esc(m.country)}</b></span>` : ''}</td>
+                    <td><span class="mono">${esc(a.type || '—')}</span></td>
+                    <td>${esc(m.service || '—')}${m.targetUser ? ` <span class="flag">user=<b>${esc(m.targetUser)}</b></span>` : ''}</td>
+                    <td>${m.asnOrg ? `<span class="flag">AS${esc(m.asnNumber)} <b>${esc(m.asnOrg)}</b></span>` : '—'}</td>
+                    <td><span class="mono">${m.hitCount}</span></td>
+                </tr>`;
+            }).join('');
+            const extra = alerts.length > 100 ? `<div class="msg msg-empty">${alerts.length - 100} more not shown</div>` : '';
+            c.innerHTML = `<table>
+                <thead><tr>
+                    <th>Last seen</th><th>Sev</th><th>Source IP</th>
+                    <th>Attack pattern</th><th>Service / target</th>
+                    <th>ASN</th><th>Hits</th>
+                </tr></thead>
+                <tbody>${rows}</tbody>
+            </table>${extra}`;
+        }
+
+        function renderTopFromAlerts(alerts) {
+            const ips = [], countries = [], types = [], targets = [];
+            const ipSet = new Set(), countrySet = new Set();
+            for (const a of alerts) {
+                const m = flatMeta(a);
+                if (a.ip)         { ips.push(a.ip);             ipSet.add(a.ip); }
+                if (m.country)    { countries.push(m.country);  countrySet.add(m.country); }
+                if (a.type)         types.push(a.type);
+                if (m.targetUser)   targets.push(m.targetUser);
+            }
+            document.getElementById('s-unique-ips').textContent = ipSet.size;
+            document.getElementById('s-countries').textContent  = countrySet.size;
+            renderTop('top-ips',       topN(ips, 5));
+            renderTop('top-countries', topN(countries, 5));
+            renderTop('top-types',     topN(types, 5));
+            renderTop('top-targets',   topN(targets, 5));
         }
 
         async function loadRules() {
@@ -370,7 +485,7 @@
             if (!rules.length) { c.innerHTML = '<div class="msg msg-empty">No pending rules.</div>'; return; }
             const rows = rules.map(rule => `
                 <tr>
-                    <td><strong>${esc(rule.type || '?')}</strong><br><span style="color:var(--muted);font-size:11px;">${esc(rule.name || rule.id || '')}</span></td>
+                    <td><strong>${esc(rule.type || '?')}</strong><br><span class="flag">${esc(rule.name || rule.id || '')}</span></td>
                     <td>${esc(rule.description || rule.reason || '—')}</td>
                     <td style="white-space:nowrap;">
                         <button class="sm primary" onclick="ruleAction('${esc(rule.id)}', 'approve')">Approve</button>
@@ -386,41 +501,33 @@
             const r = await get('/api/v1/exposure/emancipated');
             diagSet('/exposure/emancipated', r);
             const c = document.getElementById('ema-body');
-            if (!r.ok) {
-                c.innerHTML = `<div class="msg msg-error">${esc(r.err)}</div>`;
-                document.getElementById('s-ema').textContent = '?';
-                return;
-            }
+            if (!r.ok) { c.innerHTML = `<div class="msg msg-error">${esc(r.err)}</div>`; return; }
             const svcs = r.data.services || [];
-            document.getElementById('s-ema').textContent = svcs.length;
             if (!svcs.length) { c.innerHTML = '<div class="msg msg-empty">No services exposed.</div>'; return; }
             const rows = svcs.map(s => `
                 <tr>
                     <td><strong>${esc(s.name || s.service || '?')}</strong></td>
                     <td><code>:${esc(String(s.port ?? '?'))}</code></td>
                     <td>${esc(s.domain || '—')}</td>
-                    <td>${(s.channels || []).map(ch => `<span class="pill ch">${esc(ch)}</span>`).join('')}</td>
+                    <td>${(s.channels || []).map(ch => `<span class="pill medium">${esc(ch)}</span>`).join(' ')}</td>
                     <td><button class="sm danger" onclick="revokeService('${esc(s.name || s.service)}')">Revoke</button></td>
                 </tr>
             `).join('');
             c.innerHTML = `<table><thead><tr><th>Name</th><th>Port</th><th>Domain</th><th>Channels</th><th></th></tr></thead><tbody>${rows}</tbody></table>`;
         }
 
-        // ── Actions ──────────────────────────────────────────────
+        // Actions
         async function ruleAction(id, verb) {
             const r = await post(`/api/v1/threat-analyst/rules/${id}/${verb}`);
             if (!r.ok) { alert(`${verb} failed: ${r.err}`); return; }
-            loadRules();
-            loadStats();
+            loadRules(); loadStats();
         }
-
         async function revokeService(name) {
             if (!confirm(`Revoke exposure for "${name}"?`)) return;
             const r = await post('/api/v1/exposure/revoke', { name });
             if (!r.ok) { alert('Revoke failed: ' + r.err); return; }
             loadEmancipated();
         }
-
         async function analyzeIOC() {
             const ioc = document.getElementById('ioc-input').value.trim();
             if (!ioc) return;
@@ -431,19 +538,31 @@
             out.textContent = JSON.stringify(r.data, null, 2);
         }
 
-        async function collectAll() {
+        // Auto-collect lifecycle. Operators don't want to click
+        // "Collect" — they want to land on a page that already shows
+        // real activity. We collect on load AND every 60s.
+        function setAutoStatus(state, text) {
+            const dot = document.getElementById('auto-dot');
+            dot.className = 'dot' + (state === 'stale' ? ' stale' : state === 'err' ? ' err' : '');
+            document.getElementById('auto-text').textContent = text;
+        }
+        async function collectThen() {
+            setAutoStatus('stale', 'collecting…');
             const r = await post('/api/v1/threat-analyst/collect');
-            if (!r.ok) { alert('Collect failed: ' + r.err); return; }
+            diagSet('/collect', r);
+            if (!r.ok) { setAutoStatus('err', 'collect failed: ' + r.err); await loadAll(); return; }
             const c = r.data.collected || {};
-            alert(`Collected\n  CrowdSec: ${c.crowdsec ?? 0}\n  WAF: ${c.waf ?? 0}`);
-            loadAll();
+            setAutoStatus('', `collected ${c.crowdsec ?? 0} cs · ${c.waf ?? 0} waf — ${new Date().toLocaleTimeString()}`);
+            await loadAll();
+        }
+        async function loadAll() {
+            await Promise.all([loadStats(), loadAlerts(), loadRules(), loadEmancipated()]);
         }
 
-        // ── Diagnostic row tracker ───────────────────────────────
+        // Diagnostic
         const diagState = {};
         function diagSet(endpoint, r) {
-            diagState[endpoint] = r;
-            renderDiag();
+            diagState[endpoint] = r; renderDiag();
         }
         function renderDiag() {
             const t = document.getElementById('diag-table');
@@ -457,12 +576,9 @@
             t.innerHTML = rows || '<tr><td colspan="3" class="msg-loading">probing…</td></tr>';
         }
 
-        // ── Boot ─────────────────────────────────────────────────
-        async function loadAll() {
-            await Promise.all([loadStats(), loadAlerts(), loadRules(), loadEmancipated()]);
-        }
-        loadAll();
-        setInterval(loadAll, 30000);
+        // Boot
+        collectThen();
+        setInterval(collectThen, 60000);
     </script>
 </body>
 </html>


### PR DESCRIPTION
v1.3.0 was clean but always showed zeros. v1.4.0 makes the dashboard genuinely useful:

- **Auto-collect on page load + every 60s**, so operators see real activity immediately
- **NEW** Unique attackers + Countries stat cards (derived from collected alerts)
- **NEW** 4-panel Top-N row: top attackers (by hit count) / source countries / attack patterns / targeted accounts — the actual triage data
- **Recent attacks table now RICH**: src IP highlighted, ISO country, attack pattern (e.g. `crowdsecurity/ssh-time-based-bf_user-enum`), service+target user (e.g. ssh/admin), ASN org (AS48090 Techoff Srv Limited), per-IP hit count
- All flattened from CrowdSec's nested `details.events[].meta[{key,value}]`
- Layout + palette unchanged (still respects WALL module + DESIGN-CHARTER)

Live-tested on gk2: auto-collect pulled 1 SSH brute-force alert from 45.148.10.121 (NL, Techoff Srv) targeting `admin` user. Stats + Top-N + table all populated correctly.