### PR TITLE
fix(ci): pass -a matrix.arch to dpkg-buildpackage — unblocks arm64 jobs + APT publish (#427)

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -197,7 +197,15 @@ jobs:
             exit 0
           fi
 
-          dpkg-buildpackage -us -uc -b
+          # Pass -a so the build targets matrix.arch — on the amd64 runner,
+          # without -a, dpkg defaults to amd64 and Architecture-specific
+          # packages (e.g. secubox-sentinelle-gsm = Architecture: arm64)
+          # produce no binary → dpkg-genbuildinfo fails with
+          # "no binary artifacts found" (#427). For amd64 jobs this is a
+          # no-op; for arm64 jobs that don't compile native code (Python +
+          # prebuilt arm64 binaries — like sentinelle-gsm), -a arm64 is
+          # enough to cross-stamp the .deb.
+          dpkg-buildpackage -us -uc -b -a ${{ matrix.arch }}
 
           echo "✅ Build OK: ${{ matrix.package }} (${{ matrix.arch }})"
 


### PR DESCRIPTION
Closes #427. The actual blocker behind 'sentinelle-gsm arm64 failure since v2.13.0'. Combined with #425 (shlibdeps -X) already on master, this should finally let `publish` go green in v2.13.3.