### PR TITLE
Add WiFi mesh kernel stack + firmware + userspace (CM-MESH-MPCIE-2026-06 v0.2.1, closes #456 gaps 2-4)

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -112,6 +112,12 @@ jobs:
           grep -q "CONFIG_ZRAM=m" .config           || (echo "FAIL: ZRAM module missing" && exit 1)
           grep -q "^CONFIG_ZRAM_DEF_COMP_ZSTD=y" .config || (echo "FAIL: ZRAM zstd default missing" && exit 1)
 
+          # Wireless mesh stack (CM-MESH-MPCIE-2026-06 v0.2.1)
+          grep -q "CONFIG_MT76x2U=m"   .config || (echo "FAIL: mt76x2u missing"  && exit 1)
+          grep -q "CONFIG_ATH10K_PCI=m" .config || (echo "FAIL: ath10k_pci missing" && exit 1)
+          grep -q "CONFIG_ATH9K_HTC=m" .config || (echo "FAIL: ath9k_htc missing" && exit 1)
+          grep -q "CONFIG_MAC80211_MESH=y" .config || (echo "FAIL: 802.11s missing" && exit 1)
+
       - name: Build kernel .deb (bindeb-pkg)
         run: |
           cd /tmp/build/linux-${KERNEL_VERSION}

--- a/board/mochabin/kernel/config-6.12-openwrt-merged.fragment
+++ b/board/mochabin/kernel/config-6.12-openwrt-merged.fragment
@@ -440,3 +440,43 @@ CONFIG_USB_NET_CDCETHER=y
 CONFIG_USB_NET_CDC_NCM=y
 CONFIG_USB_NET_RNDIS_HOST=y
 
+
+#=============================================================================
+# WIRELESS / WIFI (CM-MESH-MPCIE-2026-06 v0.2.1)
+# Backhaul mesh : QCA9880 / WLE900VX mPCIe → ath10k_pci (3x3 5 GHz)
+# Access client : MT7632U USB → mt76x2u
+# Audit option  : AR9271 USB firmware-free → ath9k_htc
+# All built as modules (=m) so they can be blacklisted per-node.
+#=============================================================================
+CONFIG_WIRELESS=y
+CONFIG_CFG80211=m
+CONFIG_CFG80211_WEXT=y
+CONFIG_MAC80211=m
+CONFIG_MAC80211_MESH=y
+CONFIG_MAC80211_HWMP=y
+CONFIG_MAC80211_RC_MINSTREL=y
+CONFIG_MAC80211_LEDS=y
+
+# Atheros family — ath10k_pci for QCA9880 backhaul, ath9k_htc for AR9271 USB
+CONFIG_WLAN_VENDOR_ATH=y
+CONFIG_ATH_COMMON=m
+CONFIG_ATH10K=m
+CONFIG_ATH10K_PCI=m
+CONFIG_ATH9K_HW=m
+CONFIG_ATH9K_COMMON=m
+CONFIG_ATH9K_HTC=m
+
+# MediaTek family — mt76x2u USB (MT7632U / S305-8946-1A4C)
+CONFIG_WLAN_VENDOR_MEDIATEK=y
+CONFIG_MT76_CORE=m
+CONFIG_MT76_USB=m
+CONFIG_MT76x02_LIB=m
+CONFIG_MT76x02_USB=m
+CONFIG_MT76x2_COMMON=m
+CONFIG_MT76x2U=m
+
+# Wireless regulatory database (FR domain lock, see secubox-mesh postinst)
+CONFIG_CFG80211_CRDA_SUPPORT=n
+CONFIG_CFG80211_REQUIRE_SIGNED_REGDB=y
+CONFIG_CFG80211_USE_KERNEL_REGDB_KEYS=y
+

--- a/image/build-mochabin-live-usb.sh
+++ b/image/build-mochabin-live-usb.sh
@@ -177,7 +177,7 @@ mkdir -p "${ROOTFS}"
 # Core system packages
 INCLUDE_PKGS="systemd,systemd-sysv,dbus,netplan.io,nftables,openssh-server,locales"
 INCLUDE_PKGS+=",python3,python3-pip,nginx,curl,wget,ca-certificates,gnupg,console-setup"
-INCLUDE_PKGS+=",iproute2,iputils-ping,ethtool,net-tools,wireguard-tools"
+INCLUDE_PKGS+=",iproute2,iputils-ping,ethtool,net-tools,wireguard-tools,iw,hostapd,wpasupplicant"
 INCLUDE_PKGS+=",sudo,less,vim-tiny,logrotate,cron,rsync,jq,dnsmasq"
 INCLUDE_PKGS+=",linux-image-arm64,live-boot,live-boot-initramfs-tools,live-config,live-config-systemd"
 INCLUDE_PKGS+=",pciutils,usbutils,parted,dosfstools,e2fsprogs,lsb-release,gdisk"

--- a/image/build-mochabin-live-usb.sh
+++ b/image/build-mochabin-live-usb.sh
@@ -194,6 +194,12 @@ INCLUDE_PKGS+=",bridge-utils,dnsutils,iputils-arping,avahi-daemon,avahi-utils"
 INCLUDE_PKGS+=",ieee-data,procps,openssl,haproxy,qrencode"
 INCLUDE_PKGS+=",fonts-noto-color-emoji"
 
+# WiFi firmware + regulatory (CM-MESH-MPCIE-2026-06 v0.2.1)
+#   firmware-misc-nonfree : mt7662 (MT7632U) + ath10k (QCA9880) blobs
+#   firmware-atheros      : htc_9271.fw (AR9271 USB) — firmware-free option
+#   wireless-regdb        : signed regulatory DB, FR domain lock at postinst
+INCLUDE_PKGS+=",firmware-misc-nonfree,firmware-atheros,wireless-regdb"
+
 # Cross-architecture debootstrap with QEMU
 debootstrap --arch=arm64 --foreign --include="${INCLUDE_PKGS}" \
     "${SUITE}" "${ROOTFS}" "${APT_MIRROR}"

--- a/packages/secubox-mesh/debian/control
+++ b/packages/secubox-mesh/debian/control
@@ -1,0 +1,29 @@
+Source: secubox-mesh
+Section: net
+Priority: optional
+Maintainer: Gerald KERMA <devel@cybermind.fr>
+Build-Depends: debhelper-compat (= 13), dh-python, python3-all
+Standards-Version: 4.6.2
+Homepage: https://cybermind.fr/secubox
+Rules-Requires-Root: no
+
+Package: secubox-mesh
+Architecture: all
+Depends: ${misc:Depends}, ${python3:Depends},
+ secubox-core (>= 1.0),
+ python3 (>= 3.11),
+ python3-fastapi | python3-pip,
+ python3-uvicorn | python3-pip,
+ python3-jinja2,
+ python3-pydantic,
+ iw,
+ hostapd,
+ wpasupplicant,
+ wireless-regdb
+Description: SecuBox-DEB MESH module (802.11s + Passpoint AP, OPAD)
+ Plan de contrôle FastAPI pour le module mesh : 802.11s/HWMP backhaul
+ (ath10k_pci QCA9880 par défaut), AP Passpoint HS2.0 via hostapd, et
+ client mesh USB (mt76x2u / ath9k_htc). Verrou régulatoire FR au
+ postinst, posture OPAD passive par défaut.
+ .
+ Référence spec : CM-MESH-MPCIE-2026-06 v0.2.1.


### PR DESCRIPTION
## Summary

Wires the WiFi mesh stack (kernel modules + firmware + userspace + canonical debian/control) per CM-MESH-MPCIE-2026-06 v0.2.1, observed missing on the live MochaBin at 192.168.1.200.

4 logical commits :

1. `67c54ee4` feat(kernel): 802.11s mesh stack in board/mochabin/kernel fragment (mac80211 + 802.11s/HWMP, ath10k_pci/ath9k_htc/mt76x2u as modules, signed regdb). + 4 sanity-check greps in build-kernel.yml.
2. `7858a3d0` feat(image): iw/hostapd/wpasupplicant added to MochaBin live-USB INCLUDE_PKGS.
3. `8e02ced3` feat(image): firmware-misc-nonfree + firmware-atheros + wireless-regdb added to live-USB.
4. `317f1909` fix(secubox-mesh): canonical packages/secubox-mesh/debian/control with full Depends (iw, hostapd, wpasupplicant, wireless-regdb, jinja2, pydantic).

## Test plan

- [ ] CI passes (build-kernel.yml + build-image.yml not blocked).
- [ ] Manual `gh workflow run build-kernel.yml -f kernel_version=6.12.85 -f revision=3secubox` produces linux-image-*.deb with the new modules.
- [ ] Deploy linux-image to MochaBin at 192.168.1.200, reboot, verify : `modprobe mt76x2u` succeeds, `iw dev` lists wlan interfaces, `lspci` shows the WLE900VX if installed.

## Follow-ups (issue #456)

- Wire build-kernel.yml output into build-image.yml (currently disconnected).
- Scaffold the rest of packages/secubox-mesh/debian/ (changelog/rules/postinst/install) per #449.