### PR TITLE
DTS: enable USB3 SuperSpeed on mPCIe slot (J5) after hardware mod — supersedes USB2-only patch 003

### DIFF
--- a/kernel-build/patches/004-mochabin-mpcie-usb3-superspeed.patch
+++ b/kernel-build/patches/004-mochabin-mpcie-usb3-superspeed.patch
@@ -1,0 +1,72 @@
+From: Gerald Kerma <devel@cybermind.fr>
+Subject: [PATCH] arm64: dts: marvell: mochabin: route SerDes lane 5 to USB3 SuperSpeed on mPCIe slot
+
+The MOCHAbin mPCIe slot J5 ships from Globalscale wired as :
+
+  - PCIe x1 on SerDes lane 5 (cp0_pcie2)
+  - USB 2.0 on UTMI (cp0_usb3_1, no SerDes)
+  - I2C1
+
+Per the official MOCHAbin block diagram (provided by Globalscale after
+the SCO request) the slot is sized for a "2x2 WiFi 802.11/ax BT5.1"
+card. WiFi 6 chipsets in this segment (e.g. MT7921 family) are
+predominantly **USB 3.0** rather than PCIe.
+
+A hardware modification (SerDes lane 5 retargeted from PCIe to USB3
+SuperSpeed on the mPCIe USB pins) has been applied to the test board.
+The kernel must now reflect that reroute :
+
+  1. cp0_pcie2 has no SerDes anymore — disable the controller so the
+     armada8k-pcie driver doesn't loop on "Phy link never came up".
+  2. cp0_usb3_1 must declare cp0_comphy5 in mode 5 (PHY_TYPE_USB3_HOST1)
+     alongside the existing UTMI binding from patch 003. This gives
+     the slot full USB 3.0 5 Gbps SuperSpeed + USB 2.0 fallback.
+
+Pattern mirrors cp0_usb3_0 (USB3 HUB on comphy1 mode 4 PHY_TYPE_USB3_HOST0)
+which is the only USB3 host that works on stock MOCHAbin.
+
+After this patch, plugging an MT7921U-class card in J5 should enumerate
+on USB3 with the chip wired for 2x2 5 Gbps throughput — matching the
+official block-diagram intent of the slot.
+
+Note: this supersedes patch 003 (USB2 baseline) for boards that have
+received the SerDes-5 USB3 modification. Boards still in stock
+configuration should ship with 003 only. A future per-board profile
+will gate which patches apply.
+
+Closes: #463
+Signed-off-by: Gerald Kerma <devel@cybermind.fr>
+
+--- a/arch/arm64/boot/dts/marvell/armada-7040-mochabin.dts
++++ b/arch/arm64/boot/dts/marvell/armada-7040-mochabin.dts
+@@ -422,12 +422,28 @@
+ 	phy-names = "cp0-usb3h0-comphy", "utmi";
+ };
+
+-/* miniPCI-E USB */
++/* miniPCI-E USB — slot J5
++ *
++ * Hardware-modded board : SerDes lane 5 retargeted from PCIe to USB3
++ * SuperSpeed on the mPCIe USB pins. cp0_pcie2 is now disabled (see
++ * the &cp0_pcie2 override below). cp0_usb3_1 binds both UTMI (USB 2.0
++ * baseline from patch 003) AND cp0_comphy5 mode 5
++ * (PHY_TYPE_USB3_HOST1) for SuperSpeed. The slot becomes USB 3.0
++ * 5 Gbps capable for MT7921-class WiFi 6 cards per the official
++ * MOCHAbin block diagram.
++ */
+ &cp0_usb3_1 {
+ 	status = "okay";
+
+-	phys = <&cp0_utmi1>;
+-	phy-names = "utmi";
++	phys = <&cp0_comphy5 5>, <&cp0_utmi1>;
++	phy-names = "cp0-usb3h1-comphy", "utmi";
+ 	dr_mode = "host";
+ };
+
++/* SerDes lane 5 retargeted to USB3 — PCIe controller has no PHY left. */
++&cp0_pcie2 {
++	status = "disabled";
++};
++
+ &cp0_sata0 {


### PR DESCRIPTION
Closes #463