### PR TITLE
feat(hub): v1.4.2 — sidebar HTML pre-cache for instant render (v2.39.0)

### DIFF
--- a/packages/secubox-hub/debian/changelog
+++ b/packages/secubox-hub/debian/changelog
@@ -1,3 +1,24 @@
+secubox-hub (1.4.2-1~bookworm1) bookworm; urgency=medium
+
+  * www/shared/sidebar.js: sidebar HTML pre-cache for instant render
+    (v2.38.0 → v2.39.0). Previous versions cached the menu DATA but
+    only used it as a FALLBACK when the API failed — every page
+    transition still showed a "Loading…" placeholder for 200-2000ms
+    until /api/v1/hub/public/menu responded. v2.39.0:
+      - NEW saveCachedSidebarHTML / loadCachedSidebarHTML helpers
+        (localStorage key `sbx_sidebar_html_v1`, same 1h TTL as the
+        existing menu cache).
+      - loadSidebar() now paints the cached HTML instantly at the
+        top of the function (before the await), then the existing
+        API fetch overwrites with fresh content + live LEDs.
+      - At the end of every successful render, the fully-rendered
+        sidebar.innerHTML is persisted for the next page load.
+    Net effect: instant skeleton on every internal navigation, no
+    perceived delay. First-ever visit still hits the "Loading…"
+    placeholder (cache empty).
+
+ -- Gerald Kerma <devel@cybermind.fr>  Sat, 23 May 2026 15:45:00 +0000
+
 secubox-hub (1.4.1-1~bookworm1) bookworm; urgency=medium
 
   * www/shared/hybrid-skin.css: drop the "gradient text" trick

--- a/packages/secubox-hub/www/shared/sidebar.js
+++ b/packages/secubox-hub/www/shared/sidebar.js
@@ -23,7 +23,7 @@
 (function() {
     const MENU_API = '/api/v1/hub/public/menu';
     const BATCH_HEALTH_API = '/api/v1/hub/public/health-batch';
-    const VERSION = 'v2.38.0';
+    const VERSION = 'v2.39.0';
 
     // Resilience settings
     const HEARTBEAT_INTERVAL = 15000;  // 15s - check sidebar health
@@ -67,6 +67,38 @@
             }));
         } catch (e) {
             console.log('[Sidebar] Menu cache save error:', e);
+        }
+    }
+
+    // ── Sidebar HTML pre-cache (v2.39.0) ────────────────────────
+    // Previous versions saved the menu DATA in cache but only used
+    // it as a FALLBACK when the API failed. Operators still saw a
+    // "Loading…" placeholder for 200-2000ms on every page transition.
+    // v2.39.0 caches the fully rendered sidebar HTML and paints it
+    // immediately on load. The fresh API result then overwrites it
+    // (LEDs etc. update from the actual /health-batch call). Net:
+    // instant skeleton, no perceived delay.
+    const SIDEBAR_HTML_CACHE_KEY = 'sbx_sidebar_html_v1';
+    function saveCachedSidebarHTML(html) {
+        try {
+            localStorage.setItem(SIDEBAR_HTML_CACHE_KEY, JSON.stringify({
+                ts: Date.now(),
+                html: html,
+            }));
+        } catch (e) {
+            // Quota exceeded etc. — silent: cache is best-effort.
+        }
+    }
+    function loadCachedSidebarHTML() {
+        try {
+            var raw = localStorage.getItem(SIDEBAR_HTML_CACHE_KEY);
+            if (!raw || raw.charAt(0) !== '{') return null;
+            var data = JSON.parse(raw);
+            if (!data.ts || (Date.now() - data.ts) > MENU_CACHE_TTL) return null;
+            return data.html;
+        } catch (e) {
+            try { localStorage.removeItem(SIDEBAR_HTML_CACHE_KEY); } catch (_) {}
+            return null;
         }
     }
 
@@ -2240,14 +2272,24 @@
         injectStyles();
         hideUnknownEnabled = getHideUnknownPref();
 
-        sidebar.innerHTML = '<div class="sidebar-header"><a href="/"><span class="logo-icon">🔒</span><div><span class="logo">SECUBOX</span><span class="logo-version">🚀 ' + VERSION + '</span></div></a>' +
-            '<div class="header-leds-metrics" id="header-leds-metrics">' +
-            '<div class="led-metric-row sync-status" id="sync-status-row"><div class="sync-led" id="sync-led">⏳</div><span class="led-metric-val sync-val" id="lm-sync" title="Data sync status">--</span></div>' +
-            '<div class="led-metric-row" onmouseenter="SecuBoxSidebar.showHwLedTooltip(this,3)" onmouseleave="SecuBoxSidebar.hideHwLedTooltip()"><div class="hw-led-v" id="hw-led-3"></div><span class="led-metric-val" id="lm-sec">--</span></div>' +
-            '<div class="led-metric-row" onmouseenter="SecuBoxSidebar.showHwLedTooltip(this,2)" onmouseleave="SecuBoxSidebar.hideHwLedTooltip()"><div class="hw-led-v" id="hw-led-2"></div><span class="led-metric-val" id="lm-svc">--</span></div>' +
-            '<div class="led-metric-row" onmouseenter="SecuBoxSidebar.showHwLedTooltip(this,1)" onmouseleave="SecuBoxSidebar.hideHwLedTooltip()"><div class="hw-led-v" id="hw-led-1"></div><span class="led-metric-val" id="lm-hw">--</span></div>' +
-            '</div></div>' +
-            '<div class="sidebar-nav"><div class="nav-section"><div class="nav-section-title"><span>Loading...</span></div></div></div>';
+        // v2.39.0: paint the cached sidebar HTML instantly. The API
+        // fetch below overwrites it within ~200ms-2s with the fresh
+        // structure + live LED states. Operators stop seeing a
+        // "Loading…" flash on every page transition.
+        var cachedHTML = loadCachedSidebarHTML();
+        if (cachedHTML) {
+            sidebar.innerHTML = cachedHTML;
+            console.log('[Sidebar] Instant render from HTML cache');
+        } else {
+            sidebar.innerHTML = '<div class="sidebar-header"><a href="/"><span class="logo-icon">🔒</span><div><span class="logo">SECUBOX</span><span class="logo-version">🚀 ' + VERSION + '</span></div></a>' +
+                '<div class="header-leds-metrics" id="header-leds-metrics">' +
+                '<div class="led-metric-row sync-status" id="sync-status-row"><div class="sync-led" id="sync-led">⏳</div><span class="led-metric-val sync-val" id="lm-sync" title="Data sync status">--</span></div>' +
+                '<div class="led-metric-row" onmouseenter="SecuBoxSidebar.showHwLedTooltip(this,3)" onmouseleave="SecuBoxSidebar.hideHwLedTooltip()"><div class="hw-led-v" id="hw-led-3"></div><span class="led-metric-val" id="lm-sec">--</span></div>' +
+                '<div class="led-metric-row" onmouseenter="SecuBoxSidebar.showHwLedTooltip(this,2)" onmouseleave="SecuBoxSidebar.hideHwLedTooltip()"><div class="hw-led-v" id="hw-led-2"></div><span class="led-metric-val" id="lm-svc">--</span></div>' +
+                '<div class="led-metric-row" onmouseenter="SecuBoxSidebar.showHwLedTooltip(this,1)" onmouseleave="SecuBoxSidebar.hideHwLedTooltip()"><div class="hw-led-v" id="hw-led-1"></div><span class="led-metric-val" id="lm-hw">--</span></div>' +
+                '</div></div>' +
+                '<div class="sidebar-nav"><div class="nav-section"><div class="nav-section-title"><span>Loading...</span></div></div></div>';
+        }
 
         try {
             var token = localStorage.getItem('sbx_token');
@@ -2355,6 +2397,11 @@
                 '<div class="sidebar-clock" id="sidebar-clock">00:00:00</div>' +
                 '<div class="sidebar-user"><span class="sidebar-user-avatar">👤</span><div class="sidebar-user-info"><div class="sidebar-user-name">' + user + '</div><div class="sidebar-user-role">OPERATOR</div></div><button class="sidebar-logout" onclick="localStorage.removeItem(\'sbx_token\');window.location.href=\'/login.html\';">EXIT</button></div>' +
                 '</div>';
+
+            // v2.39.0: persist this fully-rendered HTML so the next
+            // page transition can paint it instantly (see
+            // loadCachedSidebarHTML() at the top of loadSidebar).
+            saveCachedSidebarHTML(sidebar.innerHTML);
 
             var clock = document.getElementById('sidebar-clock');
             if (clock) startClock(clock);


### PR DESCRIPTION
Previous sidebar.js cached menu DATA but used it only as fallback when API failed. Every page transition showed Loading... for 200-2000ms.

v2.39.0: localStorage `sbx_sidebar_html_v1` holds the fully-rendered sidebar.innerHTML. loadSidebar() paints it instantly at the top, then the existing API fetch overwrites with fresh content + live LEDs. End of each fresh render persists the new HTML for the next load. 1h TTL. Best-effort (silent on quota errors).

Live-deployed on gk2 (1.4.1 → 1.4.2).