### PR TITLE
kiosk: enable cursor on Pi 400 (remove -nocursor — keyboard+mouse form factor)

### DIFF
--- a/image/build-rpi-usb.sh
+++ b/image/build-rpi-usb.sh
@@ -958,7 +958,7 @@ Conflicts=getty@tty7.service
 Type=simple
 User=root
 Environment=HOME=/root
-ExecStart=/usr/bin/startx -- :0 vt7 -nocursor
+ExecStart=/usr/bin/startx -- :0 vt7
 Restart=on-failure
 RestartSec=5
 StandardInput=tty


### PR DESCRIPTION
Closes #444