### PR TITLE
SecuBox user provisioning: push master users into Nextcloud & PhotoPrism (#410)

### DIFF
--- a/common/secubox_core/tests/test_user_store.py
+++ b/common/secubox_core/tests/test_user_store.py
@@ -96,3 +96,47 @@ def test_fallback_to_auth_toml_when_users_json_corrupt(tmp_path: Path, monkeypat
     monkeypatch.setattr(user_store, "AUTH_TOML_PATH", auth_toml)
     caplog.set_level(logging.WARNING)
     assert user_store.verify_password("admin", "fallbackonly") is True
+
+
+# --- set_password / provisioning (#410) ---------------------------------------
+
+def test_set_password_updates_existing(tmp_path: Path, monkeypatch):
+    p = tmp_path / "users.json"
+    _write_user(p)
+    monkeypatch.setattr(user_store, "USERS_PATH", p)
+    user_store.set_password("admin", "NewPass!99zz")
+    assert user_store.verify_password("admin", "NewPass!99zz") is True
+
+
+def test_set_password_provisions_new_user(tmp_path: Path, monkeypatch):
+    p = tmp_path / "users.json"
+    _write_user(p)
+    monkeypatch.setattr(user_store, "USERS_PATH", p)
+    user_store.set_password("gk2", "Gk2Pass!77aa", provision=True, role="user")
+    assert "gk2" in user_store.list_users()
+    assert user_store.verify_password("gk2", "Gk2Pass!77aa") is True
+
+
+def test_set_password_unknown_without_provision_raises(tmp_path: Path, monkeypatch):
+    p = tmp_path / "users.json"
+    _write_user(p)
+    monkeypatch.setattr(user_store, "USERS_PATH", p)
+    with pytest.raises(KeyError):
+        user_store.set_password("ghost", "whatever")
+
+
+def test_set_password_missing_store_raises(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(user_store, "USERS_PATH", tmp_path / "nope.json")
+    with pytest.raises(RuntimeError):
+        user_store.set_password("admin", "whatever", provision=True)
+
+
+def test_set_password_preserves_other_users(tmp_path: Path, monkeypatch):
+    p = tmp_path / "users.json"
+    _write_user(p)
+    monkeypatch.setattr(user_store, "USERS_PATH", p)
+    user_store.set_password("gk2", "Gk2Pass!77aa", provision=True)
+    user_store.set_password("admin", "AdminPass!88bb")
+    assert sorted(user_store.list_users()) == ["admin", "gk2"]
+    assert user_store.verify_password("admin", "AdminPass!88bb") is True
+    assert user_store.verify_password("gk2", "Gk2Pass!77aa") is True

--- a/common/secubox_core/user_store.py
+++ b/common/secubox_core/user_store.py
@@ -102,6 +102,87 @@ def verify_password(username: str, plaintext: str) -> bool:
         return False
 
 
+def list_users() -> list[str]:
+    """Return all usernames from the canonical store (empty list on fallback/missing)."""
+    doc = _load_users_json()
+    if not doc:
+        return []
+    return [u.get("username") for u in doc.get("users", []) if u.get("username")]
+
+
+def _atomic_write_users(doc: Dict[str, Any]) -> None:
+    """Write users.json atomically, preserving 0600 + owner."""
+    import os
+    import tempfile
+    USERS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(USERS_PATH.parent), prefix=".users.", suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(doc, f, indent=2)
+            f.write("\n")
+        try:
+            if USERS_PATH.exists():
+                st = USERS_PATH.stat()
+                os.chmod(tmp, st.st_mode & 0o777)
+                os.chown(tmp, st.st_uid, st.st_gid)
+            else:
+                os.chmod(tmp, 0o600)
+        except OSError:
+            pass
+        os.replace(tmp, USERS_PATH)
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def set_password(username: str, plaintext: str, *, provision: bool = False,
+                 role: str = "user", email: Optional[str] = None) -> Dict[str, Any]:
+    """Set a user's password (argon2) in the canonical store and return the user.
+
+    This is the single password *write* path, and therefore the natural
+    capture point for downstream provisioning (push the same plaintext into
+    Nextcloud/PhotoPrism right after calling this). If the user is absent and
+    ``provision`` is True a new enabled user is created.
+
+    Raises KeyError if the user is absent and ``provision`` is False, and
+    RuntimeError if the canonical store is missing (fallback can't be written).
+    """
+    if not username or not plaintext:
+        raise ValueError("username and plaintext are required")
+    doc = _load_users_json()
+    if doc is None:
+        raise RuntimeError("users.json missing/corrupt; refusing to write")
+    doc.setdefault("users", [])
+    hash_ = _HASHER.hash(plaintext)
+    for u in doc["users"]:
+        if u.get("username") == username:
+            u["password_hash"] = hash_
+            u["must_change_password"] = False
+            if email is not None:
+                u["email"] = email
+            _atomic_write_users(doc)
+            log.info("user_store: password set for %s", username)
+            return u
+    if not provision:
+        raise KeyError(f"unknown user {username!r} (pass provision=True to create)")
+    new_user = {
+        "username": username,
+        "email": email,
+        "role": role,
+        "enabled": True,
+        "password_hash": hash_,
+        "must_change_password": False,
+        "totp": None,
+        "google": None,
+    }
+    doc["users"].append(new_user)
+    _atomic_write_users(doc)
+    log.info("user_store: provisioned new user %s (role=%s)", username, role)
+    return new_user
+
+
 def load_with_fallback() -> Dict[str, Any]:
     """Return {'source': 'users.json'|'auth.toml.fallback', 'users': [...]}.
 

--- a/packages/secubox-core/debian/rules
+++ b/packages/secubox-core/debian/rules
@@ -64,5 +64,8 @@ override_dh_auto_install:
 	               debian/secubox-core/usr/sbin/
 	install -m 755 usr/sbin/secubox-led-k2000 \
 	               debian/secubox-core/usr/sbin/
+	# User provisioning push (gk2/admin → Nextcloud/PhotoPrism, #410)
+	install -m 755 usr/sbin/secubox-user-sync \
+	               debian/secubox-core/usr/sbin/
 	install -m 644 systemd/secubox-led-heartbeat.service \
 	               debian/secubox-core/usr/lib/systemd/system/

--- a/packages/secubox-core/usr/sbin/secubox-user-sync
+++ b/packages/secubox-core/usr/sbin/secubox-user-sync
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+SecuBox-Deb :: secubox-user-sync
+
+Provisioning push: SecuBox is the single source of truth for user accounts.
+Setting a user's password here writes the canonical argon2 hash and pushes the
+same plaintext into every login-capable app that exposes a `<app>ctl
+user-provision` verb (Nextcloud, PhotoPrism, …). The plaintext is passed to the
+provisioners via the SECUBOX_USER_PASSWORD environment variable, never on argv.
+
+Master users `gk2` (host handler) and `admin` (management) must exist
+everywhere — `seed` provisions both.
+
+Usage:
+  secubox-user-sync set <user> [--role admin|user] [--email E] [--password-stdin]
+  secubox-user-sync seed                # (re)set gk2 + admin, prompting for each
+  secubox-user-sync sync <user>         # re-push existing account (prompts pwd)
+  secubox-user-sync list                # master users + per-app provisioning state
+  Add --dry-run to print actions without executing.
+"""
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+import shutil
+import subprocess
+import sys
+
+sys.path.insert(0, "/usr/lib/python3/dist-packages")
+try:
+    from secubox_core import user_store
+except Exception as exc:  # pragma: no cover
+    print(f"error: cannot import secubox_core.user_store: {exc}", file=sys.stderr)
+    sys.exit(2)
+
+MASTER_USERS = ("gk2", "admin")
+
+# (label, ctl binary, extra args builder). A provisioner is used only if its
+# ctl is installed on PATH — keeps core decoupled from which apps are present.
+PROVISIONERS = [
+    ("nextcloud", "nextcloudctl", lambda user, role: ["user-provision", user]),
+    ("photoprism", "photoprismctl", lambda user, role: ["user-provision", user, role]),
+]
+
+
+def _read_password(args) -> str:
+    if getattr(args, "password_stdin", False):
+        pw = sys.stdin.readline().rstrip("\n")
+        if not pw:
+            sys.exit("error: empty password on stdin")
+        return pw
+    pw = getpass.getpass(f"New password for {args.user}: ")
+    pw2 = getpass.getpass("Confirm: ")
+    if pw != pw2:
+        sys.exit("error: passwords do not match")
+    if not pw:
+        sys.exit("error: empty password")
+    return pw
+
+
+def _run_provisioners(user: str, role: str, password: str, dry_run: bool) -> int:
+    failures = 0
+    for label, ctl, build in PROVISIONERS:
+        if not shutil.which(ctl):
+            print(f"  - {label}: skipped ({ctl} not installed)")
+            continue
+        argv = [ctl, *build(user, role)]
+        if dry_run:
+            print(f"  - {label}: would run: {' '.join(argv)} (password via env)")
+            continue
+        env = dict(os.environ, SECUBOX_USER_PASSWORD=password)
+        try:
+            r = subprocess.run(argv, env=env, capture_output=True, text=True, timeout=120)
+        except Exception as exc:
+            print(f"  - {label}: ERROR ({exc})")
+            failures += 1
+            continue
+        if r.returncode == 0:
+            print(f"  - {label}: ok")
+        else:
+            print(f"  - {label}: FAILED (rc={r.returncode}) {(r.stderr or r.stdout).strip()[:200]}")
+            failures += 1
+    return failures
+
+
+def cmd_set(args) -> int:
+    password = _read_password(args)
+    if args.dry_run:
+        print(f"[dry-run] would set canonical password for {args.user} "
+              f"(role={args.role}, provision=True)")
+    else:
+        user_store.set_password(args.user, password, provision=True,
+                                role=args.role, email=args.email)
+        print(f"canonical password set for {args.user} (role={args.role})")
+    print("pushing to apps:")
+    fails = _run_provisioners(args.user, args.role, password, args.dry_run)
+    return 1 if fails else 0
+
+
+def cmd_seed(args) -> int:
+    rc = 0
+    for user in MASTER_USERS:
+        role = "admin" if user == "admin" else "user"
+        print(f"== {user} (role={role}) ==")
+        ns = argparse.Namespace(user=user, role=role, email=None,
+                                password_stdin=False, dry_run=args.dry_run)
+        rc |= cmd_set(ns)
+    return rc
+
+
+def cmd_sync(args) -> int:
+    if args.user not in user_store.list_users():
+        print(f"warning: {args.user} not in canonical store; use 'set' to provision",
+              file=sys.stderr)
+    return cmd_set(args)
+
+
+def cmd_list(args) -> int:
+    masters = set(MASTER_USERS)
+    core_users = user_store.list_users()
+    print("canonical (SecuBox) users:")
+    for u in sorted(set(core_users) | masters):
+        tags = []
+        if u in masters:
+            tags.append("master")
+        if u not in core_users:
+            tags.append("MISSING-in-core")
+        print(f"  - {u}{' [' + ', '.join(tags) + ']' if tags else ''}")
+    print("\nprovisioners available:")
+    for label, ctl, _ in PROVISIONERS:
+        print(f"  - {label}: {'yes' if shutil.which(ctl) else 'no (' + ctl + ' absent)'}")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(prog="secubox-user-sync", description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--dry-run", action="store_true", help="print actions, change nothing")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("set", help="set a user's password and push to apps")
+    sp.add_argument("user")
+    sp.add_argument("--role", choices=["admin", "user"], default="user")
+    sp.add_argument("--email", default=None)
+    sp.add_argument("--password-stdin", action="store_true",
+                    help="read password from stdin instead of prompting")
+    sp.set_defaults(func=cmd_set)
+
+    ss = sub.add_parser("seed", help="(re)set the master users gk2 + admin")
+    ss.set_defaults(func=cmd_seed)
+
+    sy = sub.add_parser("sync", help="re-push an existing user (prompts for password)")
+    sy.add_argument("user")
+    sy.add_argument("--role", choices=["admin", "user"], default="user")
+    sy.add_argument("--email", default=None)
+    sy.add_argument("--password-stdin", action="store_true")
+    sy.set_defaults(func=cmd_sync)
+
+    sl = sub.add_parser("list", help="show master users + provisioner availability")
+    sl.set_defaults(func=cmd_list)
+
+    args = p.parse_args()
+    try:
+        return args.func(args)
+    except (KeyError, RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/secubox-nextcloud/sbin/nextcloudctl
+++ b/packages/secubox-nextcloud/sbin/nextcloudctl
@@ -479,11 +479,17 @@ user_provision() {
     [ -z "$password" ] && { error "SECUBOX_USER_PASSWORD not set"; return 1; }
     if ! lxc_running; then error "Container not running."; return 1; fi
 
+    # Password travels via stdin → OC_PASS (export + sudo --preserve-env, since
+    # sudo otherwise strips it); username/display passed as argv, not embedded —
+    # safe for special characters in either field.
     if occ user:list --output=json 2>/dev/null | grep -q "\"$username\""; then
         log "Resetting password for existing Nextcloud user: $username"
-        lxc_attach "export OC_PASS='$password' && sudo -u www-data php /var/www/nextcloud/occ user:resetpassword --password-from-env '$username'"
+        printf '%s' "$password" | lxc-attach -n "$CONTAINER" -P "$LXC_PATH" -- sh -c \
+            'IFS= read -r OC_PASS; export OC_PASS; sudo --preserve-env=OC_PASS -u www-data php /var/www/nextcloud/occ user:resetpassword --password-from-env "$1"' _ "$username"
     else
-        user_add "$username" "$password" "$display_name"
+        log "Creating Nextcloud user: $username"
+        printf '%s' "$password" | lxc-attach -n "$CONTAINER" -P "$LXC_PATH" -- sh -c \
+            'IFS= read -r OC_PASS; export OC_PASS; sudo --preserve-env=OC_PASS -u www-data php /var/www/nextcloud/occ user:add --password-from-env --display-name="$1" "$2"' _ "$display_name" "$username"
     fi
 
     # Per-user photo folder: /data/shared/photos/<user> (host) = /media/photos/<user> (container).

--- a/packages/secubox-nextcloud/sbin/nextcloudctl
+++ b/packages/secubox-nextcloud/sbin/nextcloudctl
@@ -467,6 +467,44 @@ user_list() {
     occ user:list --output=json
 }
 
+# Provisioning push entry point (#410): called by secubox-user-sync. Password
+# arrives via $SECUBOX_USER_PASSWORD (never argv). Idempotent: creates the user
+# or resets the password, then ensures a per-user photo folder + a Photos
+# external storage scoped to that user only.
+user_provision() {
+    local username="$1"
+    local display_name="${2:-$username}"
+    local password="${SECUBOX_USER_PASSWORD:-}"
+    [ -z "$username" ] && { echo "Usage: SECUBOX_USER_PASSWORD=... nextcloudctl user-provision <username> [display]"; return 1; }
+    [ -z "$password" ] && { error "SECUBOX_USER_PASSWORD not set"; return 1; }
+    if ! lxc_running; then error "Container not running."; return 1; fi
+
+    if occ user:list --output=json 2>/dev/null | grep -q "\"$username\""; then
+        log "Resetting password for existing Nextcloud user: $username"
+        lxc_attach "export OC_PASS='$password' && sudo -u www-data php /var/www/nextcloud/occ user:resetpassword --password-from-env '$username'"
+    else
+        user_add "$username" "$password" "$display_name"
+    fi
+
+    # Per-user photo folder: /data/shared/photos/<user> (host) = /media/photos/<user> (container).
+    mkdir -p "$SHARED_PHOTOS/$username" && chmod 0777 "$SHARED_PHOTOS/$username"
+    lxc_attach "sudo -u www-data php /var/www/nextcloud/occ app:enable files_external" >/dev/null 2>&1 || true
+    if occ files_external:list 2>/dev/null | grep -q "Photos-$username"; then
+        log "Per-user Photos storage already present for $username"
+    else
+        local mid
+        mid=$(lxc_attach "sudo -u www-data php /var/www/nextcloud/occ files_external:create 'Photos-$username' local null::null -c datadir=/media/photos/$username" 2>/dev/null | grep -oE '[0-9]+' | head -1)
+        if [ -n "$mid" ]; then
+            lxc_attach "sudo -u www-data php /var/www/nextcloud/occ files_external:applicable $mid --add-user '$username'" >/dev/null 2>&1 || true
+            lxc_attach "sudo -u www-data php /var/www/nextcloud/occ files_external:option $mid filesystem_check_changes 1" >/dev/null 2>&1 || true
+            log "Per-user Photos storage for $username (mount $mid → /media/photos/$username)"
+        else
+            warn "Could not create per-user Photos storage for $username"
+        fi
+    fi
+    log "Provisioned Nextcloud user: $username"
+}
+
 # ============================================================================
 # App Management
 # ============================================================================
@@ -828,6 +866,7 @@ case "${1:-}" in
         esac
         ;;
     link-photos) link_photos ;;
+    user-provision) shift; user_provision "$@" ;;
     occ) shift; occ "$@" ;;
     backup) shift; cmd_backup "$@" ;;
     restore) shift; cmd_restore "$@" ;;

--- a/packages/secubox-photoprism/sbin/photoprismctl
+++ b/packages/secubox-photoprism/sbin/photoprismctl
@@ -85,6 +85,37 @@ cmd_reload() {
     fi
 }
 
+# Provisioning push (#410): called by secubox-user-sync. Password via
+# $SECUBOX_USER_PASSWORD (piped over stdin, never argv on the host). Idempotent:
+# resets an existing user's password, or creates a new one scoped to a per-user
+# base path (originals/<user> = /data/shared/photos/<user>). `admin` is left
+# unrestricted (management); regular users are confined to their folder.
+cmd_user_provision() {
+    local username="${1:-}" role="${2:-user}"
+    local password="${SECUBOX_USER_PASSWORD:-}"
+    [ -z "$username" ] && { err "usage: SECUBOX_USER_PASSWORD=... photoprismctl user-provision <user> [role]"; return 1; }
+    [ -z "$password" ] && { err "SECUBOX_USER_PASSWORD not set"; return 1; }
+    case "$username" in *[!a-zA-Z0-9._-]*) err "invalid username"; return 1 ;; esac
+    lxc_running || { err "LXC not running"; return 1; }
+
+    local shared; shared=$(config_get "shared_photos" "/data/shared/photos")
+    mkdir -p "$shared/$username" && chmod 0777 "$shared/$username"
+
+    local pp_role="user"; [ "$role" = "admin" ] && pp_role="admin"
+    local verb opts
+    if lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- podman exec photoprism photoprism users ls 2>/dev/null | grep -qw "$username"; then
+        verb="mod"; opts=""
+        log "Resetting PhotoPrism password for $username"
+    else
+        verb="add"
+        opts="--role $pp_role"
+        [ "$pp_role" != "admin" ] && opts="$opts --base-path $username --upload-path $username"
+        log "Creating PhotoPrism user $username (role=$pp_role)"
+    fi
+    printf '%s\n' "$password" | lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- \
+        podman exec -i photoprism sh -c "read -r PPW; photoprism users $verb -p \"\$PPW\" $opts \"$username\""
+}
+
 cmd_help() {
     cat <<EOF
 photoprismctl $VERSION — SecuBox PhotoPrism (podman-in-LXC) controller
@@ -95,6 +126,7 @@ Usage: photoprismctl <verb> [args]
   status             LXC + service + HTTP reachability + index timer
   start|stop|restart Control photoprism.service inside the LXC
   index [args]       Run an immediate incremental index now
+  user-provision <user> [role]  Create/sync a user (SECUBOX_USER_PASSWORD env)
   logs [N]           Tail N lines of photoprism journal (default 50)
   reload             Reload host nginx
   help               This message
@@ -108,6 +140,7 @@ main() {
     local noun="${1:-help}"; shift || true
     case "$noun" in
         install|status|start|stop|restart|index|logs|reload) "cmd_${noun}" "$@" ;;
+        user-provision) cmd_user_provision "$@" ;;
         help|-h|--help) cmd_help ;;
         *) err "unknown verb: $noun"; cmd_help; exit 1 ;;
     esac

--- a/packages/secubox-photoprism/sbin/photoprismctl
+++ b/packages/secubox-photoprism/sbin/photoprismctl
@@ -108,8 +108,14 @@ cmd_user_provision() {
         log "Resetting PhotoPrism password for $username"
     else
         verb="add"
-        opts="--role $pp_role"
-        [ "$pp_role" != "admin" ] && opts="$opts --base-path $username --upload-path $username"
+        # PhotoPrism CE only offers the admin role for free; other roles need a
+        # paid membership. So: admin → --superadmin; everyone else → the default
+        # role, scoped by --upload-path (the only per-user scoping CE provides).
+        if [ "$pp_role" = "admin" ]; then
+            opts="--superadmin"
+        else
+            opts="--upload-path $username"
+        fi
         log "Creating PhotoPrism user $username (role=$pp_role)"
     fi
     printf '%s\n' "$password" | lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- \


### PR DESCRIPTION
## Summary
- SecuBox is the single source of truth for app logins. `user_store.set_password()` (the one password write-path = capture point) + `list_users()`; new host CLI **`secubox-user-sync`** (`set`/`seed`/`sync`/`list`) writes the canonical argon2 hash, then pushes the same plaintext (via env/stdin, never argv) into each app's new `<app>ctl user-provision` verb.
- **nextcloudctl** + **photoprismctl** gain `user-provision`: idempotent create/reset, a per-user photo folder `/data/shared/photos/<user>`, and a user-scoped library (NC external storage scoped to the user; PhotoPrism `--upload-path`). `admin` stays unrestricted (management); others scoped.
- `gk2` + `admin` are always provisioned (`seed`).

## Validated
- 13/13 unit tests for `set_password` (provision, update, preserve-others, error paths).
- Deployed to gk2 and validated end-to-end with a throwaway user (created + per-user folder/storage in both NC and PhotoPrism, then removed). Two bugs caught + fixed during validation:
  - NC: `sudo` strips `OC_PASS` → pipe via stdin + `--preserve-env` (special-char safe).
  - PhotoPrism CE gates non-admin roles behind paid membership → default role + `--upload-path`.

## Operator step
Seeding sets the master passwords (argon2 is one-way, can't be copied), so it's run by the operator:
```
secubox-user-sync seed     # prompts for gk2, then admin
```

## Notes
- PhotoPrism CE has no per-user *view* confinement via CLI (NC side is fully per-user isolated).
- The board's stale `nextcloudctl` (v1.3.0) was upgraded to the source version as part of live validation.

Closes #410