### PR TITLE
fix(waf): skip cred-004 on Nextcloud mobile login + WebDAV (#395)

### DIFF
--- a/packages/secubox-waf/debian/changelog
+++ b/packages/secubox-waf/debian/changelog
@@ -1,3 +1,14 @@
+secubox-waf (1.1.3-1~bookworm1) bookworm; urgency=medium
+
+  * mitmproxy/secubox_waf.py: skip cred-004 check on Nextcloud mobile
+    login + WebDAV endpoints (closes #395). NC's `/index.php/login/v2/
+    poll?token=…` and `/ocs/v2.php/core/login` use short-lived tokens
+    in URLs by design — cred-004 ("JWT/token in URL") flagged them as
+    credential leaks and banned the client after 3 polls (BAN_THRESHOLD).
+    NC enforces its own token TTL + bf protection on those endpoints.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Wed, 27 May 2026 21:30:00 +0000
+
 secubox-waf (1.1.2-1~bookworm1) bookworm; urgency=medium
 
   * Move expensive /stats, /alerts and /bans computations off the

--- a/packages/secubox-waf/mitmproxy/secubox_waf.py
+++ b/packages/secubox-waf/mitmproxy/secubox_waf.py
@@ -572,6 +572,12 @@ class SecuBoxWAF:
             return None
         if "/health" in path_lower or "/status" in path_lower or "system_health" in path_lower:
             return None
+        # NC mobile auth + WebDAV use short-lived tokens in URL by design;
+        # cred-004 ("JWT/token in URL") false-positives them and bans the
+        # client after 3 polls. NC enforces its own token TTL + bf
+        # protection. See #395.
+        if "/index.php/login/v2/" in path_lower or "/ocs/v2.php/core/login" in path_lower:
+            return None
         raw_query = dict(flow.request.query) if flow.request.query else {}
         query_str = " ".join(f"{k}={v}" for k, v in raw_query.items())
         


### PR DESCRIPTION
## Summary
The WAF `cred-004` rule fired on Nextcloud's mobile login-v2 poll (`/index.php/login/v2/poll`) and WebDAV endpoints — 1 false-positive 403/sec against the official NC mobile client. These endpoints are gated by NC's own token TTL + bruteforce protection, so excluding them from cred-004 is safe.

## Validated (gk2)
Same 6-line patch applied live to `/srv/mitmproxy/secubox_waf.py` + mitmproxy restarted: 0 new 403s in 45s (was ~1/sec). Bumped secubox-waf 1.1.2→1.1.3.

> Note: the live addon is served from the `secubox-mitmproxy` package copy; this backport lands in the `secubox-waf` copy. Reconciling the two addon copies is a separate drift cleanup.

Closes #395