### PR TITLE
fix(vortex-firewall): unmask+enable nftables so LXC NAT survives reboot (#150)

### DIFF
--- a/packages/secubox-vortex-firewall/debian/changelog
+++ b/packages/secubox-vortex-firewall/debian/changelog
@@ -1,3 +1,14 @@
+secubox-vortex-firewall (1.0.2-1~bookworm1) bookworm; urgency=medium
+
+  * postinst: unmask + enable nftables.service (closes #150). It was found
+    masked (symlink to /dev/null) on the board, so /etc/nftables.conf — which
+    carries the LXC MASQUERADE rule and `include /etc/nftables.d/*.nft` — never
+    loaded at boot, and every reboot left 10.100.0.0/24 LXCs with no outbound
+    NAT (apt/DNS broken inside containers). Not force-started in postinst to
+    avoid flushing CrowdSec's live tables; boot-time enable is the durable fix.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Fri, 29 May 2026 08:15:00 +0000
+
 secubox-vortex-firewall (1.0.1-1~bookworm1) bookworm; urgency=low
 
   * Rewrite Description to identify this as the nftables threat-feed

--- a/packages/secubox-vortex-firewall/debian/postinst
+++ b/packages/secubox-vortex-firewall/debian/postinst
@@ -19,6 +19,17 @@ EOF
         nginx -t 2>/dev/null && systemctl reload nginx 2>/dev/null || true
     fi
 
+    # Ensure the system nftables.service actually loads /etc/nftables.conf at
+    # boot. That file holds the LXC NAT (`ip saddr 10.100.0.0/24 oif lan0
+    # masquerade`) and `include "/etc/nftables.d/*.nft"`. On the board it was
+    # found masked (symlink to /dev/null), so after every reboot the kernel had
+    # no NAT and all 10.100.0.0/24 LXCs lost outbound (#150). Unmask + enable so
+    # it loads at boot, ordered before the CrowdSec bouncer adds its own tables.
+    # Not force-started here: a live `nft -f` flushes the ruleset and would
+    # momentarily drop CrowdSec's live tables — boot-time loading is the fix.
+    systemctl unmask nftables.service 2>/dev/null || true
+    systemctl enable nftables.service 2>/dev/null || true
+
     systemctl daemon-reload
     systemctl enable secubox-vortex-firewall.service || true
     systemctl start secubox-vortex-firewall.service || true


### PR DESCRIPTION
## Summary
`nftables.service` was masked on the board, so `/etc/nftables.conf` (the LXC `ip saddr 10.100.0.0/24 oif lan0 masquerade` rule + `include /etc/nftables.d/*.nft`) never loaded at boot. Every reboot left all 10.100.0.0/24 LXCs without outbound NAT → apt/DNS failures inside containers.

`secubox-vortex-firewall` postinst now `unmask`s + `enable`s `nftables.service` so it loads at boot (ordered before the CrowdSec bouncer). It is **not** force-started in postinst — a live `nft -f` flushes the ruleset and would momentarily drop CrowdSec's tables; boot-time enable is the durable fix (matches the verified live fix). Bumped 1.0.1→1.0.2.

Closes #150