### PR TITLE
fix(secubox-core): /etc/secubox parent dir 0750 → 0755 (ref #468)

### DIFF
--- a/packages/secubox-core/debian/changelog
+++ b/packages/secubox-core/debian/changelog
@@ -1,3 +1,13 @@
+secubox-core (1.1.6-1~bookworm1) bookworm; urgency=medium
+
+  * postinst: relax /etc/secubox to 0755 (was 0750). Non-secubox daemons
+    (dnsmasq for secubox-eye-remote, hostapd/wpa_supplicant for
+    secubox-mesh, etc.) need to traverse the parent to reach their
+    config files. /etc/secubox/secrets stays 0700 — no leak. Live drift
+    already applied on gk2. Closes #468.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Wed, 03 Jun 2026 09:30:00 +0200
+
 secubox-core (1.1.5-1~bookworm1) bookworm; urgency=medium
 
   * systemd/lxc.service.d/wait-for-data.conf: NEW drop-in adds

--- a/packages/secubox-core/debian/postinst
+++ b/packages/secubox-core/debian/postinst
@@ -10,7 +10,13 @@ case "$1" in
     fi
 
     # ── Répertoires ──
-    install -d -o secubox -g secubox -m 750 /etc/secubox
+    # /etc/secubox MUST be world-traversable (0755): non-secubox daemons
+    # need to read their conf files under it (dnsmasq for secubox-eye-remote,
+    # hostapd/wpa_supplicant for secubox-mesh, etc.). 0750 blocks traversal
+    # even with world-readable files inside, causing daemon startup failures
+    # (see #468). Sensitive content lives in /etc/secubox/secrets (0700
+    # secubox:secubox), so opening the parent dir does NOT leak secrets.
+    install -d -o secubox -g secubox -m 755 /etc/secubox
     install -d -m 1777 /run/secubox  # World-writable for all service sockets
     install -d -o secubox -g secubox -m 750 /var/lib/secubox
     install -d -o secubox -g secubox -m 750 /usr/share/secubox/www


### PR DESCRIPTION
## Summary

`packages/secubox-core/debian/postinst:13` créait `/etc/secubox` en **0750 secubox:secubox**. Tout daemon NON membre du groupe `secubox` ne peut **traverser** le dossier — même si les fichiers à l'intérieur sont world-readable.

Constat 2026-06-03 sur gk2 : `secubox-eye-remote-dhcp` en boucle d'échec (restart counter = **625**) parce que `dnsmasq` (`--user=dnsmasq --group=nogroup`) ne pouvait pas lire `/etc/secubox/eye-remote/reservations.conf`. Même problème prévisible pour `hostapd`/`wpa_supplicant` (secubox-mesh #449), `netifyd` (secubox-dpi), etc.

## Fix

Relax `/etc/secubox` à **0755**. Le sous-dossier `secrets/` reste **0700 secubox:secubox** — le contenu sensible reste protégé. Ouvrir le parent n'expose que les *noms* de fichiers (no leak CSPN).

```diff
-    install -d -o secubox -g secubox -m 750 /etc/secubox
+    install -d -o secubox -g secubox -m 755 /etc/secubox
```

+ commentaire explicatif (8 lignes) sur le pourquoi.

## Changes

- `packages/secubox-core/debian/postinst` — single-line fix + 8-line comment
- `packages/secubox-core/debian/changelog` — bump 1.1.5 → **1.1.6-1~bookworm1**

## Live state

Le drift live (`chmod 0755 /etc/secubox`) a déjà été appliqué sur gk2 (2026-06-03) pour débloquer Eye DHCP. Cette PR synchronise le source pour que la prochaine réinstall de `secubox-core` ne régresse pas.

## Test plan

- [x] Live fix vérifié sur gk2 : `secubox-eye-remote-dhcp.service` passe de `restart counter = 625` à `active`
- [x] `secubox-mesh 2.0.3` (#449) déploiement clean — dnsmasq pour mesh/AP n'aura plus ce problème
- [ ] Rebuild + redeploy `secubox-core` 1.1.6 sur gk2 → vérifier que `/etc/secubox` reste à 0755
- [ ] `secrets/` doit rester 0700 (vérif par stat post-install)

## References

- Memory : `project_etc_secubox_traversal.md`