### PR TITLE
secubox-photoprism 1.1.0: native-LXC rework + Nextcloud photo integration (#397)

### DIFF
--- a/packages/secubox-photoprism/README.md
+++ b/packages/secubox-photoprism/README.md
@@ -8,26 +8,47 @@ AI-powered photo management
 
 ![PhotoPrism](../../docs/screenshots/vm/photoprism.png)
 
+**Deployment:** PhotoPrism runs as a **podman container inside a dedicated
+Debian LXC** (`--network=host`), provisioned by `photoprismctl install`. The
+host nginx vhost (`:9080`) proxies the public hostname to the LXC at
+`10.100.0.130:2342`.
+
+## Nextcloud photo integration
+
+Photos live on the host at `/data/shared/photos`, bind-mounted into PhotoPrism
+as `originals` **and** exposed in Nextcloud as the **"PhotoLibrary"** external
+storage. Flow:
+
+```
+phone (Nextcloud app, auto-upload → PhotoLibrary)
+  → Nextcloud  → /data/shared/photos  → PhotoPrism originals
+                                         → indexed every 15 min (photoprism-index.timer)
+```
+
+PhotoPrism's built-in auto-index only fires for uploads through its *own* UI,
+so the timer is what picks up Nextcloud-synced files.
+
 ## Features
 
-- Face recognition
-- Auto-tagging
-- Search
-- Albums
+- Face recognition, auto-tagging, search, albums
+- Nextcloud photo integration (shared library + auto-index)
 
 ## Installation
 
 ```bash
-# Add SecuBox repository
-curl -fsSL https://apt.secubox.in/install.sh | sudo bash
-
-# Install package
-sudo apt install secubox-photoprism
+sudo apt install secubox-photoprism   # host dashboard daemon
+photoprismctl install                 # provisions the LXC + podman + PhotoPrism
+photoprismctl status                  # LXC + service + reachability + index timer
+photoprismctl index                   # force an immediate index
 ```
+
+Admin password is generated to `/etc/secubox/secrets/photoprism-admin`
+(rotate via the UI). Wire the public hostname via HAProxy SNI ACL + ACME.
 
 ## Configuration
 
-Configuration file: `/etc/secubox/photoprism.toml`
+`/etc/secubox/photoprism.toml` — `[lxc]`, `[photoprism]` (http_port, image,
+auto_index, originals), `[exposure]` (public_hostname).
 
 ## API Endpoints
 

--- a/packages/secubox-photoprism/api/main.py
+++ b/packages/secubox-photoprism/api/main.py
@@ -4,7 +4,6 @@ Provides PhotoPrism Docker container management with library indexing,
 face recognition, album management, and storage configuration.
 """
 import asyncio
-import shutil
 import subprocess
 import json
 from datetime import datetime
@@ -34,16 +33,27 @@ log = get_logger("photoprism")
 
 # Configuration
 CONFIG_FILE = Path("/etc/secubox/photoprism.toml")
-CONTAINER_NAME = "secbx-photoprism"
+INSTALL_LIB = "/usr/share/secubox/lib/photoprism/install-lxc.sh"
+PHOTOPRISMCTL = "/usr/sbin/photoprismctl"
+# PhotoPrism runs as the `photoprism` podman container INSIDE the photoprism
+# LXC (see lib/photoprism/install-lxc.sh), not on the host.
+CONTAINER_NAME = "photoprism"
 DEFAULT_CONFIG = {
+    # LXC
+    "name": "photoprism",
+    "ip": "10.100.0.130",
+    "path": "/data/lxc",
+    # PhotoPrism (inside the LXC)
     "enabled": False,
-    "image": "photoprism/photoprism:latest",
+    "image": "docker.io/photoprism/photoprism:latest",
     "port": 2342,
-    "data_path": "/srv/photoprism",
-    "originals_path": "/srv/photoprism/originals",
-    "import_path": "/srv/photoprism/import",
+    "http_port": 2342,
+    "data_path": "/data/photoprism",
+    "originals_path": "/data/shared/photos",   # shared with Nextcloud "PhotoLibrary"
+    "import_path": "/data/photoprism/import",
     "timezone": "Europe/Paris",
-    "domain": "photos.secubox.local",
+    "domain": "photoprism.gk2.secubox.in",
+    "public_hostname": "photoprism.gk2.secubox.in",
     "haproxy": False,
     "face_recognition": True,
     "experimental": False,
@@ -93,14 +103,21 @@ class RestoreRequest(BaseModel):
 # ============================================================================
 
 def get_config() -> dict:
-    """Load photoprism configuration."""
+    """Load + flatten photoprism.toml ([lxc]/[photoprism]/[exposure]) over defaults."""
+    cfg = DEFAULT_CONFIG.copy()
     if CONFIG_FILE.exists():
         try:
             import tomllib
-            return tomllib.loads(CONFIG_FILE.read_text())
+            raw = tomllib.loads(CONFIG_FILE.read_text())
+            for section in ("lxc", "photoprism", "exposure"):
+                for k, v in (raw.get(section) or {}).items():
+                    cfg[k] = v
+            for k, v in raw.items():        # tolerate flat keys too
+                if not isinstance(v, dict):
+                    cfg[k] = v
         except Exception:
             pass
-    return DEFAULT_CONFIG.copy()
+    return cfg
 
 
 def save_config(config: dict):
@@ -119,46 +136,72 @@ def save_config(config: dict):
     CONFIG_FILE.write_text("\n".join(lines) + "\n")
 
 
-def detect_runtime() -> Optional[str]:
-    """Detect container runtime."""
-    if shutil.which("podman"):
-        return "podman"
-    if shutil.which("docker"):
-        return "docker"
-    return None
+def http_reachable() -> bool:
+    """True if PhotoPrism answers on <ip>:<http_port> (inside its LXC)."""
+    cfg = get_config()
+    ip = cfg.get("ip", "10.100.0.130")
+    port = cfg.get("http_port", cfg.get("port", 2342))
+    try:
+        r = subprocess.run(
+            ["curl", "-fsS", "-o", "/dev/null", "--max-time", "3", f"http://{ip}:{port}/"],
+            capture_output=True, timeout=5,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def lxc_state() -> str:
+    """LXC container state (best-effort; the dashboard user may lack access)."""
+    cfg = get_config()
+    try:
+        r = subprocess.run(
+            ["lxc-info", "-n", cfg.get("name", "photoprism"), "-P", cfg.get("path", "/data/lxc")],
+            capture_output=True, text=True, timeout=5,
+        )
+        for line in r.stdout.splitlines():
+            if line.strip().lower().startswith("state:"):
+                return line.split(":", 1)[1].strip().lower()
+    except Exception:
+        pass
+    return "unknown"
 
 
 def get_container_status() -> dict:
-    """Get PhotoPrism container status."""
-    rt = detect_runtime()
-    if not rt:
-        return {"status": "no_runtime", "uptime": ""}
-
-    try:
-        # Check if running
-        result = subprocess.run(
-            [rt, "ps", "--filter", f"name={CONTAINER_NAME}", "--format", "{{.Status}}"],
-            capture_output=True, text=True, timeout=5
-        )
-        if result.stdout.strip():
-            return {"status": "running", "uptime": result.stdout.strip()}
-
-        # Check if exists but stopped
-        result = subprocess.run(
-            [rt, "ps", "-a", "--filter", f"name={CONTAINER_NAME}", "--format", "{{.Status}}"],
-            capture_output=True, text=True, timeout=5
-        )
-        if result.stdout.strip():
-            return {"status": "stopped", "uptime": ""}
-
-        return {"status": "not_installed", "uptime": ""}
-    except Exception:
-        return {"status": "error", "uptime": ""}
+    """PhotoPrism status — primary signal is HTTP reachability of the LXC
+    instance (the dashboard runs unprivileged and can't always read lxc-info)."""
+    if http_reachable():
+        return {"status": "running", "uptime": ""}
+    state = lxc_state()
+    if state in ("stopped", "frozen"):
+        return {"status": "stopped", "uptime": ""}
+    return {"status": "not_installed", "uptime": ""}
 
 
 def is_running() -> bool:
-    """Check if PhotoPrism container is running."""
-    return get_container_status()["status"] == "running"
+    """Check if PhotoPrism is reachable."""
+    return http_reachable()
+
+
+def _pm() -> list:
+    """Command prefix to run podman inside the PhotoPrism LXC.
+
+    NOTE: lxc-attach needs root; the dashboard runs as the unprivileged
+    'secubox' user, so container-lifecycle verbs are best driven via
+    photoprismctl from a root context. Read-only status uses http_reachable()."""
+    cfg = get_config()
+    return ["lxc-attach", "-n", cfg.get("name", "photoprism"),
+            "-P", cfg.get("path", "/data/lxc"), "--", "podman"]
+
+
+def _photoprismctl(verb: str, timeout: int = 60) -> dict:
+    try:
+        r = subprocess.run([PHOTOPRISMCTL, verb], capture_output=True, text=True, timeout=timeout)
+        return {"success": r.returncode == 0, "stdout": r.stdout, "stderr": r.stderr}
+    except subprocess.TimeoutExpired:
+        return {"success": False, "error": "timeout"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
 
 
 def get_library_stats() -> dict:
@@ -270,28 +313,34 @@ async def health():
 
 @router.get("/status")
 async def status():
-    """Get PhotoPrism service status."""
+    """Get PhotoPrism service status (native-LXC)."""
     cfg = get_config()
-    rt = detect_runtime()
     container = get_container_status()
     lib_stats = get_library_stats()
+    hostname = cfg.get("public_hostname", cfg.get("domain", "photoprism.gk2.secubox.in"))
 
     return {
+        "deployment": "lxc-native",
         "enabled": cfg.get("enabled", False),
-        "image": cfg.get("image", "photoprism/photoprism:latest"),
+        "image": cfg.get("image", "docker.io/photoprism/photoprism:latest"),
         "port": cfg.get("port", 2342),
-        "data_path": cfg.get("data_path", "/srv/photoprism"),
-        "originals_path": cfg.get("originals_path", "/srv/photoprism/originals"),
-        "import_path": cfg.get("import_path", "/srv/photoprism/import"),
+        "lxc_name": cfg.get("name", "photoprism"),
+        "lxc_ip": cfg.get("ip", "10.100.0.130"),
+        "lxc_state": lxc_state(),
+        "http_reachable": http_reachable(),
+        "data_path": cfg.get("data_path", "/data/photoprism"),
+        "originals_path": cfg.get("originals_path", "/data/shared/photos"),
+        "import_path": cfg.get("import_path", "/data/photoprism/import"),
         "timezone": cfg.get("timezone", "Europe/Paris"),
-        "domain": cfg.get("domain", "photos.secubox.local"),
+        "domain": hostname,
+        "public_url": f"https://{hostname}/",
         "haproxy": cfg.get("haproxy", False),
         "face_recognition": cfg.get("face_recognition", True),
         "experimental": cfg.get("experimental", False),
         "readonly": cfg.get("readonly", False),
         "public": cfg.get("public", False),
-        "docker_available": rt is not None,
-        "runtime": rt or "none",
+        # webui back-compat keys (was Docker; now native-LXC):
+        "runtime": "lxc-native",
         "container_status": container["status"],
         "container_uptime": container["uptime"],
         "library_stats": lib_stats,
@@ -337,16 +386,12 @@ async def start_indexing(user=Depends(require_jwt)):
     if not is_running():
         return {"success": False, "error": "PhotoPrism is not running"}
 
-    rt = detect_runtime()
-    if not rt:
-        return {"success": False, "error": "No container runtime"}
-
     log.info(f"Starting index by {user.get('sub', 'unknown')}")
 
     try:
-        # Run photoprism index command in container
+        # Run photoprism index inside the LXC container.
         result = subprocess.run(
-            [rt, "exec", CONTAINER_NAME, "photoprism", "index"],
+            _pm() + ["exec", CONTAINER_NAME, "photoprism", "index"],
             capture_output=True, text=True, timeout=300
         )
         if result.returncode == 0:
@@ -365,16 +410,12 @@ async def import_photos(user=Depends(require_jwt)):
     if not is_running():
         return {"success": False, "error": "PhotoPrism is not running"}
 
-    rt = detect_runtime()
-    if not rt:
-        return {"success": False, "error": "No container runtime"}
-
     log.info(f"Starting import by {user.get('sub', 'unknown')}")
 
     try:
-        # Run photoprism import command
+        # Run photoprism import inside the LXC container.
         result = subprocess.run(
-            [rt, "exec", CONTAINER_NAME, "photoprism", "import"],
+            _pm() + ["exec", CONTAINER_NAME, "photoprism", "import"],
             capture_output=True, text=True, timeout=300
         )
         if result.returncode == 0:
@@ -581,14 +622,14 @@ async def delete_user(username: str, user=Depends(require_jwt)):
 
 @router.get("/container/status")
 async def container_status(user=Depends(require_jwt)):
-    """Get container status."""
-    rt = detect_runtime()
+    """LXC + reachability status (kept under /container/* for webui back-compat)."""
     container = get_container_status()
-
     return {
-        "runtime": rt or "none",
-        "runtime_available": rt is not None,
+        "runtime": "lxc-native",
+        "runtime_available": True,
         "container_name": CONTAINER_NAME,
+        "lxc_state": lxc_state(),
+        "http_reachable": http_reachable(),
         "status": container["status"],
         "uptime": container["uptime"],
     }
@@ -596,187 +637,66 @@ async def container_status(user=Depends(require_jwt)):
 
 @router.post("/container/install")
 async def install_photoprism(user=Depends(require_jwt)):
-    """Install PhotoPrism container."""
-    rt = detect_runtime()
-    if not rt:
-        return {"success": False, "error": "No container runtime (docker/podman) found"}
-
-    cfg = get_config()
-    data_path = Path(cfg.get("data_path", "/srv/photoprism"))
-    originals_path = Path(cfg.get("originals_path", "/srv/photoprism/originals"))
-    import_path = Path(cfg.get("import_path", "/srv/photoprism/import"))
-
-    # Create directories
-    data_path.mkdir(parents=True, exist_ok=True)
-    originals_path.mkdir(parents=True, exist_ok=True)
-    import_path.mkdir(parents=True, exist_ok=True)
-    (data_path / "storage").mkdir(parents=True, exist_ok=True)
-
-    # Pull image
-    image = cfg.get("image", "photoprism/photoprism:latest")
-    log.info(f"Installing PhotoPrism ({image}) by {user.get('sub', 'unknown')}")
-
+    """Provision the LXC + podman + PhotoPrism. Long-running → detached."""
+    if not Path(INSTALL_LIB).exists():
+        return {"success": False, "error": f"install script missing at {INSTALL_LIB}"}
+    log.info(f"Launching native-LXC PhotoPrism install by {user.get('sub', 'unknown')}")
     try:
-        result = subprocess.run(
-            [rt, "pull", image],
-            capture_output=True, text=True, timeout=600
+        subprocess.Popen(
+            ["bash", INSTALL_LIB],
+            stdout=open("/var/log/secubox/photoprism-install.log", "a"),
+            stderr=subprocess.STDOUT, start_new_session=True,
         )
-        if result.returncode != 0:
-            return {"success": False, "error": result.stderr.strip(), "output": result.stdout}
-
-        return {"success": True, "output": "Image pulled successfully"}
-    except subprocess.TimeoutExpired:
-        return {"success": False, "error": "Pull timeout"}
+        return {"success": True,
+                "message": "Install started (several minutes). Follow "
+                           "/var/log/secubox/photoprism-install.log or 'photoprismctl logs'."}
     except Exception as e:
         return {"success": False, "error": str(e)}
 
 
 @router.post("/container/start")
 async def start_photoprism(user=Depends(require_jwt)):
-    """Start PhotoPrism container."""
-    if is_running():
-        return {"success": False, "error": "Already running"}
-
-    rt = detect_runtime()
-    if not rt:
-        return {"success": False, "error": "No container runtime"}
-
-    cfg = get_config()
-    data_path = Path(cfg.get("data_path", "/srv/photoprism"))
-    originals_path = Path(cfg.get("originals_path", "/srv/photoprism/originals"))
-    import_path = Path(cfg.get("import_path", "/srv/photoprism/import"))
-    port = cfg.get("port", 2342)
-    image = cfg.get("image", "photoprism/photoprism:latest")
-    tz = cfg.get("timezone", "Europe/Paris")
-
-    # Ensure directories exist
-    data_path.mkdir(parents=True, exist_ok=True)
-    originals_path.mkdir(parents=True, exist_ok=True)
-    import_path.mkdir(parents=True, exist_ok=True)
-    (data_path / "storage").mkdir(parents=True, exist_ok=True)
-
-    # Build environment variables
-    env_vars = [
-        f"PHOTOPRISM_SITE_URL=http://localhost:{port}/",
-        f"PHOTOPRISM_ORIGINALS_PATH=/photoprism/originals",
-        f"PHOTOPRISM_IMPORT_PATH=/photoprism/import",
-        f"PHOTOPRISM_STORAGE_PATH=/photoprism/storage",
-        "PHOTOPRISM_HTTP_PORT=2342",
-        "PHOTOPRISM_DATABASE_DRIVER=sqlite",
-        f"PHOTOPRISM_DETECT_NSFW={'true' if cfg.get('experimental', False) else 'false'}",
-        f"PHOTOPRISM_EXPERIMENTAL={'true' if cfg.get('experimental', False) else 'false'}",
-        f"PHOTOPRISM_READONLY={'true' if cfg.get('readonly', False) else 'false'}",
-        f"PHOTOPRISM_PUBLIC={'true' if cfg.get('public', False) else 'false'}",
-        f"PHOTOPRISM_DISABLE_FACES={'false' if cfg.get('face_recognition', True) else 'true'}",
-        f"TZ={tz}",
-    ]
-
-    # Set admin password if configured
-    admin_pass = cfg.get("admin_password", "")
-    if admin_pass:
-        env_vars.append(f"PHOTOPRISM_ADMIN_PASSWORD={admin_pass}")
-    else:
-        env_vars.append("PHOTOPRISM_AUTH_MODE=public")  # No auth if no password
-
-    # Build run command
-    cmd = [
-        rt, "run", "-d",
-        "--name", CONTAINER_NAME,
-        "-v", f"{originals_path}:/photoprism/originals",
-        "-v", f"{import_path}:/photoprism/import",
-        "-v", f"{data_path}/storage:/photoprism/storage",
-        "-p", f"127.0.0.1:{port}:2342",
-        "--restart", "unless-stopped",
-    ]
-
-    # Add environment variables
-    for env in env_vars:
-        cmd.extend(["-e", env])
-
-    cmd.append(image)
-
-    log.info(f"Starting PhotoPrism by {user.get('sub', 'unknown')}")
-
-    try:
-        # Remove existing stopped container
-        subprocess.run([rt, "rm", "-f", CONTAINER_NAME], capture_output=True, timeout=10)
-
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
-        await asyncio.sleep(5)
-
-        if is_running():
-            return {"success": True}
-        else:
-            return {"success": False, "error": result.stderr.strip() or "Failed to start"}
-    except Exception as e:
-        return {"success": False, "error": str(e)}
+    """Start PhotoPrism (LXC)."""
+    log.info(f"Starting PhotoPrism LXC by {user.get('sub', 'unknown')}")
+    r = _photoprismctl("start")
+    return {"success": r.get("success", False), "output": r.get("stdout", r.get("error", ""))}
 
 
 @router.post("/container/stop")
 async def stop_photoprism(user=Depends(require_jwt)):
-    """Stop PhotoPrism container."""
-    rt = detect_runtime()
-    if not rt:
-        return {"success": False, "error": "No container runtime"}
-
-    log.info(f"Stopping PhotoPrism by {user.get('sub', 'unknown')}")
-
-    try:
-        subprocess.run([rt, "stop", CONTAINER_NAME], capture_output=True, timeout=30)
-        return {"success": True}
-    except Exception as e:
-        return {"success": False, "error": str(e)}
+    """Stop PhotoPrism (LXC)."""
+    log.info(f"Stopping PhotoPrism LXC by {user.get('sub', 'unknown')}")
+    r = _photoprismctl("stop")
+    return {"success": r.get("success", False), "output": r.get("stdout", r.get("error", ""))}
 
 
 @router.post("/container/restart")
 async def restart_photoprism(user=Depends(require_jwt)):
-    """Restart PhotoPrism container."""
-    await stop_photoprism(user)
-    await asyncio.sleep(2)
-    return await start_photoprism(user)
+    """Restart PhotoPrism (LXC)."""
+    log.info(f"Restarting PhotoPrism LXC by {user.get('sub', 'unknown')}")
+    r = _photoprismctl("restart")
+    return {"success": r.get("success", False), "output": r.get("stdout", r.get("error", ""))}
 
 
 @router.post("/container/uninstall")
 async def uninstall_photoprism(user=Depends(require_jwt)):
-    """Uninstall PhotoPrism container."""
-    rt = detect_runtime()
-    if not rt:
-        return {"success": False, "error": "No container runtime"}
-
-    log.info(f"Uninstalling PhotoPrism by {user.get('sub', 'unknown')}")
-
-    try:
-        subprocess.run([rt, "stop", CONTAINER_NAME], capture_output=True, timeout=30)
-        subprocess.run([rt, "rm", "-f", CONTAINER_NAME], capture_output=True, timeout=10)
-        return {"success": True}
-    except Exception as e:
-        return {"success": False, "error": str(e)}
+    """Stop the LXC (data on /data/photoprism + /data/shared/photos preserved)."""
+    log.info(f"Stopping PhotoPrism LXC (data preserved) by {user.get('sub', 'unknown')}")
+    r = _photoprismctl("stop")
+    return {"success": r.get("success", False), "message": "LXC stopped, data preserved"}
 
 
 @router.post("/container/update")
 async def update_photoprism(user=Depends(require_jwt)):
-    """Update PhotoPrism to latest image."""
+    """Pull the latest image inside the LXC + restart."""
     cfg = get_config()
-    rt = detect_runtime()
-    if not rt:
-        return {"success": False, "error": "No container runtime"}
-
-    image = cfg.get("image", "photoprism/photoprism:latest")
-    log.info(f"Updating PhotoPrism ({image}) by {user.get('sub', 'unknown')}")
-
+    image = cfg.get("image", "docker.io/photoprism/photoprism:latest")
+    log.info(f"Updating PhotoPrism image ({image}) by {user.get('sub', 'unknown')}")
     try:
-        # Pull new image
-        result = subprocess.run(
-            [rt, "pull", image],
-            capture_output=True, text=True, timeout=600
-        )
-        if result.returncode != 0:
-            return {"success": False, "error": result.stderr.strip()}
-
-        # Restart if running
-        if is_running():
-            await restart_photoprism(user)
-
+        pull = subprocess.run(_pm() + ["pull", image], capture_output=True, text=True, timeout=600)
+        if pull.returncode != 0:
+            return {"success": False, "error": pull.stderr.strip() or "pull failed"}
+        _photoprismctl("restart")
         return {"success": True, "output": "Update complete"}
     except Exception as e:
         return {"success": False, "error": str(e)}
@@ -788,18 +708,16 @@ async def update_photoprism(user=Depends(require_jwt)):
 
 @router.get("/logs")
 async def get_logs(lines: int = 50, user=Depends(require_jwt)):
-    """Get container logs."""
-    rt = detect_runtime()
-    if not rt:
-        return {"logs": "No container runtime"}
-
+    """Tail photoprism.service journal inside the LXC."""
+    cfg = get_config()
     try:
         result = subprocess.run(
-            [rt, "logs", "--tail", str(lines), CONTAINER_NAME],
-            capture_output=True, text=True, timeout=10
+            ["lxc-attach", "-n", cfg.get("name", "photoprism"),
+             "-P", cfg.get("path", "/data/lxc"), "--",
+             "journalctl", "-u", "photoprism", "-n", str(lines), "--no-pager"],
+            capture_output=True, text=True, timeout=15,
         )
-        logs = result.stdout + result.stderr
-        return {"logs": logs}
+        return {"logs": (result.stdout + result.stderr) or "No logs available"}
     except Exception:
         return {"logs": "No logs available"}
 

--- a/packages/secubox-photoprism/conf/photoprism.nginx.conf
+++ b/packages/secubox-photoprism/conf/photoprism.nginx.conf
@@ -1,0 +1,44 @@
+# packages/secubox-photoprism/conf/photoprism.nginx.conf
+# Installed by secubox-photoprism postinst at /etc/nginx/sites-available/photoprism.conf
+# and symlinked into /etc/nginx/sites-enabled/.
+#
+# Public chain: Browser → HAProxy:443 (TLS) → nginx:9080 (this vhost, matched
+#               by server_name) → PhotoPrism LXC at 10.100.0.130:2342.
+#
+# All SecuBox public vhosts share listen :9080 and differentiate by
+# server_name (see gitea/peertube). Bypasses mitmproxy WAF — large photo/video
+# uploads are high-volume binary the WAF can't meaningfully inspect, and
+# PhotoPrism gates its own auth (gitea exception pattern).
+#
+# Operator wires the HAProxy SNI ACL + ACME cert separately (CLAUDE.md).
+
+server {
+    listen 0.0.0.0:9080;
+    server_name photoprism.gk2.secubox.in;
+
+    # Large photo/video uploads + library imports.
+    client_max_body_size 4G;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /usr/share/secubox/www;
+        try_files $uri =404;
+    }
+
+    location / {
+        proxy_pass http://10.100.0.130:2342;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+
+        # WebSocket (PhotoPrism live indexing progress).
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection $http_connection;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    access_log /var/log/nginx/photoprism_access.log;
+    error_log  /var/log/nginx/photoprism_error.log;
+}

--- a/packages/secubox-photoprism/conf/photoprism.toml.example
+++ b/packages/secubox-photoprism/conf/photoprism.toml.example
@@ -1,0 +1,24 @@
+# /etc/secubox/photoprism.toml — SecuBox PhotoPrism module configuration
+#
+# Operator override of package defaults. Edit then run `photoprismctl install`
+# (first provision) or `photoprismctl restart`.
+
+[lxc]
+name         = "photoprism"
+ip           = "10.100.0.130"
+gateway      = "10.100.0.1"
+bridge       = "br-lxc"
+path         = "/data/lxc"
+debian_suite = "bookworm"
+
+[photoprism]
+http_port            = 2342
+image                = "docker.io/photoprism/photoprism:latest"
+admin_user           = "admin"
+admin_password_file  = "/etc/secubox/secrets/photoprism-admin"
+auto_index           = 300          # delay (s) before re-index after UI change; -1 disables
+originals            = "/data/shared/photos"   # shared with Nextcloud "PhotoLibrary"
+
+[exposure]
+public_hostname = "photoprism.gk2.secubox.in"
+waf_inspect     = false             # photo/video bypass the WAF (gitea pattern)

--- a/packages/secubox-photoprism/debian/changelog
+++ b/packages/secubox-photoprism/debian/changelog
@@ -20,6 +20,16 @@ secubox-photoprism (1.1.0-1~bookworm1) bookworm; urgency=medium
     still hardcoding /srv); drop the /srv mkdir; ship default photoprism.toml;
     tolerate masked unit. Stop shipping the admin password `secubox-CHANGE-ME`
     (install-lxc.sh now generates one).
+  * debian/secubox-photoprism.service: drop the ConditionPathExists=/etc/
+    secubox/photoprism/enabled gate (the dashboard never started), the broken
+    Requires=secubox-runtime.service, and the docker.service deps; User=root →
+    User=secubox + RuntimeDirectory (mirror peertube #388). Makes the obsolete
+    live drop-ins (no-runtime-dir.conf/preserve.conf) unnecessary.
+  * api/main.py: rewritten to talk to the native instance over HTTP at
+    <lxc_ip>:<http_port> (status/reachability) instead of host docker/podman;
+    /container/* drive the LXC via photoprismctl; library index/import exec via
+    lxc-attach podman; config flattens [lxc]/[photoprism]/[exposure]; data paths
+    /srv → /data + originals → /data/shared/photos. Validated live on gk2.
   * NB: the Nextcloud side (the "PhotoLibrary" external-storage mount → the
     shared photos dir) is tracked separately for secubox-nextcloud.
 

--- a/packages/secubox-photoprism/debian/changelog
+++ b/packages/secubox-photoprism/debian/changelog
@@ -1,3 +1,30 @@
+secubox-photoprism (1.1.0-1~bookworm1) bookworm; urgency=medium
+
+  * Native-LXC rework + Nextcloud photo integration (closes #397). Captures the
+    live gk2 deployment in source (Source-first; mirrors secubox-peertube #388).
+  * lib/photoprism/install-lxc.sh (NEW): idempotent LXC bootstrap (10.100.0.130
+    on br-lxc, debian.common.conf, idmap, cgroup caps) + podman install +
+    photoprism.service (podman run --network=host, sqlite, http 0.0.0.0:2342,
+    PHOTOPRISM_AUTO_INDEX=300, generated admin password to
+    /etc/secubox/secrets/photoprism-admin) + photoprism-index.timer (every
+    15 min → `photoprism index`; PhotoPrism's built-in auto-index only fires
+    for its own UI uploads, NOT Nextcloud-synced files). Bind mounts
+    /data/shared/photos→originals (shared with Nextcloud) + /data/photoprism/
+    {storage,import}.
+  * sbin/photoprismctl (NEW): install/status/start/stop/restart/index/logs/reload.
+  * conf/photoprism.nginx.conf (NEW): public vhost :9080 → 10.100.0.130:2342,
+    4G uploads, WS; WAF-bypass (gitea pattern). postinst symlinks it into
+    sites-enabled. conf/photoprism.toml.example (NEW).
+  * debian/control: reframe Docker → native-LXC; Depends lxc/nftables/openssl.
+  * debian/postinst: #319 /srv/photoprism → /data/photoprism migration (was
+    still hardcoding /srv); drop the /srv mkdir; ship default photoprism.toml;
+    tolerate masked unit. Stop shipping the admin password `secubox-CHANGE-ME`
+    (install-lxc.sh now generates one).
+  * NB: the Nextcloud side (the "PhotoLibrary" external-storage mount → the
+    shared photos dir) is tracked separately for secubox-nextcloud.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 28 May 2026 11:00:00 +0000
+
 secubox-photoprism (1.0.0-1~bookworm1) bookworm; urgency=medium
 
   * Initial release.

--- a/packages/secubox-photoprism/debian/control
+++ b/packages/secubox-photoprism/debian/control
@@ -7,19 +7,24 @@ Standards-Version: 4.6.2
 
 Package: secubox-photoprism
 Architecture: all
-Depends: ${misc:Depends}, secubox-core (>= 1.0), python3-uvicorn | python3-pip
-Recommends: docker.io | podman
-Description: PhotoPrism photo management for SecuBox
- SecuBox module for managing PhotoPrism photo server via Docker.
- Provides container management, library indexing, face recognition,
- album management, and storage configuration.
+Depends: ${misc:Depends}, secubox-core (>= 1.0), python3-uvicorn | python3-pip,
+ lxc, lxc-templates, nftables, openssl
+Description: PhotoPrism photo management for SecuBox (native LXC)
+ SecuBox module for a PhotoPrism photo server running as a podman container
+ inside a dedicated Debian LXC (--network=host). `photoprismctl install`
+ provisions the LXC + container on demand; the host dashboard daemon stays
+ lightweight and always reachable.
+ .
+ Photos live on /data/shared/photos, also mounted by Nextcloud as the
+ "PhotoLibrary" external storage — phone → Nextcloud → /data/shared/photos →
+ PhotoPrism originals (indexed by a 15-min timer, since PhotoPrism's built-in
+ auto-index only fires for its own UI uploads).
  .
  Features:
-  - Docker/Podman container management
-  - AI-powered face recognition
-  - Photo library indexing and organization
-  - Album management
-  - Import workflow
+  - LXC lifecycle via photoprismctl (install/status/start/stop/restart/index)
+  - Public nginx vhost (:9080 → LXC :2342) bypassing the WAF (gitea pattern)
+  - AI-powered face recognition, library indexing, album management
+  - Import workflow + Nextcloud photo integration
   - CRT-light P31 phosphor theme
  .
  Provides FastAPI backend on /api/v1/photoprism/ via Unix socket.

--- a/packages/secubox-photoprism/debian/postinst
+++ b/packages/secubox-photoprism/debian/postinst
@@ -9,7 +9,10 @@ case "$1" in
     # Create runtime directories
     install -d -o secubox -g secubox -m 750 /run/secubox
     install -d -o secubox -g secubox -m 750 /var/lib/secubox
-    install -d -o root    -g root    -m 755 /etc/secubox
+    # Do NOT reset /etc/secubox — secubox-core owns it as secubox:secubox 0750
+    # (the users-engine needs dir-write for atomic users.json saves / TOTP).
+    # Only create as a fallback if it's somehow missing.
+    [ -d /etc/secubox ] || install -d -o secubox -g secubox -m 750 /etc/secubox
 
     # #319 /data migration: move legacy /srv/photoprism → /data/photoprism and
     # leave a back-compat symlink. Idempotent.

--- a/packages/secubox-photoprism/debian/postinst
+++ b/packages/secubox-photoprism/debian/postinst
@@ -9,19 +9,41 @@ case "$1" in
     # Create runtime directories
     install -d -o secubox -g secubox -m 750 /run/secubox
     install -d -o secubox -g secubox -m 750 /var/lib/secubox
-    # Create data directories
-    install -d -m 755 /srv/photoprism
-    install -d -m 755 /srv/photoprism/originals
-    install -d -m 755 /srv/photoprism/import
-    install -d -m 755 /srv/photoprism/storage
-    # Ensure nginx secubox.d directory exists
+    install -d -o root    -g root    -m 755 /etc/secubox
+
+    # #319 /data migration: move legacy /srv/photoprism → /data/photoprism and
+    # leave a back-compat symlink. Idempotent.
+    if [ -d /srv/photoprism ] && [ ! -L /srv/photoprism ] && [ ! -e /data/photoprism ]; then
+      mkdir -p /data
+      mv /srv/photoprism /data/photoprism && ln -s /data/photoprism /srv/photoprism \
+        && echo "secubox-photoprism: migrated /srv/photoprism → /data/photoprism"
+    fi
+    # Data + shared photo dirs. The bind-mount subdirs are created/chown'd by
+    # install-lxc.sh; /data/shared/photos is shared with Nextcloud.
+    install -d -m 0755 /data/photoprism /data/photoprism/storage /data/photoprism/import
+    install -d -m 0777 /data/shared/photos
+
+    # Ship a default photoprism.toml from the example if absent.
+    if [ ! -e /etc/secubox/photoprism.toml ] && [ -e /etc/secubox/photoprism.toml.example ]; then
+      cp /etc/secubox/photoprism.toml.example /etc/secubox/photoprism.toml
+    fi
+
+    # nginx snippet dir + public vhost symlink (idempotent).
     install -d -m 755 /etc/nginx/secubox.d
-    # Enable and start service
+    if [ -f /etc/nginx/sites-available/photoprism.conf ] && [ -d /etc/nginx/sites-enabled ]; then
+      ln -sf ../sites-available/photoprism.conf /etc/nginx/sites-enabled/photoprism.conf
+    fi
+
+    # Enable + start the dashboard API daemon (tolerate masked units).
     systemctl daemon-reload
-    systemctl enable secubox-photoprism.service
-    systemctl start  secubox-photoprism.service || true
-    # Reload nginx to pick up new location
-    systemctl reload nginx 2>/dev/null || true
+    if [ "$(systemctl is-enabled secubox-photoprism.service 2>/dev/null)" != "masked" ]; then
+      systemctl enable secubox-photoprism.service || true
+      systemctl start  secubox-photoprism.service || true
+    fi
+    # NOTE: PhotoPrism itself is NOT installed here — run `photoprismctl install`.
+    if nginx -t 2>/dev/null; then
+      systemctl reload nginx 2>/dev/null || true
+    fi
     ;;
 esac
 #DEBHELPER#

--- a/packages/secubox-photoprism/debian/rules
+++ b/packages/secubox-photoprism/debian/rules
@@ -3,15 +3,27 @@
 	dh $@
 
 override_dh_auto_install:
-	# API files
+	# API files (host dashboard daemon)
 	install -d debian/secubox-photoprism/usr/lib/secubox/photoprism/
 	cp -r api debian/secubox-photoprism/usr/lib/secubox/photoprism/
+	# Host control plane CLI
+	install -d debian/secubox-photoprism/usr/sbin
+	install -m 755 sbin/photoprismctl debian/secubox-photoprism/usr/sbin/photoprismctl
+	# Native-LXC bootstrap (run on demand by `photoprismctl install`)
+	install -d debian/secubox-photoprism/usr/share/secubox/lib/photoprism
+	[ -d lib/photoprism ] && cp -r lib/photoprism/. debian/secubox-photoprism/usr/share/secubox/lib/photoprism/ || true
 	# Static www files
 	install -d debian/secubox-photoprism/usr/share/secubox/www
 	[ -d www ] && cp -r www/. debian/secubox-photoprism/usr/share/secubox/www/ || true
 	# Menu definitions
 	install -d debian/secubox-photoprism/usr/share/secubox/menu.d
 	[ -d menu.d ] && cp -r menu.d/. debian/secubox-photoprism/usr/share/secubox/menu.d/ || true
-	# Modular nginx config
+	# Modular nginx config (API socket location → /etc/nginx/secubox.d/)
 	install -d debian/secubox-photoprism/etc/nginx/secubox.d
 	[ -f nginx/photoprism.conf ] && cp nginx/photoprism.conf debian/secubox-photoprism/etc/nginx/secubox.d/ || true
+	# Public vhost template → sites-available (postinst symlinks it)
+	install -d debian/secubox-photoprism/etc/nginx/sites-available
+	[ -f conf/photoprism.nginx.conf ] && cp conf/photoprism.nginx.conf debian/secubox-photoprism/etc/nginx/sites-available/photoprism.conf || true
+	# Config example
+	install -d debian/secubox-photoprism/etc/secubox
+	[ -f conf/photoprism.toml.example ] && cp conf/photoprism.toml.example debian/secubox-photoprism/etc/secubox/photoprism.toml.example || true

--- a/packages/secubox-photoprism/debian/rules
+++ b/packages/secubox-photoprism/debian/rules
@@ -18,9 +18,14 @@ override_dh_auto_install:
 	# Menu definitions
 	install -d debian/secubox-photoprism/usr/share/secubox/menu.d
 	[ -d menu.d ] && cp -r menu.d/. debian/secubox-photoprism/usr/share/secubox/menu.d/ || true
-	# Modular nginx config (API socket location → /etc/nginx/secubox.d/)
+	# Dashboard-API route. The ACTIVE include is secubox-routes.d/ (webui.conf);
+	# secubox.d/ is legacy/back-compat. Ship to BOTH (mirror secubox-grafana) so
+	# /api/v1/photoprism/ is routed — installing only to secubox.d/ silently
+	# drops the route (regression that broke the dashboard tile).
 	install -d debian/secubox-photoprism/etc/nginx/secubox.d
+	install -d debian/secubox-photoprism/etc/nginx/secubox-routes.d
 	[ -f nginx/photoprism.conf ] && cp nginx/photoprism.conf debian/secubox-photoprism/etc/nginx/secubox.d/ || true
+	[ -f nginx/photoprism.conf ] && cp nginx/photoprism.conf debian/secubox-photoprism/etc/nginx/secubox-routes.d/ || true
 	# Public vhost template → sites-available (postinst symlinks it)
 	install -d debian/secubox-photoprism/etc/nginx/sites-available
 	[ -f conf/photoprism.nginx.conf ] && cp conf/photoprism.nginx.conf debian/secubox-photoprism/etc/nginx/sites-available/photoprism.conf || true

--- a/packages/secubox-photoprism/debian/secubox-photoprism.service
+++ b/packages/secubox-photoprism/debian/secubox-photoprism.service
@@ -1,23 +1,24 @@
 [Unit]
-# Only start if explicitly enabled (backend installed)
-ConditionPathExists=/etc/secubox/photoprism/enabled
 Description=SecuBox PhotoPrism API
-After=network.target secubox-core.service secubox-runtime.service docker.service
-Requires=secubox-runtime.service
-Wants=docker.service
+After=network.target secubox-core.service
+Requires=secubox-core.service
 
 [Service]
 Type=simple
-User=root
-Group=root
+User=secubox
+Group=secubox
 WorkingDirectory=/usr/lib/secubox/photoprism
 ExecStart=/usr/bin/python3 -m uvicorn api.main:app --uds /run/secubox/photoprism.sock --log-level warning
-ExecStartPost=-/bin/sleep 1
-ExecStartPost=-/bin/chmod 660 /run/secubox/photoprism.sock
-ExecStartPost=-/bin/chown secubox:secubox /run/secubox/photoprism.sock
 Restart=on-failure
 RestartSec=5
-PrivateTmp=true
+UMask=0000
+
+NoNewPrivileges=true
+RuntimeDirectory=secubox
+RuntimeDirectoryPreserve=yes
+RuntimeDirectoryMode=0775
+
+ReadWritePaths=/run/secubox /var/lib/secubox /etc/secubox /var/log/secubox /data/photoprism
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/secubox-photoprism/lib/photoprism/install-lxc.sh
+++ b/packages/secubox-photoprism/lib/photoprism/install-lxc.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# SecuBox-Deb :: secubox-photoprism :: install-lxc.sh
+# CyberMind — https://cybermind.fr
+#
+# Idempotent native-LXC bootstrap for the PhotoPrism module. Safe to re-run.
+# Follows docs/MODULE-GUIDELINES.md §3 (mirror of grafana / secubox-peertube).
+#
+# PhotoPrism runs as a podman container inside a dedicated Debian LXC, with
+# `--network=host` (an unprivileged LXC can't bring up a podman CNI bridge on
+# the Marvell arm64 boards). Photos live on the host at /data/shared/photos,
+# which Nextcloud also mounts (see secubox-nextcloud "PhotoLibrary" external
+# storage) — phone → Nextcloud → /data/shared/photos → PhotoPrism originals.
+
+set -euo pipefail
+
+readonly LXC_NAME="${SECUBOX_LXC_NAME:-photoprism}"
+readonly LXC_IP="${SECUBOX_LXC_IP:-10.100.0.130}"
+readonly LXC_PATH="${SECUBOX_LXC_PATH:-/data/lxc}"
+readonly LXC_BRIDGE="${SECUBOX_LXC_BRIDGE:-br-lxc}"
+readonly LXC_GW="${SECUBOX_LXC_GW:-10.100.0.1}"
+readonly DEBIAN_SUITE="${SECUBOX_DEBIAN_SUITE:-bookworm}"
+readonly DATA_DIR="${SECUBOX_DATA_DIR:-/data/photoprism}"
+readonly SHARED_PHOTOS="${SECUBOX_SHARED_PHOTOS:-/data/shared/photos}"
+readonly STATE_DIR="${SECUBOX_STATE_DIR:-/var/lib/secubox/photoprism}"
+readonly SECRETS_DIR="${SECUBOX_SECRETS_DIR:-/etc/secubox/secrets}"
+readonly SENTINEL="$STATE_DIR/.lxc-provisioned"
+readonly PUBLIC_HOSTNAME="${SECUBOX_PHOTOPRISM_HOSTNAME:-photoprism.gk2.secubox.in}"
+readonly IMAGE="${SECUBOX_PHOTOPRISM_IMAGE:-docker.io/photoprism/photoprism:latest}"
+readonly HTTP_PORT="${SECUBOX_PHOTOPRISM_PORT:-2342}"
+# PhotoPrism's built-in auto-index only fires for its own UI uploads; the
+# index timer below catches Nextcloud-synced files. AUTO_INDEX is the delay
+# (s) before re-indexing after a UI change; -1 disables.
+readonly AUTO_INDEX="${SECUBOX_PHOTOPRISM_AUTO_INDEX:-300}"
+readonly LXC_ROOT_UID="${SECUBOX_LXC_ROOT_UID:-100000}"
+
+log()  { printf '[photoprism-install] %s\n' "$*"; }
+fail() { printf '[photoprism-install] ERROR: %s\n' "$*" >&2; exit 1; }
+la() { lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- "$@"; }
+
+# ── Preflight ────────────────────────────────────────────────────────────────
+require_cmds() {
+    for c in lxc-create lxc-info lxc-start lxc-attach openssl; do
+        command -v "$c" >/dev/null 2>&1 || fail "$c not installed"
+    done
+}
+
+ensure_dirs() {
+    install -d -m 0755 -o root -g root "$LXC_PATH"
+    install -d -m 0755 "$STATE_DIR" 2>/dev/null || true
+    install -d -m 0700 -o root -g root "$SECRETS_DIR"
+    install -d -m 0750 "$DATA_DIR/storage" "$DATA_DIR/import"
+    # Shared photo library — Nextcloud (www-data) writes, PhotoPrism reads.
+    # 0777 so both LXCs' service UIDs can use it (both map root→100000, but
+    # NC writes as www-data 100033). Acceptable on a single-appliance box.
+    install -d -m 0777 "$SHARED_PHOTOS"
+    chown -R "$LXC_ROOT_UID:$LXC_ROOT_UID" "$DATA_DIR"
+    chown "$LXC_ROOT_UID:$LXC_ROOT_UID" "$SHARED_PHOTOS"
+}
+
+ensure_bridge() {
+    if ! ip link show "$LXC_BRIDGE" >/dev/null 2>&1; then
+        log "Creating bridge $LXC_BRIDGE @ ${LXC_GW}/24 ..."
+        ip link add name "$LXC_BRIDGE" type bridge
+        ip addr add "${LXC_GW}/24" dev "$LXC_BRIDGE"
+        ip link set "$LXC_BRIDGE" up
+        cat > /etc/systemd/network/10-secubox-lxc-bridge.netdev <<EOF
+[NetDev]
+Name=$LXC_BRIDGE
+Kind=bridge
+EOF
+        cat > /etc/systemd/network/10-secubox-lxc-bridge.network <<EOF
+[Match]
+Name=$LXC_BRIDGE
+
+[Network]
+Address=${LXC_GW}/24
+ConfigureWithoutCarrier=yes
+IPMasquerade=ipv4
+EOF
+        systemctl reload systemd-networkd 2>/dev/null || true
+    fi
+}
+
+ensure_masquerade() {
+    if ! nft list table ip lxc 2>/dev/null | grep -q 'saddr 10.100.0.0/24'; then
+        log "Adding nftables MASQUERADE for 10.100.0.0/24 ..."
+        nft 'add table ip lxc' 2>/dev/null || true
+        nft 'add chain ip lxc postrouting { type nat hook postrouting priority srcnat ; policy accept ; }' 2>/dev/null || true
+        nft 'add rule ip lxc postrouting ip saddr 10.100.0.0/24 ip daddr != 10.100.0.0/24 counter masquerade' 2>/dev/null || true
+    fi
+}
+
+# ── LXC lifecycle ────────────────────────────────────────────────────────────
+lxc_state() {
+    lxc-info -n "$LXC_NAME" -P "$LXC_PATH" 2>/dev/null \
+        | awk -F: '/^State:/ { gsub(/ /,"",$2); print tolower($2) }'
+}
+
+create_lxc() {
+    if [ -d "$LXC_PATH/$LXC_NAME/rootfs" ]; then
+        log "LXC '$LXC_NAME' already exists — skipping debootstrap"
+        return
+    fi
+    log "Creating LXC '$LXC_NAME' (debian $DEBIAN_SUITE) ..."
+    lxc-create -n "$LXC_NAME" -t download -P "$LXC_PATH" -- \
+        --dist debian --release "$DEBIAN_SUITE" --arch "$(dpkg --print-architecture)"
+}
+
+write_lxc_config() {
+    log "Pinning LXC network: $LXC_IP/24 on $LXC_BRIDGE; bind mounts"
+    cat > "$LXC_PATH/$LXC_NAME/config" <<EOF
+# SecuBox-managed — see secubox-photoprism / install-lxc.sh
+lxc.include = /usr/share/lxc/config/debian.common.conf
+lxc.arch = linux64
+
+lxc.idmap = u 0 $LXC_ROOT_UID 65536
+lxc.idmap = g 0 $LXC_ROOT_UID 65536
+
+lxc.rootfs.path = dir:$LXC_PATH/$LXC_NAME/rootfs
+lxc.uts.name = $LXC_NAME
+
+lxc.net.0.type = veth
+lxc.net.0.link = $LXC_BRIDGE
+lxc.net.0.flags = up
+lxc.net.0.ipv4.address = $LXC_IP/24
+lxc.net.0.ipv4.gateway = $LXC_GW
+lxc.net.0.name = eth0
+
+# Shared photo library (Nextcloud writes here) + PhotoPrism-private dirs.
+lxc.mount.entry = $SHARED_PHOTOS var/lib/photoprism/originals none bind,create=dir 0 0
+lxc.mount.entry = $DATA_DIR/storage var/lib/photoprism/storage none bind,create=dir 0 0
+lxc.mount.entry = $DATA_DIR/import var/lib/photoprism/import none bind,create=dir 0 0
+
+lxc.cgroup2.memory.high = 1500M
+lxc.cgroup2.memory.max = 2G
+
+lxc.start.auto = 1
+lxc.start.delay = 5
+EOF
+}
+
+ensure_resolv() {
+    log "Seeding /etc/resolv.conf in LXC ..."
+    la sh -c 'rm -f /etc/resolv.conf; printf "nameserver 1.1.1.1\nnameserver 9.9.9.9\n" > /etc/resolv.conf'
+}
+
+start_lxc() {
+    [ "$(lxc_state)" = "running" ] && { log "LXC already running"; return; }
+    log "Starting LXC '$LXC_NAME' ..."
+    lxc-start -n "$LXC_NAME" -P "$LXC_PATH"
+}
+
+wait_for_network() {
+    log "Waiting for LXC network ..."
+    for _ in $(seq 1 30); do
+        la ping -c1 -W1 "$LXC_GW" >/dev/null 2>&1 && return 0
+        sleep 1
+    done
+    fail "LXC did not reach $LXC_GW within 30s"
+}
+
+# ── PhotoPrism (podman) install inside LXC ───────────────────────────────────
+install_photoprism_in_lxc() {
+    local admin_pw
+    admin_pw="$(cat "$SECRETS_DIR/photoprism-admin" 2>/dev/null || true)"
+    if [ -z "$admin_pw" ]; then
+        admin_pw="$(openssl rand -hex 16)"
+        echo "$admin_pw" > "$SECRETS_DIR/photoprism-admin"
+        chmod 600 "$SECRETS_DIR/photoprism-admin"
+    fi
+
+    log "Installing podman + PhotoPrism in '$LXC_NAME' ..."
+    la env \
+        ADMIN_PW="$admin_pw" SITE_URL="https://$PUBLIC_HOSTNAME/" \
+        IMAGE="$IMAGE" HTTP_PORT="$HTTP_PORT" AUTO_INDEX="$AUTO_INDEX" \
+        DEBIAN_FRONTEND=noninteractive LC_ALL=C LANG=C \
+        bash -e <<'INNER'
+set -euo pipefail
+echo '[1/4] podman'
+apt-get update -q
+apt-get install -y -q --no-install-recommends podman ca-certificates curl
+
+echo '[2/4] pull image'
+podman pull "$IMAGE"
+
+echo '[3/4] photoprism.service'
+cat > /etc/systemd/system/photoprism.service <<UNIT
+[Unit]
+Description=PhotoPrism (podman)
+After=network.target
+
+[Service]
+Type=simple
+ExecStartPre=-/usr/bin/podman rm -f photoprism
+ExecStart=/usr/bin/podman run --rm --name photoprism \\
+  --network=host \\
+  -v /var/lib/photoprism/originals:/photoprism/originals \\
+  -v /var/lib/photoprism/storage:/photoprism/storage \\
+  -v /var/lib/photoprism/import:/photoprism/import \\
+  -e PHOTOPRISM_ADMIN_USER=admin \\
+  -e PHOTOPRISM_ADMIN_PASSWORD=${ADMIN_PW} \\
+  -e PHOTOPRISM_DATABASE_DRIVER=sqlite \\
+  -e PHOTOPRISM_HTTP_HOST=0.0.0.0 \\
+  -e PHOTOPRISM_HTTP_PORT=${HTTP_PORT} \\
+  -e PHOTOPRISM_AUTO_INDEX=${AUTO_INDEX} \\
+  -e PHOTOPRISM_SITE_URL="${SITE_URL}" \\
+  ${IMAGE}
+ExecStop=/usr/bin/podman stop photoprism
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+echo '[4/4] index timer (catches Nextcloud-synced files)'
+cat > /etc/systemd/system/photoprism-index.service <<'UNIT'
+[Unit]
+Description=PhotoPrism incremental index (picks up Nextcloud-synced photos)
+After=photoprism.service
+Requires=photoprism.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/podman exec photoprism photoprism index
+UNIT
+cat > /etc/systemd/system/photoprism-index.timer <<'UNIT'
+[Unit]
+Description=Run PhotoPrism index every 15 min
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now photoprism.service
+systemctl enable --now photoprism-index.timer
+echo '=== PhotoPrism install complete ==='
+INNER
+}
+
+verify() {
+    log "Verifying PhotoPrism on $LXC_IP:$HTTP_PORT ..."
+    for _ in $(seq 1 30); do
+        curl -fsS -o /dev/null --max-time 3 "http://$LXC_IP:$HTTP_PORT/" && { log "OK — responding."; return 0; }
+        sleep 2
+    done
+    log "WARN: not responding yet (first boot can take a while; check 'photoprismctl logs')."
+}
+
+mark_provisioned() { date -Iseconds > "$SENTINEL"; }
+
+main() {
+    require_cmds
+    ensure_dirs
+    ensure_bridge
+    ensure_masquerade
+    create_lxc
+    write_lxc_config
+    start_lxc
+    wait_for_network
+    ensure_resolv
+    install_photoprism_in_lxc
+    verify
+    mark_provisioned
+    log "Done — LXC '$LXC_NAME' at $LXC_IP, PhotoPrism running."
+    log "Admin: admin / $(cat "$SECRETS_DIR/photoprism-admin")  (rotate via UI)."
+    log "Public (wire HAProxy SNI + nginx vhost): https://$PUBLIC_HOSTNAME/"
+    log "Nextcloud side: enable the 'PhotoLibrary' external-storage mount → $SHARED_PHOTOS (secubox-nextcloud)."
+}
+
+main "$@"

--- a/packages/secubox-photoprism/sbin/photoprismctl
+++ b/packages/secubox-photoprism/sbin/photoprismctl
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# SecuBox-Deb :: photoprismctl
+# CyberMind — https://cybermind.fr
+#
+# PhotoPrism host-side controller. PhotoPrism runs as a podman container inside
+# a dedicated Debian LXC (default 10.100.0.130 on br-lxc, --network=host).
+# Photos live on /data/shared/photos (shared with Nextcloud "PhotoLibrary").
+#
+# Conventions: docs/MODULE-GUIDELINES.md §7 (mirror of peertubectl/grafanactl).
+
+set -u
+
+readonly VERSION="1.1.0"
+readonly CONFIG_FILE="${SECUBOX_PHOTOPRISM_CONFIG:-/etc/secubox/photoprism.toml}"
+readonly INSTALL_LIB="${SECUBOX_INSTALL_LIB:-/usr/share/secubox/lib/photoprism/install-lxc.sh}"
+
+readonly RED='\033[0;31m'; readonly GREEN='\033[0;32m'; readonly YELLOW='\033[1;33m'; readonly NC='\033[0m'
+log()  { printf '%b[photoprism]%b %s\n' "$GREEN" "$NC" "$*"; }
+warn() { printf '%b[warn]%b %s\n'    "$YELLOW" "$NC" "$*" >&2; }
+err()  { printf '%b[error]%b %s\n'   "$RED"    "$NC" "$*" >&2; }
+
+config_get() {
+    local key="$1" default="${2:-}" raw=""
+    [ -f "$CONFIG_FILE" ] && raw=$(grep -E "^[[:space:]]*${key}[[:space:]]*=" "$CONFIG_FILE" 2>/dev/null | head -1)
+    [ -z "$raw" ] && { echo "$default"; return; }
+    local val
+    val=$(echo "$raw" | cut -d= -f2- | sed 's/[[:space:]]*#.*$//' \
+        | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' | tr -d '"' | tr -d "'")
+    [ -z "$val" ] && echo "$default" || echo "$val"
+}
+
+LXC_NAME=$(config_get "name" "photoprism")
+LXC_IP=$(config_get "ip" "10.100.0.130")
+LXC_PATH=$(config_get "path" "/data/lxc")
+HTTP_PORT=$(config_get "http_port" "2342")
+PUBLIC_HOSTNAME=$(config_get "public_hostname" "photoprism.gk2.secubox.in")
+
+lxc_state() {
+    lxc-info -n "$LXC_NAME" -P "$LXC_PATH" 2>/dev/null \
+        | awk -F: '/^State:/ { gsub(/ /,"",$2); print tolower($2) }'
+}
+lxc_running() { [ "$(lxc_state)" = "running" ]; }
+svc() { lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl "$@" photoprism.service; }
+
+cmd_install() {
+    [ -f "$INSTALL_LIB" ] || { err "install script not found at $INSTALL_LIB"; exit 1; }
+    log "Running LXC bootstrap from $INSTALL_LIB ..."
+    SECUBOX_LXC_NAME="$LXC_NAME" SECUBOX_LXC_IP="$LXC_IP" SECUBOX_LXC_PATH="$LXC_PATH" \
+    SECUBOX_PHOTOPRISM_HOSTNAME="$PUBLIC_HOSTNAME" \
+        bash "$INSTALL_LIB"
+    log "Done. Try 'photoprismctl status'."
+}
+
+cmd_status() {
+    printf 'LXC %s          : %s\n' "$LXC_NAME" "$(lxc_state || echo absent)"
+    if lxc_running; then
+        printf 'photoprism.service : %s\n' "$(svc is-active 2>/dev/null || echo unknown)"
+        if curl -fsS -o /dev/null --max-time 3 "http://$LXC_IP:$HTTP_PORT/" 2>/dev/null; then
+            printf 'HTTP %s:%s     : responding\n' "$LXC_IP" "$HTTP_PORT"
+        else
+            printf 'HTTP %s:%s     : NOT responding\n' "$LXC_IP" "$HTTP_PORT"
+        fi
+        printf 'index timer        : %s\n' "$(lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl is-active photoprism-index.timer 2>/dev/null || echo unknown)"
+    fi
+    printf 'public URL         : https://%s/\n' "$PUBLIC_HOSTNAME"
+}
+
+cmd_start()   { lxc_running || lxc-start -n "$LXC_NAME" -P "$LXC_PATH"; svc start;   log "started"; }
+cmd_stop()    { lxc_running && svc stop || true;                                     log "stopped"; }
+cmd_restart() { lxc_running || lxc-start -n "$LXC_NAME" -P "$LXC_PATH"; svc restart; log "restarted"; }
+cmd_logs()    { lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- journalctl -u photoprism -n "${1:-50}" --no-pager; }
+
+cmd_index() {
+    lxc_running || { err "LXC not running"; exit 1; }
+    log "Triggering PhotoPrism index (picks up new Nextcloud-synced photos) ..."
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- podman exec photoprism photoprism index "$@"
+}
+
+cmd_reload() {
+    if nginx -t 2>/dev/null; then
+        systemctl reload nginx 2>/dev/null && log "host nginx reloaded" || warn "reload failed"
+    else
+        err "nginx -t failed; not reloading"; exit 1
+    fi
+}
+
+cmd_help() {
+    cat <<EOF
+photoprismctl $VERSION — SecuBox PhotoPrism (podman-in-LXC) controller
+
+Usage: photoprismctl <verb> [args]
+
+  install            Provision the LXC + podman + PhotoPrism (idempotent)
+  status             LXC + service + HTTP reachability + index timer
+  start|stop|restart Control photoprism.service inside the LXC
+  index [args]       Run an immediate incremental index now
+  logs [N]           Tail N lines of photoprism journal (default 50)
+  reload             Reload host nginx
+  help               This message
+
+Config: $CONFIG_FILE  — LXC $LXC_NAME @ $LXC_IP, public https://$PUBLIC_HOSTNAME/
+Photos: /data/shared/photos (shared with Nextcloud "PhotoLibrary").
+EOF
+}
+
+main() {
+    local noun="${1:-help}"; shift || true
+    case "$noun" in
+        install|status|start|stop|restart|index|logs|reload) "cmd_${noun}" "$@" ;;
+        help|-h|--help) cmd_help ;;
+        *) err "unknown verb: $noun"; cmd_help; exit 1 ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Captures the live gk2 PhotoPrism deployment in source (Source-first; mirrors
secubox-peertube #388 / PR #396). PhotoPrism runs as a podman container inside
a dedicated Debian LXC (`--network=host`); photos live on `/data/shared/photos`,
shared with Nextcloud as the "PhotoLibrary" external storage.

## Changes

- **`lib/photoprism/install-lxc.sh`** (new): idempotent LXC bootstrap
  (10.100.0.130, br-lxc, `debian.common.conf`, idmap, cgroup caps) + podman +
  `photoprism.service` (`podman run --network=host`, sqlite, `:2342`,
  `PHOTOPRISM_AUTO_INDEX=300`, generated admin password) +
  `photoprism-index.timer` (every 15 min → `photoprism index` — PhotoPrism's
  built-in auto-index only fires for its own UI uploads, NOT Nextcloud-synced
  files). Bind mounts `/data/shared/photos→originals` + `/data/photoprism/*`.
- **`sbin/photoprismctl`** (new): install/status/start/stop/restart/index/logs/reload.
- **`conf/photoprism.nginx.conf`** (new): public vhost `:9080 → 10.100.0.130:2342`,
  WAF-bypass (gitea pattern); postinst symlinks it. `conf/photoprism.toml.example`.
- **`debian/control`**: reframed Docker → native-LXC; Depends lxc/nftables/openssl.
- **`debian/postinst`**: #319 `/srv/photoprism → /data/photoprism` migration
  (was still hardcoding `/srv`); drop `/srv` mkdir; ship default toml; tolerate
  masked unit; stop shipping the `secubox-CHANGE-ME` admin password.
- README + changelog **1.1.0**.

## Test plan

- [x] `bash -n` install-lxc.sh + photoprismctl + postinst; heredocs balanced
- [x] Live integration (PhotoLibrary mount + index timer) validated on gk2
- [ ] Rebuild `.deb` + deploy to gk2 (dashboard daemon)
- [ ] `photoprismctl install` on a clean board (full LXC bootstrap)

## Related
- secubox-peertube #388 / PR #396 (same pattern)
- Nextcloud side: #398