### PR TITLE
fix(core): v1.1.5 — lxc.service waits for /data before autostart (LXCs not starting at boot)

### DIFF
--- a/packages/secubox-core/debian/changelog
+++ b/packages/secubox-core/debian/changelog
@@ -1,3 +1,21 @@
+secubox-core (1.1.5-1~bookworm1) bookworm; urgency=medium
+
+  * systemd/lxc.service.d/wait-for-data.conf: NEW drop-in adds
+    `RequiresMountsFor=/data` to lxc.service. The stock unit's
+    `After=remote-fs.target` doesn't cover local ext4 mounts like
+    /data; lxc.service ran ~2s into boot, lxc-autostart enumerated
+    /data/lxc/ before the mount happened, found nothing, exited 0
+    — every LXC with lxc.start.auto stayed STOPPED. Authelia
+    being one of them meant every /__sbx_auth_verify auth_request
+    returned 503 and every SecuBox vhost (zigbee, etc.) bounced
+    back with HTTP 500 instead of the SSO 302.
+    Reproduced on gk2 boot of 2026-05-22 16:38; 12 LXCs
+    (gitea, grafana, horde, lyrion, mail, matrix, nextcloud,
+    roundcube, rustdesk, streamlit, yacy, zigbee) all confirmed
+    sound — manual lxc-start works, autostart didn't fire.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Sat, 23 May 2026 16:30:00 +0000
+
 secubox-core (1.1.4-1~bookworm1) bookworm; urgency=medium
 
   * systemd/secubox-runtime.service: stop fighting tmpfiles.d. The old

--- a/packages/secubox-core/debian/rules
+++ b/packages/secubox-core/debian/rules
@@ -42,6 +42,14 @@ override_dh_auto_install:
 	install -d debian/secubox-core/etc/systemd/system/nftables.service.d
 	install -m 644 systemd/nftables.service.d/override.conf \
 	               debian/secubox-core/etc/systemd/system/nftables.service.d/override.conf
+	# lxc.service drop-in: wait for /data before LXC autostart. Without
+	# this, lxc-autostart ran in 2s at boot and found nothing because
+	# the /data ext4 mount hadn't happened yet — 12+ LXCs stayed STOPPED
+	# despite lxc.start.auto = 1. RequiresMountsFor=/data lets systemd
+	# resolve the right mount unit and order lxc.service after it.
+	install -d debian/secubox-core/etc/systemd/system/lxc.service.d
+	install -m 644 systemd/lxc.service.d/wait-for-data.conf \
+	               debian/secubox-core/etc/systemd/system/lxc.service.d/wait-for-data.conf
 	# Create modular nginx directory (modules install their snippets here)
 	install -d debian/secubox-core/etc/nginx/secubox.d
 

--- a/packages/secubox-core/systemd/lxc.service.d/wait-for-data.conf
+++ b/packages/secubox-core/systemd/lxc.service.d/wait-for-data.conf
@@ -1,0 +1,32 @@
+# /etc/systemd/system/lxc.service.d/wait-for-data.conf — installed by
+# secubox-core.
+#
+# Symptom: on a fresh boot, lxc.service (the LXC autostart driver) ran
+# in ~2s and exited 0, but no LXCs were actually started. Manual
+# `lxc-start -n NAME` immediately afterwards worked fine for every
+# container.
+#
+# Root cause: the secubox stack stores LXC containers under /data/lxc/
+# (see lxc.lxcpath in /etc/lxc/lxc.conf). The stock lxc.service has
+# `After=remote-fs.target` but NOT `After=data.mount`, and /data is a
+# LOCAL ext4 mount (UUID-based, not NFS). At boot, lxc.service started
+# BEFORE /data was mounted; lxc-autostart enumerated /data/lxc/, found
+# nothing (because the mount wasn't there yet), and exited cleanly with
+# no work to do.
+#
+# Fix: RequiresMountsFor=/data — systemd auto-resolves to the right
+# mount unit (data.mount) and waits for it before starting lxc.service.
+# A subsequent boot now correctly autostarts every LXC with
+# `lxc.start.auto = 1` in its config.
+#
+# Affected the entire SOC stack: when authelia (10.100.0.20) didn't
+# start, every other secubox vhost gated by /__sbx_auth_verify returned
+# 500 because the auth_request target itself hit a 503.
+#
+# Companion: this drop-in does nothing on appliances that don't have
+# /data (e.g. dev VMs running everything off /). systemd silently
+# treats RequiresMountsFor as a no-op when the path isn't a separate
+# mount.
+
+[Unit]
+RequiresMountsFor=/data


### PR DESCRIPTION
Stock lxc.service had `After=remote-fs.target` but no dependency on the local `/data` ext4 mount. At boot lxc-autostart ran 2s in, enumerated /data/lxc/ before mount completed, found nothing, exited 0. Every LXC with `lxc.start.auto=1` stayed STOPPED.

Authelia being one of them broke every SSO-gated vhost: auth_request hit `/run/secubox/authelia.sock` → 503 because the LXC was down → nginx returned HTTP 500 on https://zigbee.gk2.secubox.in/ etc.

Fix: drop-in adds `RequiresMountsFor=/data`. Live-validated on gk2 (1.1.4 → 1.1.5).