### PR TITLE
feat(netplan): x64-vm + x64-live static IP fallback (192.168.1.55) when DHCP fails (closes #370)

### DIFF
--- a/board/x64-live/netplan/00-secubox.yaml
+++ b/board/x64-live/netplan/00-secubox.yaml
@@ -9,11 +9,20 @@ network:
   renderer: networkd
 
   ethernets:
-    # Bootstrap: Enable DHCP on all ethernet interfaces for initial connectivity
-    # This ensures we get an IP regardless of interface naming (eno1, enp2s0, etc.)
+    # Bootstrap: Enable DHCP on all ethernet interfaces for initial connectivity.
+    # This ensures we get an IP regardless of interface naming (eno1, enp2s0, …).
     # After first boot, secubox-net-detect rewrites this with proper WAN/LAN split.
+    #
+    # WAN fallback (closes #370): the en*/eth* matches also carry a static
+    # 192.168.1.55/24 + gw 192.168.1.254. systemd-networkd accepts DHCP
+    # and static at the same time — DHCP routes use the configured low
+    # metric (100 / 200), the static gets metric 1000, so DHCP wins when
+    # available and the static keeps the appliance reachable when not.
+    # Caveat: if multiple interfaces match the pattern, both will try to
+    # take 192.168.1.55 and one will fail with address-in-use. In practice
+    # bare-metal boxes have ONE primary NIC; multi-NIC operators run
+    # net-detect to refine the layout anyway.
 
-    # Match all common ethernet interface patterns
     eth-dhcp:
       match:
         name: "en*"
@@ -24,6 +33,13 @@ network:
         use-routes: true
         route-metric: 100
       optional: true
+      addresses: [192.168.1.55/24]
+      nameservers:
+        addresses: [1.1.1.1, 8.8.8.8]
+      routes:
+        - to: default
+          via: 192.168.1.254
+          metric: 1000
 
     eth-legacy:
       match:
@@ -35,6 +51,13 @@ network:
         use-routes: true
         route-metric: 200
       optional: true
+      addresses: [192.168.1.55/24]
+      nameservers:
+        addresses: [1.1.1.1, 8.8.8.8]
+      routes:
+        - to: default
+          via: 192.168.1.254
+          metric: 1000
 
   bridges:
     # br-lan: Pre-defined but empty - secubox-net-detect populates interfaces

--- a/board/x64-vm/netplan/00-secubox.yaml
+++ b/board/x64-vm/netplan/00-secubox.yaml
@@ -1,15 +1,32 @@
 # /etc/netplan/00-secubox.yaml — x64 VM — Mode Router
-# Configuration pour environnements virtualisés
+# Configuration pour environnements virtualisés.
+#
+# WAN fallback (closes #370): every WAN-candidate interface declares
+# BOTH `dhcp4: true` AND a static `192.168.1.55/24` with
+# gw 192.168.1.254. systemd-networkd accepts both at once — DHCP
+# routes get the default low metric (100), the static route gets
+# `metric: 1000`, so DHCP wins whenever it answers. If DHCP fails
+# the system still has the static IP and the appliance is reachable
+# at 192.168.1.55. Same idea for all 3 vendor adapter patterns
+# (VirtualBox enp0s3, KVM enp1s0, VMware ens192) so the operator
+# doesn't have to know which hypervisor they're on.
 network:
   version: 2
   renderer: networkd
 
   ethernets:
-    # VirtualBox NAT adapter (WAN)
+    # VirtualBox NAT adapter (WAN) — DHCP first, static fallback
     enp0s3:
       dhcp4: true
       dhcp6: false
       optional: true
+      addresses: [192.168.1.55/24]
+      nameservers:
+        addresses: [1.1.1.1, 8.8.8.8]
+      routes:
+        - to: default
+          via: 192.168.1.254
+          metric: 1000
 
     # VirtualBox Host-only adapter (LAN)
     enp0s8:
@@ -19,6 +36,13 @@ network:
     enp1s0:
       dhcp4: true
       optional: true
+      addresses: [192.168.1.55/24]
+      nameservers:
+        addresses: [1.1.1.1, 8.8.8.8]
+      routes:
+        - to: default
+          via: 192.168.1.254
+          metric: 1000
     enp2s0:
       optional: true
 
@@ -26,6 +50,13 @@ network:
     ens192:
       dhcp4: true
       optional: true
+      addresses: [192.168.1.55/24]
+      nameservers:
+        addresses: [1.1.1.1, 8.8.8.8]
+      routes:
+        - to: default
+          via: 192.168.1.254
+          metric: 1000
     ens224:
       optional: true
 


### PR DESCRIPTION
Both x64 netplan profiles were DHCP-only — appliance unreachable when DHCP isn't available.

Now: DHCP4 + static 192.168.1.55/24 + gw 192.168.1.254 on every WAN candidate. systemd-networkd accepts both; DHCP routes get metric 100-200, the static fallback gets metric 1000. DHCP wins when available, static takes over when not.

Applied to:
- x64-vm: enp0s3 (VBox NAT), enp1s0 (KVM), ens192 (VMware)
- x64-live: `en*` and `eth*` matches

LAN-side and other interfaces unchanged. Bakes into the next image build.