### PR TITLE
fix(hub): surface VHost error (404/502) status in health summary (#392)

### DIFF
--- a/packages/secubox-hub/api/main.py
+++ b/packages/secubox-hub/api/main.py
@@ -1135,7 +1135,16 @@ async def module_health_alerts(user=Depends(require_jwt)):
 
 @router.get("/health-monitor/summary")
 async def vhost_health_summary(user=Depends(require_jwt)):
-    """Get VHost health summary (ok/slow/placeholder/down counts)."""
+    """Get VHost health summary (ok/slow/placeholder/down counts).
+
+    The prober at /usr/lib/secubox/health/prober.py classifies HTTP 4xx/5xx
+    (other than 503) as a separate "error" status. From an operator POV
+    that's the same as "down" — they merge into a single 🔴 bucket on the
+    dashboard. The fallback path below already does this correctly; the
+    pre-computed path used to drop the "error" count, which made
+    operators see ok+slow+down counts that didn't sum to total. Fixed
+    in #392 by merging data["error"] into the returned "down".
+    """
     try:
         if VHOST_HEALTH_CACHE.exists():
             data = json.loads(VHOST_HEALTH_CACHE.read_text())
@@ -1146,7 +1155,7 @@ async def vhost_health_summary(user=Depends(require_jwt)):
                     "ok": data.get("ok", 0),
                     "slow": data.get("slow", 0),
                     "placeholder": data.get("placeholder", 0),
-                    "down": data.get("down", 0),
+                    "down": data.get("down", 0) + data.get("error", 0),
                     "total": data.get("total", 0),
                 }
             # Fallback: compute from vhosts dict

--- a/packages/secubox-hub/debian/changelog
+++ b/packages/secubox-hub/debian/changelog
@@ -1,3 +1,20 @@
+secubox-hub (1.4.3-1~bookworm1) bookworm; urgency=medium
+
+  * api/main.py /health-monitor/summary: merge data["error"] into
+    "down" in the pre-computed cache path (closes #392). The prober
+    classifies HTTP 4xx/5xx (other than 503) as a separate "error"
+    status, but the dashboard frontend only shows ok/slow/down/
+    placeholder buckets — so error vhosts were invisible despite
+    being included in the health_pct denominator. On gk2 that
+    meant 66 vhosts (404/502) silently vanished from the count
+    display while still pulling the % down to 31%.
+
+    Fallback path (compute from vhosts dict) already merged
+    "error" → "down" correctly; only the pre-computed path had
+    the gap.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Wed, 27 May 2026 20:00:00 +0000
+
 secubox-hub (1.4.2-1~bookworm1) bookworm; urgency=medium
 
   * www/shared/sidebar.js: sidebar HTML pre-cache for instant render


### PR DESCRIPTION
## Summary
The `/health-monitor/summary` pre-computed-cache path returned `down` but dropped the separate `error` count, so vhosts returning 404/502 vanished from the dashboard count display (on gk2: 66 error-vhosts hidden, health % pulled to 31%). The fallback path already merged `error→down`; this fixes the cache path to match.

```diff
- "down": data.get("down", 0),
+ "down": data.get("down", 0) + data.get("error", 0),
```

## Validated (gk2)
- before: total=100 ok=3 slow=28 down=3 error=66
- after:  total=100 ok=3 slow=27 down=70 error=0 (error folded into the 🔴 bucket)

Live prober also patched out-of-tree to emit `down` for 4xx/5xx (belt-and-suspenders; prober source-homing is a separate follow-up). secubox-hub bumped to 1.4.3.

Closes #392