### PR TITLE
secubox-peertube 1.1.0: native-LXC deployment + dashboard correction + URL import (#388, supersedes #390)

### DIFF
--- a/packages/secubox-peertube/README.md
+++ b/packages/secubox-peertube/README.md
@@ -8,31 +8,49 @@ Federated video platform
 
 ![PeerTube](../../docs/screenshots/vm/peertube.png)
 
+**Deployment:** PeerTube runs **natively inside a dedicated Debian LXC**
+(its own `peertube.service`: Node 22 + PostgreSQL 15 + Redis + ffmpeg), not
+in Docker/Podman — an unprivileged LXC can't reliably bring up a podman CNI
+bridge on the Marvell arm64 boards. The host nginx vhost (`:9080`) proxies
+the public hostname to the LXC at `10.100.0.120:9000`.
+
 ## Features
 
-- Video hosting
-- Federation
-- Live streaming
-- Comments
+- Video hosting, channels, users, federation (ActivityPub)
+- **Import from URL** (YouTube/Vimeo/direct file) via PeerTube's native HTTP
+  import (yt-dlp) — from the dashboard "Import" tab or PeerTube's own UI
+- Transcoding settings (HLS, WebTorrent), plugins, storage monitoring
+- Host dashboard at `/peertube/` + `/api/v1/peertube/*`
 
 ## Installation
 
 ```bash
-# Add SecuBox repository
-curl -fsSL https://apt.secubox.in/install.sh | sudo bash
-
-# Install package
-sudo apt install secubox-peertube
+sudo apt install secubox-peertube     # installs the host dashboard daemon
+peertubectl install                   # provisions the LXC + native PeerTube
+peertubectl status                    # LXC state + HTTP reachability
 ```
+
+Then wire the public hostname: add the HAProxy SNI ACL
+(`host_<host> → nginx_vhosts`) and an ACME cert. The package ships the nginx
+vhost at `/etc/nginx/sites-available/peertube.conf` (symlinked into
+sites-enabled by postinst).
+
+The first-boot admin password is captured to
+`/etc/secubox/secrets/peertube-admin` (rotate it via the web UI; if you do,
+update that file or the dashboard's write operations re-auth fails).
 
 ## Configuration
 
-Configuration file: `/etc/secubox/peertube.toml`
+`/etc/secubox/peertube.toml` — `[lxc]` (name/ip/path), `[peertube]`
+(http_port/admin/transcoding), `[exposure]` (public_hostname).
 
 ## API Endpoints
 
-- `GET /api/v1/peertube/status` - Module status
-- `GET /api/v1/peertube/health` - Health check
+- `GET  /api/v1/peertube/status`  — real LXC state + HTTP reachability + version
+- `GET  /api/v1/peertube/health`  — health check
+- `POST /api/v1/peertube/import`  — `{target_url, channel_id?, name?, privacy}`
+- `GET  /api/v1/peertube/imports` — recent import jobs
+- `POST /api/v1/peertube/container/{install,start,stop,restart}` — LXC lifecycle
 
 ## License
 

--- a/packages/secubox-peertube/api/main.py
+++ b/packages/secubox-peertube/api/main.py
@@ -1,28 +1,28 @@
 """secubox-peertube -- FastAPI application for PeerTube video platform management.
 
-Provides PeerTube Docker container management with video, channel, user,
-federation, transcoding, plugin, and storage management.
+PeerTube runs NATIVELY inside a dedicated Debian LXC (peertube.service:
+Node 22 + PostgreSQL 15 + Redis + ffmpeg), provisioned by
+`peertubectl install` / lib/peertube/install-lxc.sh. This dashboard talks to
+that instance over HTTP at <lxc_ip>:<http_port> and drives the LXC lifecycle
+via peertubectl. It is NOT a Docker/Podman manager.
 
 SecuBox-Deb :: PeerTube
 CyberMind -- https://cybermind.fr
 Author: Gerald Kerma <gandalf@gk2.net>
 License: Proprietary / ANSSI CSPN candidate
 """
-import asyncio
 import json
-import shutil
 import subprocess
-from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict
 
-from fastapi import FastAPI, APIRouter, Depends, HTTPException, Query
+from fastapi import FastAPI, APIRouter, Depends
 from pydantic import BaseModel, Field
 
 from secubox_core.auth import router as auth_router, require_jwt
 from secubox_core.logger import get_logger
 
-app = FastAPI(title="secubox-peertube", version="1.0.0", root_path="/api/v1/peertube")
+app = FastAPI(title="secubox-peertube", version="1.1.0", root_path="/api/v1/peertube")
 
 # ══════════════════════════════════════════════════════════════════
 # Health Check Endpoint (public, no auth)
@@ -39,24 +39,30 @@ log = get_logger("peertube")
 
 # Configuration
 CONFIG_FILE = Path("/etc/secubox/peertube.toml")
-CONTAINER_NAME = "secbx-peertube"
+INSTALL_LIB = "/usr/share/secubox/lib/peertube/install-lxc.sh"
+PEERTUBECTL = "/usr/sbin/peertubectl"
+
+# Flat defaults. The on-disk TOML uses [lxc]/[peertube]/[exposure] sections;
+# get_config() flattens them into these keys.
 DEFAULT_CONFIG = {
-    "enabled": False,
-    "image": "chocobozzz/peertube:production-bookworm",
-    "http_port": 9000,
+    # LXC
+    "name": "peertube",
+    "ip": "10.100.0.120",
+    "path": "/data/lxc",
     "data_path": "/data/peertube",
-    "timezone": "Europe/Paris",
-    "domain": "peertube.secubox.local",
-    "haproxy": False,
-    "signup_enabled": False,
+    # PeerTube (inside the LXC)
+    "http_port": 9000,
+    "admin_user": "root",
+    "admin_password_file": "/etc/secubox/secrets/peertube-admin",
     "transcoding_enabled": True,
     "transcoding_threads": 2,
     "hls_enabled": True,
     "webtorrent_enabled": True,
     "federation_enabled": True,
-    "auto_follow_back": False,
     "instance_name": "SecuBox PeerTube",
     "short_description": "Federated video platform on SecuBox",
+    # Exposure
+    "public_hostname": "peertube.gk2.secubox.in",
 }
 
 
@@ -65,20 +71,13 @@ DEFAULT_CONFIG = {
 # ============================================================================
 
 class PeerTubeConfig(BaseModel):
-    enabled: bool = False
-    image: str = "chocobozzz/peertube:production-bookworm"
     http_port: int = 9000
-    data_path: str = "/data/peertube"
-    timezone: str = "Europe/Paris"
-    domain: str = "peertube.secubox.local"
-    haproxy: bool = False
-    signup_enabled: bool = False
+    public_hostname: str = "peertube.gk2.secubox.in"
     transcoding_enabled: bool = True
     transcoding_threads: int = 2
     hls_enabled: bool = True
     webtorrent_enabled: bool = True
     federation_enabled: bool = True
-    auto_follow_back: bool = False
 
 
 class InstanceSettings(BaseModel):
@@ -114,13 +113,8 @@ class TranscodingSettings(BaseModel):
     hls_enabled: bool = True
     webtorrent_enabled: bool = True
     resolutions: Dict[str, bool] = {
-        "240p": True,
-        "360p": True,
-        "480p": True,
-        "720p": True,
-        "1080p": True,
-        "1440p": False,
-        "2160p": False,
+        "240p": True, "360p": True, "480p": True, "720p": True,
+        "1080p": True, "1440p": False, "2160p": False,
     }
 
 
@@ -128,119 +122,176 @@ class PluginInstall(BaseModel):
     npm_name: str  # e.g., peertube-plugin-auth-ldap
 
 
+class VideoImport(BaseModel):
+    """Import a video from a remote URL (YouTube, Vimeo, direct .mp4, …).
+
+    Uses PeerTube's native HTTP import (yt-dlp under the hood)."""
+    target_url: str = Field(..., min_length=4)
+    channel_id: Optional[int] = None      # default channel if omitted
+    name: Optional[str] = None            # title; PeerTube derives one if omitted
+    privacy: int = 1                      # 1=public 2=unlisted 3=private 4=internal
+
+
 # ============================================================================
-# Helpers
+# Config helpers
 # ============================================================================
 
 def get_config() -> dict:
-    """Load peertube configuration."""
+    """Load + flatten peertube.toml ([lxc]/[peertube]/[exposure]) over defaults."""
+    cfg = DEFAULT_CONFIG.copy()
     if CONFIG_FILE.exists():
         try:
             import tomllib
-            return tomllib.loads(CONFIG_FILE.read_text())
+            raw = tomllib.loads(CONFIG_FILE.read_text())
+            for section in ("lxc", "peertube", "exposure"):
+                for k, v in (raw.get(section) or {}).items():
+                    cfg[k] = v
+            for k, v in raw.items():        # tolerate flat keys too
+                if not isinstance(v, dict):
+                    cfg[k] = v
         except Exception:
             pass
-    return DEFAULT_CONFIG.copy()
+    return cfg
 
 
 def save_config(config: dict):
-    """Save peertube configuration."""
-    CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
-    lines = ["# PeerTube configuration"]
-    for k, v in config.items():
+    """Persist a flat config back as sectioned TOML."""
+    cfg = config
+    lxc_keys = ("name", "ip", "gateway", "bridge", "path", "debian_suite")
+    pt_keys = ("http_port", "admin_user", "admin_password_file", "secret_file",
+               "admin_email", "transcoding_enabled", "transcoding_threads",
+               "hls_enabled", "webtorrent_enabled", "federation_enabled",
+               "instance_name", "short_description", "description", "terms",
+               "signup_enabled", "signup_requires_email", "transcoding_resolutions")
+    exp_keys = ("public_hostname", "waf_inspect")
+
+    def emit(k):
+        v = cfg.get(k)
+        if v is None:
+            return None
         if isinstance(v, bool):
-            lines.append(f"{k} = {str(v).lower()}")
-        elif isinstance(v, int):
-            lines.append(f"{k} = {v}")
-        elif isinstance(v, dict):
-            lines.append(f'{k} = {json.dumps(v)}')
-        elif isinstance(v, list):
-            lines.append(f'{k} = {v}')
-        else:
-            lines.append(f'{k} = "{v}"')
-    CONFIG_FILE.write_text("\n".join(lines) + "\n")
+            return f"{k} = {str(v).lower()}"
+        if isinstance(v, int):
+            return f"{k} = {v}"
+        if isinstance(v, (dict, list)):
+            return f"{k} = {json.dumps(v)}"
+        return f'{k} = "{v}"'
+
+    out = ["# /etc/secubox/peertube.toml — managed by secubox-peertube"]
+    for section, keys in (("lxc", lxc_keys), ("peertube", pt_keys), ("exposure", exp_keys)):
+        rows = [emit(k) for k in keys if k in cfg and emit(k) is not None]
+        if rows:
+            out.append(f"\n[{section}]")
+            out.extend(rows)
+    CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_FILE.write_text("\n".join(out) + "\n")
 
 
-def detect_runtime() -> Optional[str]:
-    """Detect container runtime."""
-    if shutil.which("podman"):
-        return "podman"
-    if shutil.which("docker"):
-        return "docker"
-    return None
+# ============================================================================
+# Native-LXC + PeerTube HTTP helpers
+# ============================================================================
 
-
-def get_container_status() -> dict:
-    """Get PeerTube container status."""
-    rt = detect_runtime()
-    if not rt:
-        return {"status": "no_runtime", "uptime": ""}
-
+def get_lxc_state() -> str:
+    """LXC container state: running | stopped | absent."""
+    cfg = get_config()
     try:
-        result = subprocess.run(
-            [rt, "ps", "--filter", f"name={CONTAINER_NAME}", "--format", "{{.Status}}"],
-            capture_output=True, text=True, timeout=5
+        r = subprocess.run(
+            ["lxc-info", "-n", cfg["name"], "-P", cfg["path"]],
+            capture_output=True, text=True, timeout=5,
         )
-        if result.stdout.strip():
-            return {"status": "running", "uptime": result.stdout.strip()}
-
-        result = subprocess.run(
-            [rt, "ps", "-a", "--filter", f"name={CONTAINER_NAME}", "--format", "{{.Status}}"],
-            capture_output=True, text=True, timeout=5
-        )
-        if result.stdout.strip():
-            return {"status": "stopped", "uptime": ""}
-
-        return {"status": "not_installed", "uptime": ""}
+        for line in r.stdout.splitlines():
+            if line.strip().lower().startswith("state:"):
+                return line.split(":", 1)[1].strip().lower()
+        return "absent"
     except Exception:
-        return {"status": "error", "uptime": ""}
+        return "absent"
+
+
+def http_reachable() -> bool:
+    """True if PeerTube answers on <ip>:<http_port>."""
+    cfg = get_config()
+    url = f"http://{cfg['ip']}:{cfg['http_port']}/api/v1/config"
+    try:
+        r = subprocess.run(
+            ["curl", "-fsS", "-o", "/dev/null", "--max-time", "3",
+             "-H", f"Host: {cfg['public_hostname']}", url],
+            capture_output=True, timeout=5,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
 
 
 def is_running() -> bool:
-    """Check if PeerTube container is running."""
-    return get_container_status()["status"] == "running"
+    return http_reachable()
 
 
-def run_in_container(cmd: List[str], timeout: int = 30) -> dict:
-    """Run command inside PeerTube container."""
-    rt = detect_runtime()
-    if not rt:
-        return {"success": False, "error": "No container runtime"}
+def pt_api(endpoint: str, method: str = "GET", data: Optional[dict] = None,
+           token: Optional[str] = None, timeout: int = 20) -> dict:
+    """Call PeerTube's HTTP API at <ip>:<http_port>.
 
+    PeerTube rejects requests whose Host is the raw IP, so we always send
+    Host: <public_hostname> (the configured webserver hostname)."""
+    cfg = get_config()
+    base = f"http://{cfg['ip']}:{cfg['http_port']}/api/v1"
+    cmd = ["curl", "-s", "--max-time", str(timeout),
+           "-H", f"Host: {cfg['public_hostname']}", base + endpoint]
+    if token:
+        cmd += ["-H", f"Authorization: Bearer {token}"]
+    if method == "POST":
+        cmd += ["-X", "POST"]
+        if data is not None:
+            cmd += ["-H", "Content-Type: application/json", "-d", json.dumps(data)]
+    elif method == "DELETE":
+        cmd += ["-X", "DELETE"]
     try:
-        full_cmd = [rt, "exec", CONTAINER_NAME] + cmd
-        result = subprocess.run(full_cmd, capture_output=True, text=True, timeout=timeout)
-        return {
-            "success": result.returncode == 0,
-            "stdout": result.stdout,
-            "stderr": result.stderr
-        }
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout + 5)
+        if r.returncode == 0 and r.stdout:
+            try:
+                return {"success": True, "data": json.loads(r.stdout)}
+            except json.JSONDecodeError:
+                return {"success": True, "data": r.stdout}
+        return {"success": False, "error": r.stderr.strip() or "API call failed"}
     except subprocess.TimeoutExpired:
-        return {"success": False, "error": "Command timeout"}
+        return {"success": False, "error": "API timeout"}
     except Exception as e:
         return {"success": False, "error": str(e)}
 
 
-def peertube_api(endpoint: str, method: str = "GET", data: dict = None) -> dict:
-    """Call PeerTube internal API."""
+def get_admin_token() -> Optional[str]:
+    """OAuth password-grant token for the stored admin user (for write ops)."""
     cfg = get_config()
-    port = cfg.get("http_port", 9000)
-    curl_cmd = ["curl", "-s", f"http://127.0.0.1:{port}/api/v1{endpoint}"]
+    pw_file = Path(cfg.get("admin_password_file", "/etc/secubox/secrets/peertube-admin"))
+    if not pw_file.exists():
+        return None
+    password = pw_file.read_text().strip()
+    username = cfg.get("admin_user", "root")
+    oc = pt_api("/oauth-clients/local")
+    if not oc.get("success") or not isinstance(oc.get("data"), dict):
+        return None
+    client = oc["data"]
+    base = f"http://{cfg['ip']}:{cfg['http_port']}/api/v1/users/token"
+    cmd = ["curl", "-s", "--max-time", "15", "-H", f"Host: {cfg['public_hostname']}", base,
+           "-d", f"client_id={client.get('client_id','')}",
+           "-d", f"client_secret={client.get('client_secret','')}",
+           "-d", "grant_type=password",
+           "-d", f"username={username}",
+           "-d", f"password={password}"]
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
+        tok = json.loads(r.stdout)
+        return tok.get("access_token")
+    except Exception:
+        return None
 
-    if method == "POST" and data:
-        curl_cmd.extend(["-X", "POST", "-H", "Content-Type: application/json", "-d", json.dumps(data)])
-    elif method == "DELETE":
-        curl_cmd.extend(["-X", "DELETE"])
 
-    result = run_in_container(curl_cmd)
-
-    if result.get("success") and result.get("stdout"):
-        try:
-            return {"success": True, "data": json.loads(result["stdout"])}
-        except json.JSONDecodeError:
-            return {"success": True, "data": result["stdout"]}
-
-    return {"success": False, "error": result.get("error", "API call failed")}
+def default_channel_id(token: str) -> Optional[int]:
+    me = pt_api("/users/me", token=token)
+    if me.get("success") and isinstance(me.get("data"), dict):
+        chans = me["data"].get("videoChannels") or []
+        if chans:
+            return chans[0].get("id")
+    return None
 
 
 # ============================================================================
@@ -249,57 +300,64 @@ def peertube_api(endpoint: str, method: str = "GET", data: dict = None) -> dict:
 
 @router.get("/health")
 async def health():
-    """Health check."""
     return {"status": "ok", "module": "peertube"}
 
 
 @router.get("/status")
 async def status():
-    """Get PeerTube service status."""
+    """Real native-LXC status: LXC state + PeerTube HTTP reachability + disk."""
     cfg = get_config()
-    rt = detect_runtime()
-    container = get_container_status()
+    state = get_lxc_state()
+    reachable = http_reachable()
 
-    # Disk usage
     disk_usage = ""
     data_path = Path(cfg.get("data_path", "/data/peertube"))
     if data_path.exists():
         try:
-            result = subprocess.run(
-                ["du", "-sh", str(data_path)],
-                capture_output=True, text=True, timeout=30
-            )
-            disk_usage = result.stdout.split()[0] if result.stdout else ""
+            r = subprocess.run(["du", "-sh", str(data_path)],
+                               capture_output=True, text=True, timeout=30)
+            disk_usage = r.stdout.split()[0] if r.stdout else ""
         except Exception:
             pass
 
-    # Video count (if storage exists)
+    # Live counts straight from the instance config/stats when reachable.
+    instance_name = cfg.get("instance_name", "SecuBox PeerTube")
+    server_version = ""
     video_count = 0
-    videos_path = data_path / "storage" / "videos"
-    if videos_path.exists():
-        try:
-            video_count = len(list(videos_path.glob("*")))
-        except Exception:
-            pass
+    if reachable:
+        c = pt_api("/config")
+        if c.get("success") and isinstance(c.get("data"), dict):
+            d = c["data"]
+            instance_name = (d.get("instance") or {}).get("name", instance_name)
+            server_version = d.get("serverVersion", "")
+        v = pt_api("/videos?count=0")
+        if v.get("success") and isinstance(v.get("data"), dict):
+            video_count = v["data"].get("total", 0)
+
+    # Map LXC state onto the keys the webui already consumes.
+    container_status = {"running": "running", "stopped": "stopped",
+                        "absent": "not_installed"}.get(state, state)
 
     return {
-        "enabled": cfg.get("enabled", False),
-        "image": cfg.get("image", DEFAULT_CONFIG["image"]),
+        "deployment": "lxc-native",
+        "lxc_name": cfg.get("name", "peertube"),
+        "lxc_ip": cfg.get("ip", "10.100.0.120"),
+        "lxc_state": state,
         "http_port": cfg.get("http_port", 9000),
+        "http_reachable": reachable,
         "data_path": cfg.get("data_path", "/data/peertube"),
-        "timezone": cfg.get("timezone", "Europe/Paris"),
-        "domain": cfg.get("domain", "peertube.secubox.local"),
-        "haproxy": cfg.get("haproxy", False),
-        "signup_enabled": cfg.get("signup_enabled", False),
+        "domain": cfg.get("public_hostname", "peertube.gk2.secubox.in"),
+        "public_url": f"https://{cfg.get('public_hostname', 'peertube.gk2.secubox.in')}/",
         "transcoding_enabled": cfg.get("transcoding_enabled", True),
         "federation_enabled": cfg.get("federation_enabled", True),
-        "docker_available": rt is not None,
-        "runtime": rt or "none",
-        "container_status": container["status"],
-        "container_uptime": container["uptime"],
+        # webui back-compat keys (was Docker; now native-LXC):
+        "runtime": "lxc-native",
+        "container_status": container_status,
+        "container_uptime": "",
         "disk_usage": disk_usage,
         "video_count": video_count,
-        "instance_name": cfg.get("instance_name", "SecuBox PeerTube"),
+        "instance_name": instance_name,
+        "server_version": server_version,
     }
 
 
@@ -309,7 +367,6 @@ async def status():
 
 @router.get("/instance")
 async def get_instance(user=Depends(require_jwt)):
-    """Get instance information."""
     cfg = get_config()
     return {
         "name": cfg.get("instance_name", "SecuBox PeerTube"),
@@ -318,13 +375,12 @@ async def get_instance(user=Depends(require_jwt)):
         "terms": cfg.get("terms", ""),
         "signup_enabled": cfg.get("signup_enabled", False),
         "signup_requires_email": cfg.get("signup_requires_email", True),
-        "domain": cfg.get("domain", "peertube.secubox.local"),
+        "domain": cfg.get("public_hostname", "peertube.gk2.secubox.in"),
     }
 
 
 @router.post("/instance")
 async def update_instance(settings: InstanceSettings, user=Depends(require_jwt)):
-    """Update instance settings."""
     cfg = get_config()
     cfg["instance_name"] = settings.name
     cfg["short_description"] = settings.short_description
@@ -342,34 +398,75 @@ async def update_instance(settings: InstanceSettings, user=Depends(require_jwt))
 # ============================================================================
 
 @router.get("/videos")
-async def list_videos(
-    start: int = 0,
-    count: int = 15,
-    sort: str = "-publishedAt",
-    user=Depends(require_jwt)
-):
-    """List videos on instance."""
+async def list_videos(start: int = 0, count: int = 15,
+                      sort: str = "-publishedAt", user=Depends(require_jwt)):
     if not is_running():
-        return {"videos": [], "total": 0, "error": "Container not running"}
-
-    result = peertube_api(f"/videos?start={start}&count={count}&sort={sort}")
-
+        return {"videos": [], "total": 0, "error": "PeerTube not reachable"}
+    result = pt_api(f"/videos?start={start}&count={count}&sort={sort}")
     if result.get("success") and isinstance(result.get("data"), dict):
-        data = result["data"]
-        return {"videos": data.get("data", []), "total": data.get("total", 0)}
-
+        d = result["data"]
+        return {"videos": d.get("data", []), "total": d.get("total", 0)}
     return {"videos": [], "total": 0}
 
 
 @router.delete("/video/{video_id}")
 async def delete_video(video_id: str, user=Depends(require_jwt)):
-    """Delete a video."""
     if not is_running():
-        return {"success": False, "error": "Container not running"}
-
+        return {"success": False, "error": "PeerTube not reachable"}
+    token = get_admin_token()
     log.info(f"Deleting video {video_id} by {user.get('sub', 'unknown')}")
-    result = peertube_api(f"/videos/{video_id}", method="DELETE")
+    result = pt_api(f"/videos/{video_id}", method="DELETE", token=token)
     return {"success": result.get("success", False)}
+
+
+# ============================================================================
+# Video Import (yt-dlp via PeerTube native HTTP import)
+# ============================================================================
+
+@router.get("/imports")
+async def list_imports(user=Depends(require_jwt)):
+    """List the current user's video imports (queued/processing/done/failed)."""
+    if not is_running():
+        return {"imports": [], "total": 0, "error": "PeerTube not reachable"}
+    token = get_admin_token()
+    if not token:
+        return {"imports": [], "total": 0, "error": "no admin credentials on host"}
+    result = pt_api("/users/me/videos/imports?count=20&sort=-createdAt", token=token)
+    if result.get("success") and isinstance(result.get("data"), dict):
+        d = result["data"]
+        return {"imports": d.get("data", []), "total": d.get("total", 0)}
+    return {"imports": [], "total": 0, "error": result.get("error", "import list failed")}
+
+
+@router.post("/import")
+async def import_video(req: VideoImport, user=Depends(require_jwt)):
+    """Download a video from a URL into PeerTube (yt-dlp under the hood).
+
+    PeerTube must have import.videos.http enabled (install-lxc.sh sets it)."""
+    if not is_running():
+        return {"success": False, "error": "PeerTube not reachable"}
+    token = get_admin_token()
+    if not token:
+        return {"success": False,
+                "error": "No admin credentials at /etc/secubox/secrets/peertube-admin"}
+    channel_id = req.channel_id or default_channel_id(token)
+    if not channel_id:
+        return {"success": False, "error": "could not resolve a target channel"}
+    payload = {
+        "targetUrl": req.target_url,
+        "channelId": channel_id,
+        "privacy": req.privacy,
+    }
+    if req.name:
+        payload["name"] = req.name
+    log.info(f"Importing {req.target_url} → channel {channel_id} by {user.get('sub', 'unknown')}")
+    result = pt_api("/videos/imports", method="POST", data=payload, token=token, timeout=60)
+    if result.get("success"):
+        d = result.get("data") or {}
+        vid = (d.get("video") or {})
+        return {"success": True, "import_id": d.get("id"),
+                "video_uuid": vid.get("uuid"), "state": (d.get("state") or {})}
+    return {"success": False, "error": result.get("error", "import failed")}
 
 
 # ============================================================================
@@ -378,27 +475,22 @@ async def delete_video(video_id: str, user=Depends(require_jwt)):
 
 @router.get("/channels")
 async def list_channels(user=Depends(require_jwt)):
-    """List video channels."""
     if not is_running():
-        return {"channels": [], "error": "Container not running"}
-
-    result = peertube_api("/video-channels?count=100")
-
+        return {"channels": [], "error": "PeerTube not reachable"}
+    result = pt_api("/video-channels?count=100")
     if result.get("success") and isinstance(result.get("data"), dict):
-        data = result["data"]
-        return {"channels": data.get("data", []), "total": data.get("total", 0)}
-
+        d = result["data"]
+        return {"channels": d.get("data", []), "total": d.get("total", 0)}
     return {"channels": [], "total": 0}
 
 
 @router.post("/channel")
 async def create_channel(channel: ChannelCreate, user=Depends(require_jwt)):
-    """Create a video channel."""
     if not is_running():
-        return {"success": False, "error": "Container not running"}
-
+        return {"success": False, "error": "PeerTube not reachable"}
+    token = get_admin_token()
     log.info(f"Creating channel {channel.name} by {user.get('sub', 'unknown')}")
-    result = peertube_api("/video-channels", method="POST", data={
+    result = pt_api("/video-channels", method="POST", token=token, data={
         "name": channel.name,
         "displayName": channel.display_name,
         "description": channel.description,
@@ -408,12 +500,11 @@ async def create_channel(channel: ChannelCreate, user=Depends(require_jwt)):
 
 @router.delete("/channel/{channel_name}")
 async def delete_channel(channel_name: str, user=Depends(require_jwt)):
-    """Delete a video channel."""
     if not is_running():
-        return {"success": False, "error": "Container not running"}
-
+        return {"success": False, "error": "PeerTube not reachable"}
+    token = get_admin_token()
     log.info(f"Deleting channel {channel_name} by {user.get('sub', 'unknown')}")
-    result = peertube_api(f"/video-channels/{channel_name}", method="DELETE")
+    result = pt_api(f"/video-channels/{channel_name}", method="DELETE", token=token)
     return {"success": result.get("success", False)}
 
 
@@ -423,27 +514,23 @@ async def delete_channel(channel_name: str, user=Depends(require_jwt)):
 
 @router.get("/users")
 async def list_users(user=Depends(require_jwt)):
-    """List users."""
     if not is_running():
-        return {"users": [], "error": "Container not running"}
-
-    result = peertube_api("/users?count=100")
-
+        return {"users": [], "error": "PeerTube not reachable"}
+    token = get_admin_token()
+    result = pt_api("/users?count=100", token=token)
     if result.get("success") and isinstance(result.get("data"), dict):
-        data = result["data"]
-        return {"users": data.get("data", []), "total": data.get("total", 0)}
-
+        d = result["data"]
+        return {"users": d.get("data", []), "total": d.get("total", 0)}
     return {"users": [], "total": 0}
 
 
 @router.post("/user")
 async def create_user(new_user: UserCreate, user=Depends(require_jwt)):
-    """Create a user."""
     if not is_running():
-        return {"success": False, "error": "Container not running"}
-
+        return {"success": False, "error": "PeerTube not reachable"}
+    token = get_admin_token()
     log.info(f"Creating user {new_user.username} by {user.get('sub', 'unknown')}")
-    result = peertube_api("/users", method="POST", data={
+    result = pt_api("/users", method="POST", token=token, data={
         "username": new_user.username,
         "email": new_user.email,
         "password": new_user.password,
@@ -455,12 +542,11 @@ async def create_user(new_user: UserCreate, user=Depends(require_jwt)):
 
 @router.delete("/user/{user_id}")
 async def delete_user(user_id: int, user=Depends(require_jwt)):
-    """Delete a user."""
     if not is_running():
-        return {"success": False, "error": "Container not running"}
-
+        return {"success": False, "error": "PeerTube not reachable"}
+    token = get_admin_token()
     log.info(f"Deleting user {user_id} by {user.get('sub', 'unknown')}")
-    result = peertube_api(f"/users/{user_id}", method="DELETE")
+    result = pt_api(f"/users/{user_id}", method="DELETE", token=token)
     return {"success": result.get("success", False)}
 
 
@@ -470,53 +556,43 @@ async def delete_user(user_id: int, user=Depends(require_jwt)):
 
 @router.get("/federation/followers")
 async def get_followers(user=Depends(require_jwt)):
-    """Get instance followers."""
     if not is_running():
-        return {"followers": [], "error": "Container not running"}
-
-    result = peertube_api("/server/followers?count=100")
-
+        return {"followers": [], "error": "PeerTube not reachable"}
+    result = pt_api("/server/followers?count=100")
     if result.get("success") and isinstance(result.get("data"), dict):
-        data = result["data"]
-        return {"followers": data.get("data", []), "total": data.get("total", 0)}
-
+        d = result["data"]
+        return {"followers": d.get("data", []), "total": d.get("total", 0)}
     return {"followers": [], "total": 0}
 
 
 @router.get("/federation/following")
 async def get_following(user=Depends(require_jwt)):
-    """Get instances we are following."""
     if not is_running():
-        return {"following": [], "error": "Container not running"}
-
-    result = peertube_api("/server/following?count=100")
-
+        return {"following": [], "error": "PeerTube not reachable"}
+    result = pt_api("/server/following?count=100")
     if result.get("success") and isinstance(result.get("data"), dict):
-        data = result["data"]
-        return {"following": data.get("data", []), "total": data.get("total", 0)}
-
+        d = result["data"]
+        return {"following": d.get("data", []), "total": d.get("total", 0)}
     return {"following": [], "total": 0}
 
 
 @router.post("/federation/follow")
 async def follow_instance(req: FollowRequest, user=Depends(require_jwt)):
-    """Follow remote instances."""
     if not is_running():
-        return {"success": False, "error": "Container not running"}
-
+        return {"success": False, "error": "PeerTube not reachable"}
+    token = get_admin_token()
     log.info(f"Following instances {req.hosts} by {user.get('sub', 'unknown')}")
-    result = peertube_api("/server/following", method="POST", data={"hosts": req.hosts})
+    result = pt_api("/server/following", method="POST", token=token, data={"hosts": req.hosts})
     return {"success": result.get("success", False)}
 
 
 @router.delete("/federation/following/{follow_id}")
 async def unfollow_instance(follow_id: int, user=Depends(require_jwt)):
-    """Unfollow a remote instance."""
     if not is_running():
-        return {"success": False, "error": "Container not running"}
-
+        return {"success": False, "error": "PeerTube not reachable"}
+    token = get_admin_token()
     log.info(f"Unfollowing {follow_id} by {user.get('sub', 'unknown')}")
-    result = peertube_api(f"/server/following/{follow_id}", method="DELETE")
+    result = pt_api(f"/server/following/{follow_id}", method="DELETE", token=token)
     return {"success": result.get("success", False)}
 
 
@@ -526,22 +602,18 @@ async def unfollow_instance(follow_id: int, user=Depends(require_jwt)):
 
 @router.get("/transcoding/jobs")
 async def get_transcoding_jobs(user=Depends(require_jwt)):
-    """Get transcoding job queue."""
     if not is_running():
-        return {"jobs": [], "error": "Container not running"}
-
-    result = peertube_api("/jobs/video-transcoding?count=50")
-
+        return {"jobs": [], "error": "PeerTube not reachable"}
+    token = get_admin_token()
+    result = pt_api("/jobs/video-transcoding?count=50", token=token)
     if result.get("success") and isinstance(result.get("data"), dict):
-        data = result["data"]
-        return {"jobs": data.get("data", []), "total": data.get("total", 0)}
-
+        d = result["data"]
+        return {"jobs": d.get("data", []), "total": d.get("total", 0)}
     return {"jobs": [], "total": 0}
 
 
 @router.get("/transcoding/settings")
 async def get_transcoding_settings(user=Depends(require_jwt)):
-    """Get transcoding settings."""
     cfg = get_config()
     return {
         "enabled": cfg.get("transcoding_enabled", True),
@@ -549,20 +621,14 @@ async def get_transcoding_settings(user=Depends(require_jwt)):
         "hls_enabled": cfg.get("hls_enabled", True),
         "webtorrent_enabled": cfg.get("webtorrent_enabled", True),
         "resolutions": cfg.get("transcoding_resolutions", {
-            "240p": True,
-            "360p": True,
-            "480p": True,
-            "720p": True,
-            "1080p": True,
-            "1440p": False,
-            "2160p": False,
+            "240p": True, "360p": True, "480p": True, "720p": True,
+            "1080p": True, "1440p": False, "2160p": False,
         })
     }
 
 
 @router.post("/transcoding/settings")
 async def update_transcoding_settings(settings: TranscodingSettings, user=Depends(require_jwt)):
-    """Update transcoding settings."""
     cfg = get_config()
     cfg["transcoding_enabled"] = settings.enabled
     cfg["transcoding_threads"] = settings.threads
@@ -570,7 +636,6 @@ async def update_transcoding_settings(settings: TranscodingSettings, user=Depend
     cfg["webtorrent_enabled"] = settings.webtorrent_enabled
     cfg["transcoding_resolutions"] = settings.resolutions
     save_config(cfg)
-
     log.info(f"Transcoding settings updated by {user.get('sub', 'unknown')}")
     return {"success": True, "message": "Restart PeerTube to apply changes"}
 
@@ -581,45 +646,27 @@ async def update_transcoding_settings(settings: TranscodingSettings, user=Depend
 
 @router.get("/storage/stats")
 async def get_storage_stats(user=Depends(require_jwt)):
-    """Get storage usage statistics."""
     cfg = get_config()
     data_path = Path(cfg.get("data_path", "/data/peertube"))
-
-    stats = {
-        "total": "",
-        "videos": "",
-        "thumbnails": "",
-        "torrents": "",
-        "streaming_playlists": "",
-    }
-
+    stats = {"total": "", "videos": "", "thumbnails": "",
+             "torrents": "", "streaming_playlists": ""}
     if not data_path.exists():
         return {"stats": stats, "error": "Data path not found"}
-
     try:
-        # Total size
-        result = subprocess.run(
-            ["du", "-sh", str(data_path)],
-            capture_output=True, text=True, timeout=30
-        )
-        if result.stdout:
-            stats["total"] = result.stdout.split()[0]
-
-        # Subdirectory sizes
+        r = subprocess.run(["du", "-sh", str(data_path)],
+                           capture_output=True, text=True, timeout=30)
+        if r.stdout:
+            stats["total"] = r.stdout.split()[0]
         storage_path = data_path / "storage"
         for subdir in ["videos", "thumbnails", "torrents", "streaming-playlists"]:
-            sub_path = storage_path / subdir
-            if sub_path.exists():
-                result = subprocess.run(
-                    ["du", "-sh", str(sub_path)],
-                    capture_output=True, text=True, timeout=30
-                )
-                if result.stdout:
-                    key = subdir.replace("-", "_")
-                    stats[key] = result.stdout.split()[0]
+            sp = storage_path / subdir
+            if sp.exists():
+                r = subprocess.run(["du", "-sh", str(sp)],
+                                   capture_output=True, text=True, timeout=30)
+                if r.stdout:
+                    stats[subdir.replace("-", "_")] = r.stdout.split()[0]
     except Exception as e:
         return {"stats": stats, "error": str(e)}
-
     return {"stats": stats}
 
 
@@ -629,189 +676,113 @@ async def get_storage_stats(user=Depends(require_jwt)):
 
 @router.get("/plugins")
 async def list_plugins(user=Depends(require_jwt)):
-    """List installed plugins."""
     if not is_running():
-        return {"plugins": [], "error": "Container not running"}
-
-    result = peertube_api("/plugins?count=100")
-
+        return {"plugins": [], "error": "PeerTube not reachable"}
+    token = get_admin_token()
+    result = pt_api("/plugins?count=100", token=token)
     if result.get("success") and isinstance(result.get("data"), dict):
-        data = result["data"]
-        return {"plugins": data.get("data", []), "total": data.get("total", 0)}
-
+        d = result["data"]
+        return {"plugins": d.get("data", []), "total": d.get("total", 0)}
     return {"plugins": [], "total": 0}
 
 
 @router.post("/plugin/install")
 async def install_plugin(plugin: PluginInstall, user=Depends(require_jwt)):
-    """Install a plugin."""
     if not is_running():
-        return {"success": False, "error": "Container not running"}
-
+        return {"success": False, "error": "PeerTube not reachable"}
+    token = get_admin_token()
     log.info(f"Installing plugin {plugin.npm_name} by {user.get('sub', 'unknown')}")
-    result = peertube_api("/plugins/install", method="POST", data={"npmName": plugin.npm_name})
+    result = pt_api("/plugins/install", method="POST", token=token,
+                    data={"npmName": plugin.npm_name})
     return {"success": result.get("success", False)}
 
 
 @router.delete("/plugin/{plugin_name}")
 async def uninstall_plugin(plugin_name: str, user=Depends(require_jwt)):
-    """Uninstall a plugin."""
     if not is_running():
-        return {"success": False, "error": "Container not running"}
-
+        return {"success": False, "error": "PeerTube not reachable"}
+    token = get_admin_token()
     log.info(f"Uninstalling plugin {plugin_name} by {user.get('sub', 'unknown')}")
-    result = peertube_api(f"/plugins/uninstall", method="POST", data={"npmName": plugin_name})
+    result = pt_api("/plugins/uninstall", method="POST", token=token,
+                    data={"npmName": plugin_name})
     return {"success": result.get("success", False)}
 
 
 # ============================================================================
-# Container Management
+# LXC lifecycle (was "Container Management" — now native-LXC via peertubectl)
 # ============================================================================
+
+def _peertubectl(verb: str, timeout: int = 30) -> dict:
+    try:
+        r = subprocess.run([PEERTUBECTL, verb], capture_output=True, text=True, timeout=timeout)
+        return {"success": r.returncode == 0, "stdout": r.stdout, "stderr": r.stderr}
+    except subprocess.TimeoutExpired:
+        return {"success": False, "error": "timeout"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
 
 @router.get("/container/status")
 async def container_status():
-    """Get container runtime status."""
-    rt = detect_runtime()
-    container = get_container_status()
-
+    """LXC + reachability status (kept under /container/* for webui back-compat)."""
+    cfg = get_config()
     return {
-        "runtime": rt or "none",
-        "docker_available": rt is not None,
-        "status": container["status"],
-        "uptime": container["uptime"],
+        "runtime": "lxc-native",
+        "lxc_state": get_lxc_state(),
+        "http_reachable": http_reachable(),
+        "lxc_ip": cfg.get("ip", "10.100.0.120"),
+        "http_port": cfg.get("http_port", 9000),
     }
 
 
 @router.post("/container/install")
 async def install_peertube(user=Depends(require_jwt)):
-    """Install PeerTube container."""
-    rt = detect_runtime()
-    if not rt:
-        return {"success": False, "error": "No container runtime (docker/podman) found"}
-
-    cfg = get_config()
-    data_path = Path(cfg.get("data_path", "/data/peertube"))
-
-    # Create directories
-    for subdir in ["data", "config", "storage"]:
-        (data_path / subdir).mkdir(parents=True, exist_ok=True)
-
-    # Pull image
-    image = cfg.get("image", DEFAULT_CONFIG["image"])
-    log.info(f"Installing PeerTube ({image}) by {user.get('sub', 'unknown')}")
-
+    """Provision the LXC + native PeerTube install. Long-running → detached."""
+    if not Path(INSTALL_LIB).exists():
+        return {"success": False, "error": f"install script missing at {INSTALL_LIB}"}
+    log.info(f"Launching native-LXC PeerTube install by {user.get('sub', 'unknown')}")
     try:
-        result = subprocess.run(
-            [rt, "pull", image],
-            capture_output=True, text=True, timeout=600
+        # Detach: install takes several minutes (apt + pnpm + release download).
+        subprocess.Popen(
+            ["bash", INSTALL_LIB],
+            stdout=open("/var/log/secubox/peertube-install.log", "a"),
+            stderr=subprocess.STDOUT, start_new_session=True,
         )
-        if result.returncode != 0:
-            return {"success": False, "error": result.stderr.strip(), "output": result.stdout}
-
-        return {"success": True, "output": "Image pulled successfully"}
-    except subprocess.TimeoutExpired:
-        return {"success": False, "error": "Pull timeout (>10 minutes)"}
+        return {"success": True,
+                "message": "Install started (several minutes). "
+                           "Follow /var/log/secubox/peertube-install.log or 'peertubectl logs'."}
     except Exception as e:
         return {"success": False, "error": str(e)}
 
 
 @router.post("/container/start")
 async def start_peertube(user=Depends(require_jwt)):
-    """Start PeerTube container."""
-    if is_running():
-        return {"success": False, "error": "Already running"}
-
-    rt = detect_runtime()
-    if not rt:
-        return {"success": False, "error": "No container runtime"}
-
-    cfg = get_config()
-    data_path = Path(cfg.get("data_path", "/data/peertube"))
-    port = cfg.get("http_port", 9000)
-    image = cfg.get("image", DEFAULT_CONFIG["image"])
-    tz = cfg.get("timezone", "Europe/Paris")
-    domain = cfg.get("domain", "peertube.secubox.local")
-
-    # Ensure directories exist
-    for subdir in ["data", "config", "storage"]:
-        (data_path / subdir).mkdir(parents=True, exist_ok=True)
-
-    # Build run command - PeerTube with embedded PostgreSQL and Redis
-    cmd = [
-        rt, "run", "-d",
-        "--name", CONTAINER_NAME,
-        "-v", f"{data_path}/data:/data",
-        "-v", f"{data_path}/config:/config",
-        "-v", f"{data_path}/storage:/var/www/peertube/storage",
-        "-e", f"TZ={tz}",
-        "-e", f"PEERTUBE_WEBSERVER_HOSTNAME={domain}",
-        "-e", "PEERTUBE_WEBSERVER_PORT=443",
-        "-e", "PEERTUBE_WEBSERVER_HTTPS=true",
-        "-e", "PEERTUBE_DB_SSL=false",
-        "-e", "PEERTUBE_TRUST_PROXY=loopback,uniquelocal",
-        "-e", "PT_INITIAL_ROOT_PASSWORD=secubox",
-        "-p", f"127.0.0.1:{port}:9000",
-        "--restart", "unless-stopped",
-    ]
-
-    cmd.append(image)
-
-    log.info(f"Starting PeerTube by {user.get('sub', 'unknown')}")
-
-    try:
-        # Remove existing stopped container
-        subprocess.run([rt, "rm", "-f", CONTAINER_NAME], capture_output=True, timeout=10)
-
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
-        await asyncio.sleep(5)
-
-        if is_running():
-            return {"success": True}
-        else:
-            return {"success": False, "error": result.stderr.strip() or "Failed to start"}
-    except Exception as e:
-        return {"success": False, "error": str(e)}
+    log.info(f"Starting PeerTube LXC by {user.get('sub', 'unknown')}")
+    r = _peertubectl("start")
+    return {"success": r.get("success", False), "output": r.get("stdout", r.get("error", ""))}
 
 
 @router.post("/container/stop")
 async def stop_peertube(user=Depends(require_jwt)):
-    """Stop PeerTube container."""
-    rt = detect_runtime()
-    if not rt:
-        return {"success": False, "error": "No container runtime"}
-
-    log.info(f"Stopping PeerTube by {user.get('sub', 'unknown')}")
-
-    try:
-        subprocess.run([rt, "stop", CONTAINER_NAME], capture_output=True, timeout=30)
-        return {"success": True}
-    except Exception as e:
-        return {"success": False, "error": str(e)}
+    log.info(f"Stopping PeerTube LXC by {user.get('sub', 'unknown')}")
+    r = _peertubectl("stop")
+    return {"success": r.get("success", False), "output": r.get("stdout", r.get("error", ""))}
 
 
 @router.post("/container/restart")
 async def restart_peertube(user=Depends(require_jwt)):
-    """Restart PeerTube container."""
-    await stop_peertube(user)
-    await asyncio.sleep(3)
-    return await start_peertube(user)
+    log.info(f"Restarting PeerTube LXC by {user.get('sub', 'unknown')}")
+    r = _peertubectl("restart")
+    return {"success": r.get("success", False), "output": r.get("stdout", r.get("error", ""))}
 
 
 @router.post("/container/uninstall")
 async def uninstall_peertube(user=Depends(require_jwt)):
-    """Uninstall PeerTube container (data preserved)."""
-    rt = detect_runtime()
-    if not rt:
-        return {"success": False, "error": "No container runtime"}
-
-    log.info(f"Uninstalling PeerTube by {user.get('sub', 'unknown')}")
-
-    try:
-        subprocess.run([rt, "stop", CONTAINER_NAME], capture_output=True, timeout=30)
-        subprocess.run([rt, "rm", "-f", CONTAINER_NAME], capture_output=True, timeout=10)
-        return {"success": True, "message": "Container removed, data preserved"}
-    except Exception as e:
-        return {"success": False, "error": str(e)}
+    """Stop the LXC (data on /data/peertube is preserved)."""
+    log.info(f"Stopping PeerTube LXC (data preserved) by {user.get('sub', 'unknown')}")
+    r = _peertubectl("stop")
+    return {"success": r.get("success", False),
+            "message": "LXC stopped, data preserved at /data/peertube"}
 
 
 # ============================================================================
@@ -820,18 +791,15 @@ async def uninstall_peertube(user=Depends(require_jwt)):
 
 @router.get("/logs")
 async def get_logs(lines: int = 100, user=Depends(require_jwt)):
-    """Get container logs."""
-    rt = detect_runtime()
-    if not rt:
-        return {"logs": "No container runtime"}
-
+    """Tail peertube.service journal inside the LXC."""
+    cfg = get_config()
     try:
-        result = subprocess.run(
-            [rt, "logs", "--tail", str(lines), CONTAINER_NAME],
-            capture_output=True, text=True, timeout=10
+        r = subprocess.run(
+            ["lxc-attach", "-n", cfg["name"], "-P", cfg["path"], "--",
+             "journalctl", "-u", "peertube", "-n", str(lines), "--no-pager"],
+            capture_output=True, text=True, timeout=15,
         )
-        logs = result.stdout + result.stderr
-        return {"logs": logs}
+        return {"logs": (r.stdout + r.stderr) or "No logs available"}
     except Exception:
         return {"logs": "No logs available"}
 
@@ -842,15 +810,13 @@ async def get_logs(lines: int = 100, user=Depends(require_jwt)):
 
 @router.get("/config")
 async def get_peertube_config(user=Depends(require_jwt)):
-    """Get PeerTube configuration."""
     return get_config()
 
 
 @router.post("/config")
 async def set_peertube_config(config: PeerTubeConfig, user=Depends(require_jwt)):
-    """Update PeerTube configuration."""
     cfg = get_config()
-    cfg.update(config.dict())
+    cfg.update(config.model_dump())
     save_config(cfg)
     log.info(f"Config updated by {user.get('sub', 'unknown')}")
     return {"success": True}

--- a/packages/secubox-peertube/api/main.py
+++ b/packages/secubox-peertube/api/main.py
@@ -334,9 +334,15 @@ async def status():
         if v.get("success") and isinstance(v.get("data"), dict):
             video_count = v["data"].get("total", 0)
 
-    # Map LXC state onto the keys the webui already consumes.
-    container_status = {"running": "running", "stopped": "stopped",
-                        "absent": "not_installed"}.get(state, state)
+    # Map LXC state onto the keys the webui already consumes. The dashboard
+    # runs as the unprivileged 'secubox' user, which can't always read the
+    # root-owned LXC via lxc-info (reports "absent"); trust HTTP reachability
+    # as the primary "running" signal, fall back to lxc_state when unreachable.
+    if reachable:
+        container_status = "running"
+    else:
+        container_status = {"running": "running", "stopped": "stopped",
+                            "absent": "not_installed"}.get(state, state)
 
     return {
         "deployment": "lxc-native",

--- a/packages/secubox-peertube/api/main.py
+++ b/packages/secubox-peertube/api/main.py
@@ -12,11 +12,12 @@ Author: Gerald Kerma <gandalf@gk2.net>
 License: Proprietary / ANSSI CSPN candidate
 """
 import json
+import os
 import subprocess
 from pathlib import Path
 from typing import List, Optional, Dict
 
-from fastapi import FastAPI, APIRouter, Depends
+from fastapi import FastAPI, APIRouter, Depends, Request
 from pydantic import BaseModel, Field
 
 from secubox_core.auth import router as auth_router, require_jwt
@@ -473,6 +474,51 @@ async def import_video(req: VideoImport, user=Depends(require_jwt)):
         return {"success": True, "import_id": d.get("id"),
                 "video_uuid": vid.get("uuid"), "state": (d.get("state") or {})}
     return {"success": False, "error": result.get("error", "import failed")}
+
+
+# Spool path the dashboard (secubox) can write and that the narrowly-scoped
+# sudoers rule lets peertubectl read as root (see debian/secubox-peertube.sudoers).
+COOKIES_SPOOL = "/run/secubox/peertube-yt-cookies.txt"
+
+
+@router.post("/import/cookies")
+async def import_cookies(request: Request, user=Depends(require_jwt)):
+    """Install operator-supplied YouTube cookies (Netscape format) so yt-dlp
+    import can fetch YouTube. Body = the cookies.txt text (the SecuBox
+    WebExtension reads them from the logged-in browser and POSTs here, #401).
+
+    The dashboard runs unprivileged (secubox); it spools the body to
+    COOKIES_SPOOL then escalates via a single narrowly-scoped sudoers rule to
+    `peertubectl set-youtube-cookies`, which writes them into the LXC + enables
+    the feature + restarts PeerTube."""
+    body = (await request.body()).decode("utf-8", "replace")
+    if "\t" not in body or "youtube" not in body.lower():
+        return {"success": False, "error": "body is not a Netscape youtube cookies file"}
+    try:
+        with open(COOKIES_SPOOL, "w") as f:
+            f.write(body)
+        os.chmod(COOKIES_SPOOL, 0o600)
+    except Exception as e:
+        return {"success": False, "error": f"spool write failed: {e}"}
+    log.info(f"Installing YouTube cookies ({len(body)} bytes) by {user.get('sub', 'unknown')}")
+    try:
+        r = subprocess.run(
+            ["sudo", "-n", PEERTUBECTL, "set-youtube-cookies", COOKIES_SPOOL],
+            capture_output=True, text=True, timeout=90,
+        )
+        ok = r.returncode == 0
+        return {"success": ok,
+                "message": "cookies installed; PeerTube restarting" if ok else None,
+                "error": None if ok else (r.stderr or r.stdout or "install failed").strip()}
+    except subprocess.TimeoutExpired:
+        return {"success": False, "error": "timeout"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+    finally:
+        try:
+            os.remove(COOKIES_SPOOL)
+        except OSError:
+            pass
 
 
 # ============================================================================

--- a/packages/secubox-peertube/api/main.py
+++ b/packages/secubox-peertube/api/main.py
@@ -44,7 +44,7 @@ DEFAULT_CONFIG = {
     "enabled": False,
     "image": "chocobozzz/peertube:production-bookworm",
     "http_port": 9000,
-    "data_path": "/srv/peertube",
+    "data_path": "/data/peertube",
     "timezone": "Europe/Paris",
     "domain": "peertube.secubox.local",
     "haproxy": False,
@@ -68,7 +68,7 @@ class PeerTubeConfig(BaseModel):
     enabled: bool = False
     image: str = "chocobozzz/peertube:production-bookworm"
     http_port: int = 9000
-    data_path: str = "/srv/peertube"
+    data_path: str = "/data/peertube"
     timezone: str = "Europe/Paris"
     domain: str = "peertube.secubox.local"
     haproxy: bool = False
@@ -262,7 +262,7 @@ async def status():
 
     # Disk usage
     disk_usage = ""
-    data_path = Path(cfg.get("data_path", "/srv/peertube"))
+    data_path = Path(cfg.get("data_path", "/data/peertube"))
     if data_path.exists():
         try:
             result = subprocess.run(
@@ -286,7 +286,7 @@ async def status():
         "enabled": cfg.get("enabled", False),
         "image": cfg.get("image", DEFAULT_CONFIG["image"]),
         "http_port": cfg.get("http_port", 9000),
-        "data_path": cfg.get("data_path", "/srv/peertube"),
+        "data_path": cfg.get("data_path", "/data/peertube"),
         "timezone": cfg.get("timezone", "Europe/Paris"),
         "domain": cfg.get("domain", "peertube.secubox.local"),
         "haproxy": cfg.get("haproxy", False),
@@ -583,7 +583,7 @@ async def update_transcoding_settings(settings: TranscodingSettings, user=Depend
 async def get_storage_stats(user=Depends(require_jwt)):
     """Get storage usage statistics."""
     cfg = get_config()
-    data_path = Path(cfg.get("data_path", "/srv/peertube"))
+    data_path = Path(cfg.get("data_path", "/data/peertube"))
 
     stats = {
         "total": "",
@@ -690,7 +690,7 @@ async def install_peertube(user=Depends(require_jwt)):
         return {"success": False, "error": "No container runtime (docker/podman) found"}
 
     cfg = get_config()
-    data_path = Path(cfg.get("data_path", "/srv/peertube"))
+    data_path = Path(cfg.get("data_path", "/data/peertube"))
 
     # Create directories
     for subdir in ["data", "config", "storage"]:
@@ -726,7 +726,7 @@ async def start_peertube(user=Depends(require_jwt)):
         return {"success": False, "error": "No container runtime"}
 
     cfg = get_config()
-    data_path = Path(cfg.get("data_path", "/srv/peertube"))
+    data_path = Path(cfg.get("data_path", "/data/peertube"))
     port = cfg.get("http_port", 9000)
     image = cfg.get("image", DEFAULT_CONFIG["image"])
     tz = cfg.get("timezone", "Europe/Paris")

--- a/packages/secubox-peertube/conf/peertube.nginx.conf
+++ b/packages/secubox-peertube/conf/peertube.nginx.conf
@@ -1,0 +1,57 @@
+# packages/secubox-peertube/conf/peertube.nginx.conf
+# Installed by secubox-peertube postinst at /etc/nginx/sites-available/peertube.conf
+# and symlinked into /etc/nginx/sites-enabled/.
+#
+# Public chain: Browser → HAProxy:443 (TLS) → nginx:9080 (this vhost, matched
+#               by server_name) → PeerTube LXC at 10.100.0.120:9000.
+#
+# All SecuBox public vhosts share listen :9080 and differentiate by
+# server_name (see gitea/grafana) — there is no port collision. PeerTube
+# runs natively in its own LXC (install-lxc.sh) on its default port 9000.
+#
+# Bypasses mitmproxy WAF intentionally — video streaming and large uploads
+# are high-volume binary that the WAF cannot meaningfully inspect, and the
+# admin/auth endpoints are gated by PeerTube's own user system. Matches the
+# documented gitea exception pattern (see packages/secubox-gitea/conf/
+# gitea.nginx.conf header for the same rationale).
+#
+# Operator wires the HAProxy SNI ACL + ACME cert separately (CLAUDE.md
+# packaging convention). Override the proxied LXC IP via the conf if the
+# board uses a non-default address.
+
+server {
+    listen 0.0.0.0:9080;
+    server_name peertube.gk2.secubox.in;
+
+    # Large file uploads (videos). PeerTube enforces its own size cap.
+    client_max_body_size 8G;
+
+    # ACME HTTP-01 challenge — outside any auth layer for renewals.
+    location ^~ /.well-known/acme-challenge/ {
+        root /usr/share/secubox/www;
+        try_files $uri =404;
+    }
+
+    location / {
+        proxy_pass http://10.100.0.120:9000;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host  $host;
+
+        # WebTorrent + live streams use long-lived connections.
+        proxy_read_timeout 7d;
+        proxy_send_timeout 7d;
+        proxy_buffering    off;
+        proxy_request_buffering off;
+
+        # WebSockets (live chat, P2P tracker handshake).
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection $http_connection;
+    }
+
+    access_log /var/log/nginx/peertube_access.log;
+    error_log  /var/log/nginx/peertube_error.log;
+}

--- a/packages/secubox-peertube/conf/peertube.toml.example
+++ b/packages/secubox-peertube/conf/peertube.toml.example
@@ -1,0 +1,25 @@
+# /etc/secubox/peertube.toml — SecuBox PeerTube module configuration
+#
+# Operator-facing override of the package defaults. Edit values then run
+# `peertubectl install` (first provision) or `peertubectl restart`.
+
+# ── LXC ───────────────────────────────────────────────────────────────
+[lxc]
+name         = "peertube"
+ip           = "10.100.0.120"
+gateway      = "10.100.0.1"
+bridge       = "br-lxc"
+path         = "/data/lxc"
+debian_suite = "bookworm"
+
+# ── PeerTube (native, inside the LXC) ─────────────────────────────────
+[peertube]
+http_port           = 9000     # PeerTube's own listen port inside the LXC
+db_password_file    = "/etc/secubox/secrets/peertube-db"
+secret_file         = "/etc/secubox/secrets/peertube-secret"
+admin_email         = "admin@cybermind.fr"
+
+# ── Public exposure (nginx vhost :9080 → LXC :9000; HAProxy SNI ACL) ──
+[exposure]
+public_hostname = "peertube.gk2.secubox.in"   # baked into PeerTube webserver config
+waf_inspect     = false        # video/uploads bypass the WAF (gitea pattern)

--- a/packages/secubox-peertube/debian/changelog
+++ b/packages/secubox-peertube/debian/changelog
@@ -1,3 +1,46 @@
+secubox-peertube (1.1.0-1~bookworm1) bookworm; urgency=medium
+
+  * Native-LXC deployment + dashboard correction + URL import (closes #388,
+    supersedes #390). Validated live on gk2 — https://peertube.gk2.secubox.in/.
+  * lib/peertube/install-lxc.sh (NEW): idempotent native install of PeerTube
+    inside a dedicated Debian LXC (default 10.100.0.120 on br-lxc), mirroring
+    grafana/yacy. Bakes in every fix found while bringing the live instance up:
+    - Node 22 via the signed NodeSource apt repo (PeerTube 8.x requires >=22;
+      no `curl | bash`); pnpm with MSGPACKR_NATIVE_ACCELERATION_DISABLED=1
+      (arm64 msgpackr-extract prebuilt binding is broken, JS fallback is fine);
+    - debian.common.conf template (NOT common.conf) — postgresql-15 initdb +
+      postinst fail under the stricter unprivileged defaults;
+    - bind mounts /data/peertube/{storage,config,postgres,redis} chown'd to the
+      LXC root UID (100000) so the container can manage them;
+    - production.yaml patched: listen 0.0.0.0:9000, webserver https/hostname/
+      443, generated 64-byte secret, DB password, admin email, AND
+      import.videos.http.enabled=true (native HTTP import / yt-dlp);
+    - captures the first-boot root password to /etc/secubox/secrets/peertube-
+      admin so the dashboard can authenticate for write ops.
+  * sbin/peertubectl (NEW): install/status/start/stop/restart/logs/reload.
+  * conf/peertube.nginx.conf (folds #390, port corrected): public vhost
+    listen :9080 → PeerTube LXC 10.100.0.120:9000 (NOT the old 127.0.0.1:9001
+    Docker-on-host plan; all SecuBox vhosts share :9080 and differ by
+    server_name, so there is no lyrion collision). 8G upload cap, 7d streaming
+    timeouts, WS upgrade, ACME passthrough. Bypasses the WAF (gitea pattern).
+    postinst symlinks it into sites-enabled.
+  * api/main.py: rewritten to talk to the native instance over HTTP at
+    <lxc_ip>:<http_port> (with the required Host: <public_hostname> header —
+    PeerTube 403s on raw-IP Host) instead of `podman/docker exec` inside a
+    container. Status reports real LXC state + HTTP reachability + server
+    version. /container/* verbs now drive the LXC via peertubectl. NEW
+    POST /import + GET /imports (URL → instance via PeerTube import API).
+  * www/peertube/index.html: new "Import" tab (URL + channel + privacy +
+    recent-imports list); status/labels/links corrected for native-LXC
+    (Open PeerTube → public https URL; "Restart/Stop LXC"; logs from
+    peertube.service).
+  * debian/control: Description + Depends reframed Docker/Podman → native-LXC
+    (lxc, lxc-templates, nftables, openssl). debian/secubox-peertube.service:
+    drop the now-irrelevant Wants=podman.service docker.service.
+  * conf/peertube.toml.example (NEW): [lxc]/[peertube]/[exposure] sections.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 28 May 2026 10:00:00 +0000
+
 secubox-peertube (1.0.1-1~bookworm1) bookworm; urgency=medium
 
   * Rework to align with SecuBox conventions (closes #388):

--- a/packages/secubox-peertube/debian/changelog
+++ b/packages/secubox-peertube/debian/changelog
@@ -1,3 +1,34 @@
+secubox-peertube (1.0.1-1~bookworm1) bookworm; urgency=medium
+
+  * Rework to align with SecuBox conventions (closes #388):
+    - Service unit: User=root → User=secubox; replace ExecStartPost=
+      chmod/chown hacks with RuntimeDirectory=secubox +
+      RuntimeDirectoryPreserve=yes + RuntimeDirectoryMode=0775
+      (mass-redeploy safety); drop the broken
+      Requires=secubox-runtime.service (no such service); drop
+      ConditionPathExists=/etc/secubox/peertube/enabled gate so the
+      API daemon is always reachable to serve the management
+      dashboard (the heavy PeerTube container is still operator-
+      deployed on demand).
+    - api/main.py: default data_path switched from /srv/peertube to
+      /data/peertube (per #319 /data convention). Five hardcoded
+      fallbacks updated in lockstep.
+    - debian/postinst: added #319 /data migration block (mirror
+      gitea/wazuh pattern); wrapped systemctl enable in is-enabled
+      != masked check (per wazuh fix 63284497) so a deliberately
+      masked unit no longer fails the postinst; dropped the
+      hardcoded /srv/peertube/{storage,config,data} mkdir — those
+      subdirs are created by the API on first container/install so
+      PeerTube's UID/GID can own them; nginx reload guarded by
+      `nginx -t`.
+    - debian/control: Description rewritten with cross-references
+      to the other federated/streaming/media SecuBox packages
+      (matrix, jitsi, jellyfin, gotosocial, simplex). Recommends
+      reordered: podman first (smaller, distro-native), docker.io
+      as alternative.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Wed, 27 May 2026 17:00:00 +0000
+
 secubox-peertube (1.0.0-1~bookworm1) bookworm; urgency=medium
 
   * Rewrite for Docker/Podman container management.

--- a/packages/secubox-peertube/debian/control
+++ b/packages/secubox-peertube/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 4.6.2
 Package: secubox-peertube
 Architecture: all
 Depends: ${misc:Depends}, secubox-core (>= 1.0), python3-uvicorn | python3-pip,
- lxc, lxc-templates, nftables, openssl
+ lxc, lxc-templates, nftables, openssl, sudo
 Description: SecuBox PeerTube — federated video platform (native LXC)
  Dashboard + FastAPI backend for a PeerTube video-hosting instance
  installed NATIVELY inside a dedicated Debian LXC (its own

--- a/packages/secubox-peertube/debian/control
+++ b/packages/secubox-peertube/debian/control
@@ -8,20 +8,28 @@ Standards-Version: 4.6.2
 Package: secubox-peertube
 Architecture: all
 Depends: ${misc:Depends}, secubox-core (>= 1.0), python3-uvicorn | python3-pip
-Recommends: docker.io | podman
-Description: PeerTube federated video platform management
- SecuBox module for managing PeerTube video hosting via Docker/Podman.
- Provides container management, video hosting, channel management,
- user management, federation (ActivityPub), transcoding settings,
- plugin management, and storage statistics.
+Recommends: podman | docker.io
+Description: SecuBox PeerTube — federated video platform manager (Docker/Podman)
+ Dashboard + FastAPI backend for managing a PeerTube video-hosting
+ instance running in a Docker or Podman container. The API daemon
+ itself is lightweight (always reachable); the heavy PeerTube
+ container is operator-deployed on demand from the dashboard.
  .
  Features:
-  - Docker/Podman container management
+  - Docker/Podman container lifecycle (install, start, stop, restart, uninstall)
   - Video and channel management
-  - User creation and role assignment
-  - Federation with other PeerTube instances
+  - User creation and role assignment (admin/moderator/user)
+  - Federation (ActivityPub) — follow/followers
   - Transcoding settings (HLS, WebTorrent, resolutions)
   - Plugin installation from NPM
   - Storage usage monitoring
  .
- Provides FastAPI backend on /api/v1/peertube/ via Unix socket.
+ Distinct from sibling federated/streaming/media SecuBox packages:
+  - secubox-matrix — Matrix Synapse (chat federation, not video).
+  - secubox-jitsi — Jitsi Meet (real-time conferencing, not VOD).
+  - secubox-jellyfin — Jellyfin (local media library, not federated).
+  - secubox-gotosocial — GoToSocial (microblog ActivityPub, not video).
+  - secubox-simplex — SimpleX Chat (decentralized chat).
+ .
+ Reachable at /peertube/ (frontend) and /api/v1/peertube/* (API)
+ via Unix socket /run/secubox/peertube.sock.

--- a/packages/secubox-peertube/debian/control
+++ b/packages/secubox-peertube/debian/control
@@ -7,16 +7,23 @@ Standards-Version: 4.6.2
 
 Package: secubox-peertube
 Architecture: all
-Depends: ${misc:Depends}, secubox-core (>= 1.0), python3-uvicorn | python3-pip
-Recommends: podman | docker.io
-Description: SecuBox PeerTube — federated video platform manager (Docker/Podman)
- Dashboard + FastAPI backend for managing a PeerTube video-hosting
- instance running in a Docker or Podman container. The API daemon
- itself is lightweight (always reachable); the heavy PeerTube
- container is operator-deployed on demand from the dashboard.
+Depends: ${misc:Depends}, secubox-core (>= 1.0), python3-uvicorn | python3-pip,
+ lxc, lxc-templates, nftables, openssl
+Description: SecuBox PeerTube — federated video platform (native LXC)
+ Dashboard + FastAPI backend for a PeerTube video-hosting instance
+ installed NATIVELY inside a dedicated Debian LXC (its own
+ peertube.service: Node 22 + PostgreSQL 15 + Redis + ffmpeg). The API
+ daemon on the host is lightweight (always reachable to serve the
+ dashboard); `peertubectl install` provisions the LXC and the PeerTube
+ stack on demand.
+ .
+ PeerTube runs native-in-LXC rather than Docker/Podman: an unprivileged
+ LXC cannot reliably bring up a podman CNI bridge on the Marvell arm64
+ boards, so the native systemd-managed install is the supported path.
  .
  Features:
-  - Docker/Podman container lifecycle (install, start, stop, restart, uninstall)
+  - LXC lifecycle via peertubectl (install, status, start, stop, restart, logs)
+  - Public nginx vhost (:9080 → LXC :9000) bypassing the WAF (gitea pattern)
   - Video and channel management
   - User creation and role assignment (admin/moderator/user)
   - Federation (ActivityPub) — follow/followers

--- a/packages/secubox-peertube/debian/postinst
+++ b/packages/secubox-peertube/debian/postinst
@@ -9,7 +9,10 @@ if [ "$1" = "configure" ]; then
 
     # Runtime + state directories
     install -d -o secubox -g secubox -m 750 /run/secubox /var/lib/secubox
-    install -d -o root    -g root    -m 755 /etc/secubox
+    # Do NOT reset /etc/secubox — secubox-core owns it as secubox:secubox 0750
+    # (the users-engine needs dir-write for atomic users.json saves / TOTP).
+    # Only create as a fallback if it's somehow missing.
+    [ -d /etc/secubox ] || install -d -o secubox -g secubox -m 750 /etc/secubox
 
     # nginx snippet directory (peertube.conf shipped by the package lands here)
     install -d -m 755 /etc/nginx/secubox.d

--- a/packages/secubox-peertube/debian/postinst
+++ b/packages/secubox-peertube/debian/postinst
@@ -30,10 +30,22 @@ if [ "$1" = "configure" ]; then
       fi
     done
 
-    # Pre-create the /data/peertube root with neutral ownership; subdirs
-    # (config/, data/, storage/) are created by the API on first
-    # container/install so PeerTube's UID/GID can own them.
+    # Pre-create the /data/peertube root with neutral ownership; the
+    # bind-mount subdirs (storage/ config/ postgres/ redis/) are created +
+    # chown'd to the LXC root UID by install-lxc.sh on `peertubectl install`.
     install -d -o root -g root -m 755 /data/peertube
+
+    # Ship a default peertube.toml from the example if the operator has none.
+    if [ ! -e /etc/secubox/peertube.toml ] && [ -e /etc/secubox/peertube.toml.example ]; then
+      cp /etc/secubox/peertube.toml.example /etc/secubox/peertube.toml
+    fi
+
+    # Symlink the public vhost into sites-enabled (idempotent). The vhost
+    # proxies peertube.gk2.secubox.in (:9080) → PeerTube LXC :9000. Operator
+    # wires the HAProxy SNI ACL + ACME cert separately (CLAUDE.md convention).
+    if [ -f /etc/nginx/sites-available/peertube.conf ] && [ -d /etc/nginx/sites-enabled ]; then
+      ln -sf ../sites-available/peertube.conf /etc/nginx/sites-enabled/peertube.conf
+    fi
 
     # Enable + start the API daemon. Tolerate masked units (per wazuh fix
     # 63284497): if the operator deliberately masked the service, leave it
@@ -44,7 +56,9 @@ if [ "$1" = "configure" ]; then
       systemctl start  secubox-peertube.service || true
     fi
 
-    # Reload nginx to pick up the /api/v1/peertube/ + /peertube/ locations.
+    # Reload nginx to pick up the /api/v1/peertube/ + /peertube/ locations
+    # and the public vhost. NOTE: PeerTube itself is NOT installed by this
+    # postinst — run `peertubectl install` to provision the LXC.
     if nginx -t 2>/dev/null; then
       systemctl reload nginx 2>/dev/null || true
     fi

--- a/packages/secubox-peertube/debian/postinst
+++ b/packages/secubox-peertube/debian/postinst
@@ -1,27 +1,54 @@
-#!/bin/bash
+#!/bin/sh
 set -e
-case "$1" in
-  configure)
+
+if [ "$1" = "configure" ]; then
     # Ensure secubox user exists
     id -u secubox >/dev/null 2>&1 || \
       adduser --system --group --no-create-home \
         --home /var/lib/secubox --shell /usr/sbin/nologin secubox
-    # Create runtime directories
-    install -d -o secubox -g secubox -m 750 /run/secubox
-    install -d -o secubox -g secubox -m 750 /var/lib/secubox
-    # Create PeerTube data directory
-    install -d -o root -g root -m 755 /srv/peertube
-    install -d -o root -g root -m 755 /srv/peertube/storage
-    install -d -o root -g root -m 755 /srv/peertube/config
-    install -d -o root -g root -m 755 /srv/peertube/data
-    # Ensure nginx secubox.d directory exists
+
+    # Runtime + state directories
+    install -d -o secubox -g secubox -m 750 /run/secubox /var/lib/secubox
+    install -d -o root    -g root    -m 755 /etc/secubox
+
+    # nginx snippet directory (peertube.conf shipped by the package lands here)
     install -d -m 755 /etc/nginx/secubox.d
-    # Enable and start service
+
+    # #319 /data migration. Move legacy /srv/peertube → /data/peertube and
+    # leave a symlink behind for back-compat. Idempotent.
+    for _d in peertube; do
+      if [ -d "/srv/$_d" ] && [ ! -L "/srv/$_d" ] && [ ! -e "/data/$_d" ]; then
+        mkdir -p /data
+        _was_active=""
+        if systemctl is-active --quiet secubox-peertube; then
+          systemctl stop secubox-peertube || true
+          _was_active=1
+        fi
+        mv "/srv/$_d" "/data/$_d" && ln -s "/data/$_d" "/srv/$_d" \
+          && echo "secubox-peertube: migrated /srv/$_d → /data/$_d"
+        [ -n "$_was_active" ] && systemctl start secubox-peertube || true
+      fi
+    done
+
+    # Pre-create the /data/peertube root with neutral ownership; subdirs
+    # (config/, data/, storage/) are created by the API on first
+    # container/install so PeerTube's UID/GID can own them.
+    install -d -o root -g root -m 755 /data/peertube
+
+    # Enable + start the API daemon. Tolerate masked units (per wazuh fix
+    # 63284497): if the operator deliberately masked the service, leave it
+    # alone instead of failing the postinst.
     systemctl daemon-reload
-    systemctl enable secubox-peertube.service
-    systemctl start  secubox-peertube.service || true
-    # Reload nginx to pick up new location
-    systemctl reload nginx 2>/dev/null || true
-    ;;
-esac
+    if [ "$(systemctl is-enabled secubox-peertube.service 2>/dev/null)" != "masked" ]; then
+      systemctl enable secubox-peertube.service || true
+      systemctl start  secubox-peertube.service || true
+    fi
+
+    # Reload nginx to pick up the /api/v1/peertube/ + /peertube/ locations.
+    if nginx -t 2>/dev/null; then
+      systemctl reload nginx 2>/dev/null || true
+    fi
+fi
+
 #DEBHELPER#
+exit 0

--- a/packages/secubox-peertube/debian/rules
+++ b/packages/secubox-peertube/debian/rules
@@ -18,9 +18,14 @@ override_dh_auto_install:
 	# Menu definitions
 	install -d debian/secubox-peertube/usr/share/secubox/menu.d
 	[ -d menu.d ] && cp -r menu.d/. debian/secubox-peertube/usr/share/secubox/menu.d/ || true
-	# Modular nginx config (API socket location → /etc/nginx/secubox.d/)
+	# Dashboard-API route. The ACTIVE include is secubox-routes.d/ (webui.conf);
+	# secubox.d/ is legacy/back-compat. Ship to BOTH (mirror secubox-grafana) so
+	# /api/v1/peertube/ is routed — installing only to secubox.d/ silently drops
+	# the route (regression that broke the dashboard + cookie relay).
 	install -d debian/secubox-peertube/etc/nginx/secubox.d
+	install -d debian/secubox-peertube/etc/nginx/secubox-routes.d
 	[ -f nginx/peertube.conf ] && cp nginx/peertube.conf debian/secubox-peertube/etc/nginx/secubox.d/ || true
+	[ -f nginx/peertube.conf ] && cp nginx/peertube.conf debian/secubox-peertube/etc/nginx/secubox-routes.d/ || true
 	# Public vhost template → sites-available (postinst symlinks into sites-enabled)
 	install -d debian/secubox-peertube/etc/nginx/sites-available
 	[ -f conf/peertube.nginx.conf ] && cp conf/peertube.nginx.conf debian/secubox-peertube/etc/nginx/sites-available/peertube.conf || true

--- a/packages/secubox-peertube/debian/rules
+++ b/packages/secubox-peertube/debian/rules
@@ -30,3 +30,6 @@ override_dh_auto_install:
 	# Systemd service (host dashboard daemon)
 	install -d debian/secubox-peertube/usr/lib/systemd/system
 	install -m 644 debian/secubox-peertube.service debian/secubox-peertube/usr/lib/systemd/system/
+	# sudoers: narrowly-scoped escalation for the cookie-relay (#401)
+	install -d debian/secubox-peertube/etc/sudoers.d
+	install -m 0440 debian/secubox-peertube.sudoers debian/secubox-peertube/etc/sudoers.d/secubox-peertube

--- a/packages/secubox-peertube/debian/rules
+++ b/packages/secubox-peertube/debian/rules
@@ -3,18 +3,30 @@
 	dh $@
 
 override_dh_auto_install:
-	# API files
+	# API files (host dashboard daemon)
 	install -d debian/secubox-peertube/usr/lib/secubox/peertube/
 	cp -r api debian/secubox-peertube/usr/lib/secubox/peertube/
+	# Host control plane CLI
+	install -d debian/secubox-peertube/usr/sbin
+	install -m 755 sbin/peertubectl debian/secubox-peertube/usr/sbin/peertubectl
+	# Native-LXC bootstrap (shipped, run on demand by `peertubectl install`)
+	install -d debian/secubox-peertube/usr/share/secubox/lib/peertube
+	[ -d lib/peertube ] && cp -r lib/peertube/. debian/secubox-peertube/usr/share/secubox/lib/peertube/ || true
 	# Static www files
 	install -d debian/secubox-peertube/usr/share/secubox/www
 	[ -d www ] && cp -r www/. debian/secubox-peertube/usr/share/secubox/www/ || true
 	# Menu definitions
 	install -d debian/secubox-peertube/usr/share/secubox/menu.d
 	[ -d menu.d ] && cp -r menu.d/. debian/secubox-peertube/usr/share/secubox/menu.d/ || true
-	# Modular nginx config
+	# Modular nginx config (API socket location → /etc/nginx/secubox.d/)
 	install -d debian/secubox-peertube/etc/nginx/secubox.d
 	[ -f nginx/peertube.conf ] && cp nginx/peertube.conf debian/secubox-peertube/etc/nginx/secubox.d/ || true
-	# Systemd service
+	# Public vhost template → sites-available (postinst symlinks into sites-enabled)
+	install -d debian/secubox-peertube/etc/nginx/sites-available
+	[ -f conf/peertube.nginx.conf ] && cp conf/peertube.nginx.conf debian/secubox-peertube/etc/nginx/sites-available/peertube.conf || true
+	# Config example
+	install -d debian/secubox-peertube/etc/secubox
+	[ -f conf/peertube.toml.example ] && cp conf/peertube.toml.example debian/secubox-peertube/etc/secubox/peertube.toml.example || true
+	# Systemd service (host dashboard daemon)
 	install -d debian/secubox-peertube/usr/lib/systemd/system
 	install -m 644 debian/secubox-peertube.service debian/secubox-peertube/usr/lib/systemd/system/

--- a/packages/secubox-peertube/debian/secubox-peertube.service
+++ b/packages/secubox-peertube/debian/secubox-peertube.service
@@ -13,7 +13,10 @@ Restart=on-failure
 RestartSec=5
 UMask=0000
 
-NoNewPrivileges=true
+# NoNewPrivileges intentionally NOT set: the dashboard escalates via a single
+# narrowly-scoped sudoers rule (peertubectl set-youtube-cookies) to install
+# operator-supplied YouTube cookies into the LXC. NoNewPrivileges=true would
+# block sudo. See debian/secubox-peertube.sudoers.
 RuntimeDirectory=secubox
 RuntimeDirectoryPreserve=yes
 RuntimeDirectoryMode=0775

--- a/packages/secubox-peertube/debian/secubox-peertube.service
+++ b/packages/secubox-peertube/debian/secubox-peertube.service
@@ -2,7 +2,6 @@
 Description=SecuBox PeerTube API
 After=network.target secubox-core.service
 Requires=secubox-core.service
-Wants=podman.service docker.service
 
 [Service]
 Type=simple

--- a/packages/secubox-peertube/debian/secubox-peertube.service
+++ b/packages/secubox-peertube/debian/secubox-peertube.service
@@ -1,23 +1,25 @@
 [Unit]
 Description=SecuBox PeerTube API
-After=network.target secubox-core.service secubox-runtime.service docker.service
-Requires=secubox-runtime.service
-Wants=docker.service
-# Only start if explicitly enabled (PeerTube LXC configured)
-ConditionPathExists=/etc/secubox/peertube/enabled
+After=network.target secubox-core.service
+Requires=secubox-core.service
+Wants=podman.service docker.service
 
 [Service]
 Type=simple
-User=root
-Group=root
+User=secubox
+Group=secubox
 WorkingDirectory=/usr/lib/secubox/peertube
 ExecStart=/usr/bin/python3 -m uvicorn api.main:app --uds /run/secubox/peertube.sock --log-level warning
-ExecStartPost=-/bin/sleep 1
-ExecStartPost=-/bin/chmod 660 /run/secubox/peertube.sock
-ExecStartPost=-/bin/chown secubox:secubox /run/secubox/peertube.sock
 Restart=on-failure
 RestartSec=5
-PrivateTmp=true
+UMask=0000
+
+NoNewPrivileges=true
+RuntimeDirectory=secubox
+RuntimeDirectoryPreserve=yes
+RuntimeDirectoryMode=0775
+
+ReadWritePaths=/run/secubox /var/lib/secubox /etc/secubox /var/log/secubox /data/peertube
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/secubox-peertube/debian/secubox-peertube.sudoers
+++ b/packages/secubox-peertube/debian/secubox-peertube.sudoers
@@ -1,0 +1,9 @@
+# Installed at /etc/sudoers.d/secubox-peertube (mode 0440).
+#
+# Lets the unprivileged dashboard user (secubox) install operator-supplied
+# YouTube cookies into the PeerTube LXC, for the WebExtension/dashboard cookie
+# relay (#401). Tightly scoped: one command + one fixed spool path — the
+# dashboard writes the Netscape cookies body to /run/secubox/peertube-yt-cookies.txt
+# then runs exactly this command, which copies them into the LXC, enables the
+# import cookies feature, and restarts PeerTube.
+secubox ALL=(root) NOPASSWD: /usr/sbin/peertubectl set-youtube-cookies /run/secubox/peertube-yt-cookies.txt

--- a/packages/secubox-peertube/lib/peertube/install-lxc.sh
+++ b/packages/secubox-peertube/lib/peertube/install-lxc.sh
@@ -1,0 +1,405 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# SecuBox-Deb :: secubox-peertube :: install-lxc.sh
+# CyberMind — https://cybermind.fr
+#
+# Idempotent native-LXC bootstrap for the PeerTube module. Safe to re-run.
+# Follows docs/MODULE-GUIDELINES.md §3 (mirror of grafana/yacy/rustdesk).
+#
+# PeerTube is installed NATIVELY inside a dedicated Debian LXC (its own
+# systemd `peertube.service`), NOT in a Docker/Podman container — podman in
+# an unprivileged LXC repeatedly hits CNI bridge / iptables failures on the
+# Marvell arm64 boards. The host nginx vhost proxies the public hostname to
+# this LXC at <LXC_IP>:9000.
+#
+# Stack inside the LXC: Node 22 (PeerTube 8.x requires >=22) + PostgreSQL 15
+# + Redis + ffmpeg, installed via pnpm. msgpackr-extract native acceleration
+# is disabled (arm64 prebuilt binding is broken; JS fallback is correct).
+
+set -euo pipefail
+
+readonly LXC_NAME="${SECUBOX_LXC_NAME:-peertube}"
+readonly LXC_IP="${SECUBOX_LXC_IP:-10.100.0.120}"
+readonly LXC_PATH="${SECUBOX_LXC_PATH:-/data/lxc}"
+readonly LXC_BRIDGE="${SECUBOX_LXC_BRIDGE:-br-lxc}"
+readonly LXC_GW="${SECUBOX_LXC_GW:-10.100.0.1}"
+readonly DEBIAN_SUITE="${SECUBOX_DEBIAN_SUITE:-bookworm}"
+readonly DATA_DIR="${SECUBOX_DATA_DIR:-/data/peertube}"
+readonly STATE_DIR="${SECUBOX_STATE_DIR:-/var/lib/secubox/peertube}"
+readonly SECRETS_DIR="${SECUBOX_SECRETS_DIR:-/etc/secubox/secrets}"
+readonly SENTINEL="$STATE_DIR/.lxc-provisioned"
+# Public hostname baked into PeerTube's webserver config. Override per board.
+readonly PUBLIC_HOSTNAME="${SECUBOX_PEERTUBE_HOSTNAME:-peertube.gk2.secubox.in}"
+# LXC root's host-side UID (idmap u 0 100000) — bind-mounts must be owned by
+# this so LXC root can chown them to the in-container service UIDs.
+readonly LXC_ROOT_UID="${SECUBOX_LXC_ROOT_UID:-100000}"
+
+log()  { printf '[peertube-install] %s\n' "$*"; }
+fail() { printf '[peertube-install] ERROR: %s\n' "$*" >&2; exit 1; }
+
+la() { lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- "$@"; }
+
+# ── Preflight ────────────────────────────────────────────────────────────────
+require_cmds() {
+    for c in lxc-create lxc-info lxc-start lxc-attach openssl; do
+        command -v "$c" >/dev/null 2>&1 || fail "$c not installed"
+    done
+}
+
+ensure_dirs() {
+    install -d -m 0755 -o root -g root "$LXC_PATH"
+    install -d -m 0755 -o secubox -g secubox "$STATE_DIR" 2>/dev/null \
+        || install -d -m 0755 "$STATE_DIR"
+    install -d -m 0700 -o root -g root "$SECRETS_DIR"
+    # Bind-mount targets, owned by the LXC root UID so the container can chown
+    # them to postgres/redis/peertube during install.
+    for d in storage config postgres redis; do
+        install -d -m 0750 "$DATA_DIR/$d"
+    done
+    chown -R "$LXC_ROOT_UID:$LXC_ROOT_UID" "$DATA_DIR"
+}
+
+ensure_bridge() {
+    if ! ip link show "$LXC_BRIDGE" >/dev/null 2>&1; then
+        log "Creating bridge $LXC_BRIDGE @ ${LXC_GW}/24 ..."
+        ip link add name "$LXC_BRIDGE" type bridge
+        ip addr add "${LXC_GW}/24" dev "$LXC_BRIDGE"
+        ip link set "$LXC_BRIDGE" up
+        cat > /etc/systemd/network/10-secubox-lxc-bridge.netdev <<EOF
+[NetDev]
+Name=$LXC_BRIDGE
+Kind=bridge
+EOF
+        cat > /etc/systemd/network/10-secubox-lxc-bridge.network <<EOF
+[Match]
+Name=$LXC_BRIDGE
+
+[Network]
+Address=${LXC_GW}/24
+ConfigureWithoutCarrier=yes
+IPMasquerade=ipv4
+EOF
+        systemctl reload systemd-networkd 2>/dev/null || true
+    fi
+}
+
+ensure_masquerade() {
+    # NAT outbound from 10.100.0.0/24 so the LXC can reach the internet (apt,
+    # NodeSource, GitHub release download). systemd-networkd's IPMasquerade
+    # only lands when it manages the bridge; add an explicit nft rule too.
+    if ! nft list table ip lxc 2>/dev/null | grep -q 'saddr 10.100.0.0/24'; then
+        log "Adding nftables MASQUERADE for 10.100.0.0/24 ..."
+        nft 'add table ip lxc' 2>/dev/null || true
+        nft 'add chain ip lxc postrouting { type nat hook postrouting priority srcnat ; policy accept ; }' 2>/dev/null || true
+        nft 'add rule ip lxc postrouting ip saddr 10.100.0.0/24 ip daddr != 10.100.0.0/24 counter masquerade' 2>/dev/null || true
+    fi
+}
+
+# ── LXC lifecycle ────────────────────────────────────────────────────────────
+lxc_state() {
+    lxc-info -n "$LXC_NAME" -P "$LXC_PATH" 2>/dev/null \
+        | awk -F: '/^State:/ { gsub(/ /,"",$2); print tolower($2) }'
+}
+
+create_lxc() {
+    if [ -d "$LXC_PATH/$LXC_NAME/rootfs" ]; then
+        log "LXC '$LXC_NAME' already exists at $LXC_PATH — skipping debootstrap"
+        return
+    fi
+    log "Creating LXC '$LXC_NAME' (debian $DEBIAN_SUITE) ..."
+    lxc-create -n "$LXC_NAME" -t download -P "$LXC_PATH" -- \
+        --dist debian --release "$DEBIAN_SUITE" --arch "$(dpkg --print-architecture)"
+}
+
+write_lxc_config() {
+    log "Pinning LXC network: $LXC_IP/24 on $LXC_BRIDGE; bind mounts under $DATA_DIR"
+    # NOTE: debian.common.conf (NOT common.conf) — postgresql-15's postinst +
+    # initdb fail under the stricter common.conf+apparmor=generated defaults
+    # in an unprivileged LXC. debian.common.conf is the working template.
+    cat > "$LXC_PATH/$LXC_NAME/config" <<EOF
+# SecuBox-managed — see secubox-peertube / install-lxc.sh
+lxc.include = /usr/share/lxc/config/debian.common.conf
+lxc.arch = linux64
+
+lxc.idmap = u 0 $LXC_ROOT_UID 65536
+lxc.idmap = g 0 $LXC_ROOT_UID 65536
+
+lxc.rootfs.path = dir:$LXC_PATH/$LXC_NAME/rootfs
+lxc.uts.name = $LXC_NAME
+
+lxc.net.0.type = veth
+lxc.net.0.link = $LXC_BRIDGE
+lxc.net.0.flags = up
+lxc.net.0.ipv4.address = $LXC_IP/24
+lxc.net.0.ipv4.gateway = $LXC_GW
+lxc.net.0.name = eth0
+
+# Persist user data + DB outside the container so backups/upgrades are clean.
+lxc.mount.entry = $DATA_DIR/storage var/www/peertube/storage none bind,create=dir 0 0
+lxc.mount.entry = $DATA_DIR/config var/www/peertube/config none bind,create=dir 0 0
+lxc.mount.entry = $DATA_DIR/postgres var/lib/postgresql none bind,create=dir 0 0
+lxc.mount.entry = $DATA_DIR/redis var/lib/redis none bind,create=dir 0 0
+
+# Memory cap (soft) — peertube + postgres + redis + node ≈ 800-1200M peak.
+# Tune via /etc/secubox/tuning/lxc-memory-high.toml (secubox-system-tuning).
+lxc.cgroup2.memory.high = 1500M
+lxc.cgroup2.memory.max = 2G
+
+lxc.start.auto = 1
+lxc.start.delay = 5
+EOF
+}
+
+ensure_resolv() {
+    log "Seeding /etc/resolv.conf in LXC ..."
+    la sh -c 'rm -f /etc/resolv.conf; printf "nameserver 1.1.1.1\nnameserver 9.9.9.9\n" > /etc/resolv.conf'
+}
+
+start_lxc() {
+    if [ "$(lxc_state)" = "running" ]; then
+        log "LXC '$LXC_NAME' already running"
+        return
+    fi
+    log "Starting LXC '$LXC_NAME' ..."
+    lxc-start -n "$LXC_NAME" -P "$LXC_PATH"
+}
+
+wait_for_network() {
+    log "Waiting for LXC network ..."
+    for _ in $(seq 1 30); do
+        if la ping -c1 -W1 "$LXC_GW" >/dev/null 2>&1; then return 0; fi
+        sleep 1
+    done
+    fail "LXC '$LXC_NAME' did not reach $LXC_GW within 30s"
+}
+
+# ── PeerTube install inside LXC ──────────────────────────────────────────────
+install_peertube_in_lxc() {
+    log "Installing PeerTube (native) in '$LXC_NAME' — this takes several minutes ..."
+    local db_pw
+    db_pw="$(cat "$SECRETS_DIR/peertube-db" 2>/dev/null || true)"
+    if [ -z "$db_pw" ]; then
+        db_pw="$(openssl rand -hex 16)"
+        echo "$db_pw" > "$SECRETS_DIR/peertube-db"
+        chmod 600 "$SECRETS_DIR/peertube-db"
+    fi
+    local pt_secret
+    pt_secret="$(cat "$SECRETS_DIR/peertube-secret" 2>/dev/null || true)"
+    if [ -z "$pt_secret" ]; then
+        pt_secret="$(openssl rand -hex 32)"
+        echo "$pt_secret" > "$SECRETS_DIR/peertube-secret"
+        chmod 600 "$SECRETS_DIR/peertube-secret"
+    fi
+
+    la env \
+        DB_PW="$db_pw" PT_SECRET="$pt_secret" PUBLIC_HOSTNAME="$PUBLIC_HOSTNAME" \
+        DEBIAN_FRONTEND=noninteractive LC_ALL=C LANG=C \
+        bash -e <<'INNER'
+set -euo pipefail
+
+echo '[1/8] apt prereqs'
+apt-get update -q
+apt-get install -y -q --no-install-recommends \
+    curl sudo unzip ca-certificates gnupg ffmpeg postgresql postgresql-contrib \
+    openssl g++ make redis-server git python3 python3-pip python-is-python3 cron wget
+
+echo '[2/8] Node 22 (NodeSource, signed apt repo — no curl|bash)'
+if ! node -v 2>/dev/null | grep -qE '^v(2[2-9]|[3-9][0-9])'; then
+    install -d /etc/apt/keyrings
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+    chmod 644 /etc/apt/keyrings/nodesource.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list
+    apt-get update -q
+    apt-get install -y -q --allow-downgrades nodejs
+fi
+corepack enable || true
+
+echo '[3/8] peertube system user'
+id -u peertube >/dev/null 2>&1 || useradd -m -d /var/www/peertube -s /bin/bash peertube
+
+echo '[4/8] postgres + redis + database'
+service postgresql start || systemctl start postgresql || true
+service redis-server start || systemctl start redis-server || true
+sleep 3
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='peertube'" | grep -q 1 || \
+    sudo -u postgres psql -c "CREATE USER peertube WITH PASSWORD '${DB_PW}';"
+sudo -u postgres psql -c "ALTER USER peertube WITH PASSWORD '${DB_PW}';"
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='peertube_prod'" | grep -q 1 || \
+    sudo -u postgres createdb -O peertube -E UTF8 -T template0 peertube_prod
+sudo -u postgres psql -d peertube_prod -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"   2>/dev/null || true
+sudo -u postgres psql -d peertube_prod -c "CREATE EXTENSION IF NOT EXISTS unaccent;"  2>/dev/null || true
+
+echo '[5/8] download PeerTube release'
+install -d -o peertube -g peertube /var/www/peertube
+cd /var/www/peertube
+sudo -u peertube mkdir -p versions config storage
+VERSION=$(curl -s https://api.github.com/repos/Chocobozzz/PeerTube/releases/latest | grep tag_name | cut -d '"' -f 4)
+echo "  installing PeerTube $VERSION"
+cd versions
+if [ ! -d "peertube-$VERSION" ]; then
+    sudo -u peertube wget -q "https://github.com/Chocobozzz/PeerTube/releases/download/$VERSION/peertube-$VERSION.zip"
+    sudo -u peertube unzip -q "peertube-$VERSION.zip"
+    rm -f "peertube-$VERSION.zip"
+fi
+cd /var/www/peertube
+sudo -u peertube ln -sfn "versions/peertube-$VERSION" peertube-latest
+
+echo '[6/8] pnpm install (MSGPACKR native accel disabled for arm64)'
+cd /var/www/peertube/peertube-latest
+sudo -H -u peertube --preserve-env=MSGPACKR_NATIVE_ACCELERATION_DISABLED \
+    env MSGPACKR_NATIVE_ACCELERATION_DISABLED=1 \
+    pnpm install --prod --frozen-lockfile --reporter=append-only
+
+echo '[7/8] config (production.yaml)'
+sudo -u peertube cp -n /var/www/peertube/peertube-latest/config/default.yaml            /var/www/peertube/config/default.yaml
+sudo -u peertube cp -n /var/www/peertube/peertube-latest/config/production.yaml.example /var/www/peertube/config/production.yaml
+python3 - "$PUBLIC_HOSTNAME" "$PT_SECRET" "$DB_PW" <<'PY'
+import re, sys, pathlib
+hostname, secret, db_pw = sys.argv[1], sys.argv[2], sys.argv[3]
+p = pathlib.Path('/var/www/peertube/config/production.yaml')
+lines = p.read_text().splitlines()
+
+def find_in_block(top, sub):
+    in_blk = False
+    for i, l in enumerate(lines):
+        if re.match(rf'^{re.escape(top)}\s*:', l):
+            in_blk = True; continue
+        if in_blk:
+            if l and not l.startswith((' ', '\t', '#')):
+                return None
+            if re.match(rf'^\s+{re.escape(sub)}\s*:', l):
+                return i
+    return None
+
+def set_kv(top, sub, value):
+    i = find_in_block(top, sub)
+    if i is None:
+        return
+    cur = lines[i]; ind = cur[:len(cur)-len(cur.lstrip())]
+    lines[i] = f"{ind}{sub}: {value}"
+
+# listen.hostname 127.0.0.1 -> 0.0.0.0 so the host nginx reaches the LXC iface
+set_kv('listen', 'hostname', "'0.0.0.0'")
+set_kv('listen', 'port', '9000')
+set_kv('webserver', 'https', 'true')
+set_kv('webserver', 'hostname', f"'{hostname}'")
+set_kv('webserver', 'port', '443')
+set_kv('secrets', 'peertube', f"'{secret}'")
+set_kv('database', 'password', f"'{db_pw}'")
+
+for idx, l in enumerate(lines):
+    if re.match(r'^admin\s*:', l):
+        for j in range(idx+1, min(idx+12, len(lines))):
+            if re.match(r'^\s+email\s*:', lines[j]):
+                lines[j] = re.sub(r"(:\s*).*$", r"\1'admin@cybermind.fr'", lines[j]); break
+        break
+
+# Enable native HTTP import (yt-dlp). Path: import → videos → http → enabled.
+# Tracks nesting depth so we only flip the import.videos.http.enabled flag.
+in_import = in_videos = in_http = False
+def indent(s): return len(s) - len(s.lstrip())
+for i, l in enumerate(lines):
+    s = l.strip()
+    if re.match(r'^import\s*:', l) and indent(l) == 0:
+        in_import = True; in_videos = in_http = False; continue
+    if in_import and l and indent(l) == 0 and not l.startswith('#'):
+        in_import = in_videos = in_http = False
+    if in_import and re.match(r'^\s+videos\s*:', l):
+        in_videos = True; in_http = False; continue
+    if in_import and in_videos and re.match(r'^\s+http\s*:', l):
+        in_http = True; continue
+    if in_import and in_videos and in_http and re.match(r'^\s+enabled\s*:', l):
+        ind = l[:indent(l)]
+        lines[i] = f"{ind}enabled: true"
+        in_http = False
+
+p.write_text('\n'.join(lines) + '\n')
+print('  production.yaml patched (incl. import.videos.http.enabled)')
+PY
+
+echo '[8/8] systemd unit + ownership'
+cat > /etc/systemd/system/peertube.service <<'UNIT'
+[Unit]
+Description=PeerTube
+After=network.target postgresql.service redis-server.service
+
+[Service]
+Type=simple
+Environment=NODE_ENV=production
+Environment=NODE_CONFIG_DIR=/var/www/peertube/config
+User=peertube
+ExecStart=/usr/bin/npm start
+WorkingDirectory=/var/www/peertube/peertube-latest
+Restart=always
+RestartSec=5
+LimitNOFILE=30000
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+chown -R peertube:peertube /var/www/peertube
+systemctl daemon-reload
+systemctl enable peertube.service
+systemctl restart peertube.service
+echo '=== PeerTube install complete ==='
+INNER
+}
+
+verify() {
+    log "Verifying PeerTube is listening on $LXC_IP:9000 ..."
+    for _ in $(seq 1 30); do
+        if curl -fsS -o /dev/null --max-time 3 "http://$LXC_IP:9000/api/v1/config"; then
+            log "OK — PeerTube responding."
+            return 0
+        fi
+        sleep 2
+    done
+    log "WARN: PeerTube not yet responding on $LXC_IP:9000 (first boot can take a while; check 'lxc-attach -n $LXC_NAME -P $LXC_PATH -- journalctl -u peertube')."
+}
+
+capture_admin() {
+    # PeerTube logs the auto-generated root password once on first boot. Persist
+    # it to a host secret so the SecuBox dashboard can authenticate for write
+    # ops (video import, user/channel management). Operator should rotate it in
+    # the web UI; if they do, update this file or the dashboard re-auth fails.
+    [ -s "$SECRETS_DIR/peertube-admin" ] && return 0
+    local pw=""
+    for _ in $(seq 1 15); do
+        pw="$(la journalctl -u peertube --no-pager 2>/dev/null \
+            | grep -m1 'User password:' | sed 's/.*User password: //')" || true
+        [ -n "$pw" ] && break
+        sleep 2
+    done
+    if [ -n "$pw" ]; then
+        printf '%s\n' "$pw" > "$SECRETS_DIR/peertube-admin"
+        chmod 600 "$SECRETS_DIR/peertube-admin"
+        log "Initial admin: root / $pw  (saved to $SECRETS_DIR/peertube-admin — rotate via web UI)"
+    else
+        log "WARN: could not capture initial root password from journal; set $SECRETS_DIR/peertube-admin manually for dashboard write ops."
+    fi
+}
+
+mark_provisioned() { date -Iseconds > "$SENTINEL"; }
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+main() {
+    require_cmds
+    ensure_dirs
+    ensure_bridge
+    ensure_masquerade
+    create_lxc
+    write_lxc_config
+    start_lxc
+    wait_for_network
+    ensure_resolv
+    install_peertube_in_lxc
+    verify
+    capture_admin
+    mark_provisioned
+    log "Done — LXC '$LXC_NAME' at $LXC_IP, PeerTube native install running."
+    log "Public URL (wire HAProxy SNI + nginx vhost separately): https://$PUBLIC_HOSTNAME/"
+}
+
+main "$@"

--- a/packages/secubox-peertube/sbin/peertubectl
+++ b/packages/secubox-peertube/sbin/peertubectl
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# SecuBox-Deb :: peertubectl
+# CyberMind — https://cybermind.fr
+#
+# PeerTube host-side controller. PeerTube runs NATIVELY in a Debian LXC
+# (default 10.100.0.120 on br-lxc, peertube.service inside the container).
+# The host nginx vhost proxies the public hostname to <LXC_IP>:9000.
+#
+# Conventions: docs/MODULE-GUIDELINES.md §7 (mirror of grafanactl/giteactl).
+
+set -u
+
+readonly VERSION="1.1.0"
+readonly CONFIG_FILE="${SECUBOX_PEERTUBE_CONFIG:-/etc/secubox/peertube.toml}"
+readonly INSTALL_LIB="${SECUBOX_INSTALL_LIB:-/usr/share/secubox/lib/peertube/install-lxc.sh}"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m'
+
+log()  { printf '%b[peertube]%b %s\n' "$GREEN" "$NC" "$*"; }
+warn() { printf '%b[warn]%b %s\n'    "$YELLOW" "$NC" "$*" >&2; }
+err()  { printf '%b[error]%b %s\n'   "$RED"    "$NC" "$*" >&2; }
+
+# ── TOML config (best-effort, grep-style — same as giteactl/grafanactl) ──────
+config_get() {
+    local key="$1" default="${2:-}" raw=""
+    if [ -f "$CONFIG_FILE" ]; then
+        raw=$(grep -E "^[[:space:]]*${key}[[:space:]]*=" "$CONFIG_FILE" 2>/dev/null | head -1)
+    fi
+    if [ -z "$raw" ]; then echo "$default"; return; fi
+    local val
+    val=$(echo "$raw" | cut -d= -f2- | sed 's/[[:space:]]*#.*$//' \
+        | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' | tr -d '"' | tr -d "'")
+    [ -z "$val" ] && echo "$default" || echo "$val"
+}
+
+LXC_NAME=$(config_get "name" "peertube")
+LXC_IP=$(config_get "ip" "10.100.0.120")
+LXC_PATH=$(config_get "path" "/data/lxc")
+HTTP_PORT=$(config_get "http_port" "9000")
+PUBLIC_HOSTNAME=$(config_get "public_hostname" "peertube.gk2.secubox.in")
+
+# ── LXC helpers ───────────────────────────────────────────────────────────────
+lxc_state() {
+    lxc-info -n "$LXC_NAME" -P "$LXC_PATH" 2>/dev/null \
+        | awk -F: '/^State:/ { gsub(/ /,"",$2); print tolower($2) }'
+}
+lxc_running() { [ "$(lxc_state)" = "running" ]; }
+svc() { lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl "$@" peertube.service; }
+
+# ── Verbs ─────────────────────────────────────────────────────────────────────
+cmd_install() {
+    if [ ! -x "$INSTALL_LIB" ] && [ ! -f "$INSTALL_LIB" ]; then
+        err "install script not found at $INSTALL_LIB (package not installed correctly?)"
+        exit 1
+    fi
+    log "Running LXC bootstrap from $INSTALL_LIB ..."
+    SECUBOX_LXC_NAME="$LXC_NAME" SECUBOX_LXC_IP="$LXC_IP" SECUBOX_LXC_PATH="$LXC_PATH" \
+    SECUBOX_PEERTUBE_HOSTNAME="$PUBLIC_HOSTNAME" \
+        bash "$INSTALL_LIB"
+    log "Done. Try 'peertubectl status' to verify, then wire the nginx vhost + HAProxy ACL."
+}
+
+cmd_status() {
+    local state; state="$(lxc_state)"
+    printf 'LXC %s        : %s\n' "$LXC_NAME" "${state:-absent}"
+    if lxc_running; then
+        local active; active="$(svc is-active 2>/dev/null || true)"
+        printf 'peertube.service : %s\n' "${active:-unknown}"
+        if curl -fsS -o /dev/null --max-time 3 "http://$LXC_IP:$HTTP_PORT/api/v1/config" 2>/dev/null; then
+            printf 'HTTP %s:%s   : responding\n' "$LXC_IP" "$HTTP_PORT"
+        else
+            printf 'HTTP %s:%s   : NOT responding\n' "$LXC_IP" "$HTTP_PORT"
+        fi
+    fi
+    printf 'public URL       : https://%s/\n' "$PUBLIC_HOSTNAME"
+}
+
+cmd_start()   { lxc_running || lxc-start -n "$LXC_NAME" -P "$LXC_PATH"; svc start;   log "started"; }
+cmd_stop()    { lxc_running && svc stop || true;                                     log "stopped"; }
+cmd_restart() { lxc_running || lxc-start -n "$LXC_NAME" -P "$LXC_PATH"; svc restart; log "restarted"; }
+cmd_logs()    { lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- journalctl -u peertube -n "${1:-50}" --no-pager; }
+
+cmd_reload() {
+    if nginx -t 2>/dev/null; then
+        systemctl reload nginx 2>/dev/null && log "host nginx reloaded" || warn "nginx reload failed"
+    else
+        err "nginx -t failed; not reloading"; exit 1
+    fi
+}
+
+cmd_help() {
+    cat <<EOF
+peertubectl $VERSION — SecuBox PeerTube (native-LXC) controller
+
+Usage: peertubectl <verb> [args]
+
+  install            Provision the LXC + install PeerTube natively (idempotent)
+  status             LXC state + peertube.service + HTTP reachability
+  start|stop|restart Control peertube.service inside the LXC
+  logs [N]           Tail N lines of peertube journal (default 50)
+  reload             Reload host nginx (after vhost changes)
+  help               This message
+
+Config: $CONFIG_FILE  (name/ip/path/http_port/public_hostname)
+LXC: $LXC_NAME @ $LXC_IP on br-lxc — public https://$PUBLIC_HOSTNAME/
+EOF
+}
+
+main() {
+    local noun="${1:-help}"; shift || true
+    case "$noun" in
+        install|status|start|stop|restart|logs|reload) "cmd_${noun}" "$@" ;;
+        help|-h|--help) cmd_help ;;
+        *) err "unknown verb: $noun"; cmd_help; exit 1 ;;
+    esac
+}
+
+main "$@"

--- a/packages/secubox-peertube/sbin/peertubectl
+++ b/packages/secubox-peertube/sbin/peertubectl
@@ -92,18 +92,58 @@ cmd_reload() {
     fi
 }
 
+cmd_set_youtube_cookies() {
+    # Install a Netscape-format cookies.txt (exported from a browser logged into
+    # YouTube) so PeerTube's yt-dlp import can fetch YouTube videos. YouTube
+    # hard-blocks server IPs ("Sign in to confirm you're not a bot") — cookies
+    # are the only reliable workaround. Idempotent.
+    local src="${1:-}"
+    [ -n "$src" ] && [ -f "$src" ] || { err "usage: peertubectl set-youtube-cookies <cookies.txt>"; exit 1; }
+    lxc_running || { err "LXC '$LXC_NAME' not running"; exit 1; }
+    log "Installing YouTube cookies into $LXC_NAME ..."
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- bash -c '
+        d=/var/www/peertube/storage/tmp-persistent
+        install -d -o peertube -g peertube "$d"
+        cat > "$d/youtube-cookies.txt"
+        chown peertube:peertube "$d/youtube-cookies.txt"
+        chmod 600 "$d/youtube-cookies.txt"
+    ' < "$src"
+    # Ensure the cookies feature is enabled in production.yaml.
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- python3 - <<'PY'
+import re, pathlib
+p = pathlib.Path('/var/www/peertube/config/production.yaml')
+lines = p.read_text().splitlines()
+ind = lambda s: len(s) - len(s.lstrip())
+imp=vid=http=ck=False; chg=False
+for i,l in enumerate(lines):
+    if re.match(r'^import\s*:', l) and ind(l)==0: imp=True; vid=http=ck=False; continue
+    if imp and l and ind(l)==0 and not l.startswith('#'): imp=vid=http=ck=False
+    if imp and re.match(r'^\s+videos\s*:', l): vid=True; http=ck=False; continue
+    if imp and vid and re.match(r'^\s+http\s*:', l): http=True; ck=False; continue
+    if imp and vid and http and re.match(r'^\s+cookies\s*:', l): ck=True; continue
+    if ck and re.match(r'^\s+enabled\s*:', l): lines[i]=l[:ind(l)]+'enabled: true'; ck=False; chg=True
+p.write_text('\n'.join(lines)+'\n')
+print('cookies enabled' if chg else 'cookies flag unchanged')
+PY
+    log "Cookies installed + enabled. Restarting PeerTube ..."
+    svc restart
+    log "Done. Retry the import from the PeerTube 'Import with URL' page."
+}
+
 cmd_help() {
     cat <<EOF
 peertubectl $VERSION — SecuBox PeerTube (native-LXC) controller
 
 Usage: peertubectl <verb> [args]
 
-  install            Provision the LXC + install PeerTube natively (idempotent)
-  status             LXC state + peertube.service + HTTP reachability
-  start|stop|restart Control peertube.service inside the LXC
-  logs [N]           Tail N lines of peertube journal (default 50)
-  reload             Reload host nginx (after vhost changes)
-  help               This message
+  install                       Provision the LXC + install PeerTube (idempotent)
+  status                        LXC state + peertube.service + HTTP reachability
+  start|stop|restart            Control peertube.service inside the LXC
+  set-youtube-cookies <file>    Install browser-exported YouTube cookies.txt so
+                                yt-dlp import works (YouTube blocks server IPs)
+  logs [N]                      Tail N lines of peertube journal (default 50)
+  reload                        Reload host nginx (after vhost changes)
+  help                          This message
 
 Config: $CONFIG_FILE  (name/ip/path/http_port/public_hostname)
 LXC: $LXC_NAME @ $LXC_IP on br-lxc — public https://$PUBLIC_HOSTNAME/
@@ -114,6 +154,7 @@ main() {
     local noun="${1:-help}"; shift || true
     case "$noun" in
         install|status|start|stop|restart|logs|reload) "cmd_${noun}" "$@" ;;
+        set-youtube-cookies) cmd_set_youtube_cookies "$@" ;;
         help|-h|--help) cmd_help ;;
         *) err "unknown verb: $noun"; cmd_help; exit 1 ;;
     esac

--- a/packages/secubox-peertube/www/peertube/index.html
+++ b/packages/secubox-peertube/www/peertube/index.html
@@ -330,6 +330,7 @@
         <!-- Tabs -->
         <div class="tabs">
             <div class="tab active" onclick="showTab('videos')">Videos</div>
+            <div class="tab" onclick="showTab('import')">Import</div>
             <div class="tab" onclick="showTab('channels')">Channels</div>
             <div class="tab" onclick="showTab('users')">Users</div>
             <div class="tab" onclick="showTab('federation')">Federation</div>
@@ -345,6 +346,48 @@
                 <div id="videoGrid" class="video-grid">
                     <p style="color: var(--text-dim);">Loading videos...</p>
                 </div>
+            </div>
+        </div>
+
+        <!-- Import URL Tab (yt-dlp via PeerTube native HTTP import) -->
+        <div id="tab-import" class="tab-content">
+            <div class="card">
+                <h3>Import a video from a URL</h3>
+                <p style="color: var(--text-dim); margin-bottom: 1rem;">
+                    Downloads a video from YouTube, Vimeo, a direct file link, etc.
+                    straight into this PeerTube instance (yt-dlp under the hood).
+                </p>
+                <form id="importForm" onsubmit="importVideo(event)">
+                    <div class="form-group">
+                        <label>Video URL</label>
+                        <input type="url" id="importUrl" placeholder="https://www.youtube.com/watch?v=..." required>
+                    </div>
+                    <div class="form-group">
+                        <label>Title (optional — PeerTube derives one if empty)</label>
+                        <input type="text" id="importName" placeholder="My imported video">
+                    </div>
+                    <div class="form-group">
+                        <label>Channel</label>
+                        <select id="importChannel"></select>
+                    </div>
+                    <div class="form-group">
+                        <label>Privacy</label>
+                        <select id="importPrivacy">
+                            <option value="1">Public</option>
+                            <option value="2">Unlisted</option>
+                            <option value="3" selected>Private</option>
+                            <option value="4">Internal</option>
+                        </select>
+                    </div>
+                    <button type="submit" class="btn btn-primary">Import</button>
+                </form>
+            </div>
+            <div class="card">
+                <h3>Recent imports</h3>
+                <table>
+                    <thead><tr><th>Target URL</th><th>Video</th><th>State</th><th>Created</th></tr></thead>
+                    <tbody id="importsTable"><tr><td colspan="4" style="color: var(--text-dim);">Loading...</td></tr></tbody>
+                </table>
             </div>
         </div>
 
@@ -561,7 +604,7 @@
         <!-- Logs Tab -->
         <div id="tab-logs" class="tab-content">
             <div class="card">
-                <h3>Container Logs</h3>
+                <h3>PeerTube Logs (peertube.service in LXC)</h3>
                 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; align-items: center;">
                     <label>Lines:</label>
                     <select id="logLines" onchange="loadLogs()">
@@ -577,8 +620,8 @@
             <div class="card">
                 <h3>Maintenance</h3>
                 <div style="display: flex; gap: 1rem; flex-wrap: wrap;">
-                    <button class="btn" onclick="restartPeerTube()">Restart Container</button>
-                    <button class="btn btn-danger" onclick="uninstallPeerTube()">Uninstall</button>
+                    <button class="btn" onclick="restartPeerTube()">Restart LXC</button>
+                    <button class="btn btn-danger" onclick="uninstallPeerTube()">Stop LXC (keep data)</button>
                 </div>
             </div>
         </div>
@@ -608,7 +651,7 @@
         function showTab(name) {
             document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
             document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
-            const tabs = ['videos', 'channels', 'users', 'federation', 'transcoding', 'plugins', 'logs'];
+            const tabs = ['videos', 'import', 'channels', 'users', 'federation', 'transcoding', 'plugins', 'logs'];
             const idx = tabs.indexOf(name);
             if (idx >= 0) {
                 document.querySelectorAll('.tab')[idx].classList.add('active');
@@ -617,6 +660,7 @@
 
             // Load tab-specific data
             if (name === 'videos') loadVideos();
+            else if (name === 'import') { loadImportChannels(); loadImports(); }
             else if (name === 'channels') loadChannels();
             else if (name === 'users') loadUsers();
             else if (name === 'federation') { loadFollowing(); loadFollowers(); }
@@ -674,11 +718,11 @@
                     btn.onclick = () => toggleService();
                 }
 
-                // Open PeerTube link
+                // Open PeerTube link → public URL (HAProxy/nginx vhost)
                 const openLink = document.getElementById('openPeerTube');
                 if (isRunning) {
                     openLink.style.display = 'inline-flex';
-                    openLink.href = `http://${window.location.hostname}:${status.http_port}`;
+                    openLink.href = status.public_url || `https://${status.domain}/`;
                 } else {
                     openLink.style.display = 'none';
                 }
@@ -713,14 +757,13 @@
         }
 
         async function installPeerTube() {
-            if (!confirm('Install PeerTube? This will download the Docker image (~1GB).')) return;
-            toast('Installing PeerTube... This may take several minutes.');
+            if (!confirm('Provision the PeerTube LXC and install natively (Node 22 + PostgreSQL + Redis)? This runs in the background and takes several minutes.')) return;
+            toast('Installing PeerTube in its LXC... follow Logs / peertubectl logs.');
             try {
                 const res = await api('/container/install', { method: 'POST' });
                 if (res.success) {
-                    toast('PeerTube installed! Starting...');
-                    await api('/container/start', { method: 'POST' });
-                    await refresh();
+                    toast(res.message || 'Install started in background.');
+                    setTimeout(refresh, 5000);
                 } else {
                     toast(res.error || 'Install failed', 'error');
                 }
@@ -732,7 +775,7 @@
         // Videos
         async function loadVideos() {
             if (!isRunning) {
-                document.getElementById('videoGrid').innerHTML = '<p style="color: var(--text-dim);">Container not running</p>';
+                document.getElementById('videoGrid').innerHTML = '<p style="color: var(--text-dim);">PeerTube not reachable</p>';
                 return;
             }
             try {
@@ -753,6 +796,68 @@
                 }
             } catch (e) {
                 document.getElementById('videoGrid').innerHTML = '<p style="color: var(--error);">Error loading videos</p>';
+            }
+        }
+
+        // Import from URL (yt-dlp via PeerTube native HTTP import)
+        async function loadImportChannels() {
+            const sel = document.getElementById('importChannel');
+            try {
+                const data = await api('/channels');
+                const chans = data.channels || [];
+                if (chans.length === 0) {
+                    sel.innerHTML = '<option value="">(no channel — create one first)</option>';
+                } else {
+                    sel.innerHTML = chans.map(c =>
+                        `<option value="${c.id}">${c.displayName || c.name}</option>`).join('');
+                }
+            } catch (e) {
+                sel.innerHTML = '<option value="">(error loading channels)</option>';
+            }
+        }
+
+        async function loadImports() {
+            const tbody = document.getElementById('importsTable');
+            try {
+                const data = await api('/imports');
+                const imports = data.imports || [];
+                if (imports.length === 0) {
+                    tbody.innerHTML = `<tr><td colspan="4" style="color: var(--text-dim);">${data.error || 'No imports yet'}</td></tr>`;
+                    return;
+                }
+                tbody.innerHTML = imports.map(im => {
+                    const url = im.targetUrl || im.magnetUri || '-';
+                    const vid = (im.video && (im.video.name || im.video.uuid)) || '-';
+                    const state = (im.state && (im.state.label || im.state.id)) || '-';
+                    const created = im.createdAt ? new Date(im.createdAt).toLocaleString() : '-';
+                    return `<tr><td style="max-width:340px;overflow:hidden;text-overflow:ellipsis;">${url}</td><td>${vid}</td><td>${state}</td><td>${created}</td></tr>`;
+                }).join('');
+            } catch (e) {
+                tbody.innerHTML = '<tr><td colspan="4" style="color: var(--error);">Error loading imports</td></tr>';
+            }
+        }
+
+        async function importVideo(event) {
+            event.preventDefault();
+            const target_url = document.getElementById('importUrl').value.trim();
+            const name = document.getElementById('importName').value.trim();
+            const channel_id = parseInt(document.getElementById('importChannel').value, 10);
+            const privacy = parseInt(document.getElementById('importPrivacy').value, 10);
+            if (!target_url) { toast('URL required', 'error'); return; }
+            const body = { target_url, privacy };
+            if (name) body.name = name;
+            if (!isNaN(channel_id)) body.channel_id = channel_id;
+            try {
+                const res = await api('/import', { method: 'POST', body: JSON.stringify(body) });
+                if (res.success) {
+                    toast('Import queued — PeerTube is downloading the video.');
+                    document.getElementById('importForm').reset();
+                    loadImports();
+                } else {
+                    toast(res.error || 'Import failed', 'error');
+                }
+            } catch (e) {
+                toast('Import failed: ' + e.message, 'error');
             }
         }
 
@@ -1134,7 +1239,7 @@
         }
 
         async function uninstallPeerTube() {
-            if (!confirm('Uninstall PeerTube? Container will be removed but data is preserved.')) return;
+            if (!confirm('Stop the PeerTube LXC? The container stops but all data on /data/peertube is preserved.')) return;
             try {
                 const res = await api('/container/uninstall', { method: 'POST' });
                 if (res.success) {


### PR DESCRIPTION
## Summary

Aligns `secubox-peertube` with what is actually deployed and validated on gk2
(https://peertube.gk2.secubox.in/, upload confirmed) and adds yt-dlp URL import.
**Supersedes #390** — its public vhost is folded in here with the proxy port
corrected to the real LXC `:9000` (the old `127.0.0.1:9001` was a stale
Docker-on-host assumption; all SecuBox vhosts share `:9080` and differ by
`server_name`, so there is no lyrion collision).

PeerTube now runs **natively inside a dedicated Debian LXC** (Node 22 +
PostgreSQL 15 + Redis + ffmpeg, its own `peertube.service`), not Docker/Podman
— an unprivileged LXC can't reliably bring up a podman CNI bridge on the
Marvell arm64 boards.

## Changes

- **`lib/peertube/install-lxc.sh`** (new): idempotent native install, mirroring
  grafana/yacy. Bakes in every fix from the live bring-up — Node 22 via signed
  NodeSource repo (8.x needs ≥22; no `curl|bash`), pnpm with
  `MSGPACKR_NATIVE_ACCELERATION_DISABLED=1` (arm64), `debian.common.conf`
  template (postgres-15 needs it), `/data/peertube/{storage,config,postgres,redis}`
  bind mounts chown'd to the LXC root UID, `production.yaml` patch
  (listen `0.0.0.0:9000`, https/hostname/443, generated secret, db pw, admin
  email, `import.videos.http.enabled=true`), and captures the first-boot root
  password to `/etc/secubox/secrets/peertube-admin`.
- **`sbin/peertubectl`** (new): install/status/start/stop/restart/logs/reload.
- **`conf/peertube.nginx.conf`** (new, folds #390): public vhost `:9080` →
  `10.100.0.120:9000`, 8G uploads, 7d streaming timeouts, WS, ACME; WAF-bypass
  (gitea pattern). postinst symlinks it into sites-enabled.
- **`api/main.py`**: rewritten to talk to the native instance over HTTP at
  `<lxc_ip>:<http_port>` (with the `Host:` header PeerTube requires) instead of
  `podman/docker exec`. Real LXC-state status. `/container/*` drive the LXC via
  peertubectl. New `POST /import` + `GET /imports`.
- **`www/peertube/index.html`**: new **Import** tab (URL + channel + privacy +
  recent imports); status/labels/links corrected for native-LXC.
- **`debian/control` + service**: reframed Docker/Podman → native-LXC; dropped
  `Wants=podman/docker`. New `conf/peertube.toml.example`. Bumped **1.1.0**.

## Test plan

- [x] Live install validated on gk2 (upload confirmed by operator)
- [x] Native HTTP import (yt-dlp) enabled + verified on the live instance
- [x] `python -m py_compile api/main.py`, `bash -n` install-lxc.sh + peertubectl
- [ ] Rebuild `.deb` (arm64) and deploy to gk2 to exercise the corrected
      dashboard + Import tab end-to-end
- [ ] `peertubectl install` on a clean board (full native bootstrap)