### PR TITLE
fix(zigbee): v2.5.8 — /access returns url field + public SSO URL

### DIFF
--- a/packages/secubox-zigbee/api/main.py
+++ b/packages/secubox-zigbee/api/main.py
@@ -35,11 +35,15 @@ FRONTEND_PORT = int(os.environ.get("SECUBOX_Z2M_FRONTEND_PORT", "8080"))
 MQTT_LXC_IP = os.environ.get("SECUBOX_MQTT_LXC_IP", "10.100.0.110")
 MQTT_PORT = int(os.environ.get("SECUBOX_MQTT_PORT", "1883"))
 SECRETS_DIR = Path(os.environ.get("SECUBOX_SECRETS_DIR", "/etc/secubox/secrets"))
+# v2.5.8: the public SSO-gated vhost that nginx + Authelia front for
+# the zigbee2mqtt UI. Operators reach it from outside the LAN; the
+# /access list now includes it explicitly.
+PUBLIC_URL = os.environ.get("SECUBOX_ZIGBEE_PUBLIC_URL", "https://zigbee.gk2.secubox.in/")
 
 app = FastAPI(
     title="SecuBox Zigbee",
     description="zigbee2mqtt coordinator control plane (MIND layer)",
-    version="2.4.0",
+    version="2.5.8",
 )
 
 
@@ -141,13 +145,20 @@ def status() -> dict:
 
 @app.get("/access")
 def access() -> dict:
+    # v2.5.8: field renamed `endpoint` → `url` so the frontend's
+    # `a.url` access actually finds a value (previously "lan:
+    # undefined" rendered because the JS lookup missed). Public SSO-
+    # gated vhost added as the first entry — that's the one operators
+    # use from outside the LAN.
     return {
         "module": "zigbee",
         "access": [
-            {"endpoint": f"http://{LXC_IP}:{FRONTEND_PORT}/",
+            {"url": PUBLIC_URL,
+             "scope": "public", "auth": "Authelia SSO"},
+            {"url": f"http://{LXC_IP}:{FRONTEND_PORT}/",
              "scope": "lan", "auth": "none (LAN-only)"},
-            {"endpoint": f"mqtt://{MQTT_LXC_IP}:{MQTT_PORT} (zigbee2mqtt/#)",
-             "scope": "lan", "auth": "z2m user"},
+            {"url": f"mqtt://{MQTT_LXC_IP}:{MQTT_PORT} (zigbee2mqtt/#)",
+             "scope": "lan-mqtt", "auth": "z2m user"},
         ],
     }
 

--- a/packages/secubox-zigbee/debian/changelog
+++ b/packages/secubox-zigbee/debian/changelog
@@ -1,3 +1,19 @@
+secubox-zigbee (2.5.8-1~bookworm1) bookworm; urgency=medium
+
+  * api/main.py: /access endpoint fixes the "lan: undefined" bug
+    AND adds the public SSO-gated vhost. The frontend reads `a.url`
+    but the backend returned `endpoint`, so every entry rendered
+    as "lan: undefined". Field renamed `endpoint` → `url`. Also
+    NEW first entry pointing at SECUBOX_ZIGBEE_PUBLIC_URL (default
+    https://zigbee.gk2.secubox.in/) with scope=`public`,
+    auth=`Authelia SSO`. The LAN web entry now scope=`lan`, the
+    MQTT bus entry scope=`lan-mqtt` so the UI shows distinct
+    labels instead of two identical "lan:" lines.
+  * Version bump 2.4.0 → 2.5.8 in FastAPI app title (was lagging
+    behind the package changelog since v2.4).
+
+ -- Gerald Kerma <devel@cybermind.fr>  Sat, 23 May 2026 16:15:00 +0000
+
 secubox-zigbee (2.5.7-1~bookworm1) bookworm; urgency=medium
 
   * lib/zigbee/install-lxc.sh: udev RUN+= now invokes


### PR DESCRIPTION
Two bugs in the zigbee /access endpoint were rendering the Access card as 'lan: undefined / lan: undefined' on the dashboard:

1. Backend returned `endpoint` but frontend reads `a.url` — every entry got undefined.
2. Public SSO-gated vhost (`https://zigbee.gk2.secubox.in/`) wasn't in the access list at all.

Fix: rename endpoint→url, add the public entry as first item (scope=public, auth=Authelia SSO), distinguish LAN web (scope=lan) from MQTT bus (scope=lan-mqtt). App version bump 2.4.0 → 2.5.8.

Live on gk2 (2.5.7 → 2.5.8).