### PR TITLE
fix(secubox-mesh): drop postinst /run/secubox parent overwrite — restores all socket APIs (ref #471)

### DIFF
--- a/packages/secubox-mesh/debian/changelog
+++ b/packages/secubox-mesh/debian/changelog
@@ -1,3 +1,13 @@
+secubox-mesh (2.0.4-1~bookworm1) bookworm; urgency=high
+
+  * postinst: drop the `install -d /run/secubox` line. The parent runtime
+    dir is platform-managed by secubox-core (1777 root:root) ; overwriting
+    it to 0750 secubox-mesh:secubox-mesh blocks nginx (www-data) from
+    traversing → ALL /api/v1/<module>/* return 502 → dashboards full-zero.
+    Live drift already corrected on gk2. Closes #471.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 04 Jun 2026 05:30:00 +0200
+
 secubox-mesh (2.0.3-1~bookworm1) bookworm; urgency=medium
 
   * WebUI: ship www/mesh/index.html (P31 light skin, 4 cards: RF, peers,

--- a/packages/secubox-mesh/debian/postinst
+++ b/packages/secubox-mesh/debian/postinst
@@ -15,9 +15,11 @@ case "$1" in
     # 2. Dossier secrets (mesh-sae) — chmod 0700, owner secubox-mesh
     install -d -m 0700 -o secubox-mesh -g secubox-mesh /etc/secubox/secrets
 
-    # 3. Dossiers runtime + log (tmpfiles-style — créés via systemd RuntimeDirectory
-    #    serait mieux, on garde explicite ici pour compat ancienne unit)
-    install -d -m 0750 -o secubox-mesh -g secubox-mesh /run/secubox
+    # 3. Dossier log dédié au module.
+    # /run/secubox PARENT est platform-managed par secubox-core en 1777 root:root.
+    # NE PAS le toucher ici — l'écraser bloque la traversée nginx (www-data) et
+    # casse tous les /api/v1/<module>/* en 502 (cf. #471). Si besoin d'un
+    # sous-dossier privé, utiliser /run/secubox/mesh/ (et non le parent).
     install -d -m 0750 -o secubox-mesh -g secubox-mesh /var/log/secubox
 
     # 4. Verrou régulatoire FR (idempotent ; ne pas planter si iw absent)


### PR DESCRIPTION
## Summary

Critical regression introduced by PR #469 (secubox-mesh 2.0.x). The postinst contained:

\`\`\`sh
install -d -m 0750 -o secubox-mesh -g secubox-mesh /run/secubox
\`\`\`

This silently overwrote the platform-managed parent (1777 root:root posed by \`secubox-core\`). Result : nginx workers (www-data) can no longer traverse \`/run/secubox\` → **all** \`/api/v1/<module>/*\` socket-based endpoints return 502 → dashboards show full-zero for WAF, CrowdSec, Netdata, DPI, QoS, etc.

User report 2026-06-04 : "all metrics, waf, crowdsec, .. are fullzero ???"

## Fix

- Drop the offending \`install -d /run/secubox\` line from \`packages/secubox-mesh/debian/postinst\`
- Add an 4-line comment explaining the constraint (parent is platform-managed, use \`/run/secubox/mesh/\` subdir if needed)
- Bump 2.0.3 → **2.0.4-1~bookworm1** (urgency=high)

## Live state

Already corrected on gk2 (2026-06-04 ~05:25) :
\`\`\`sh
chown root:root /run/secubox
chmod 1777 /run/secubox
\`\`\`
→ all /health endpoints return 200 again.

This PR syncs the source so the next \`secubox-mesh\` reinstall doesn't reproduce the regression.

## Test plan

- [x] Live fix on gk2 verified : \`/api/v1/{waf,crowdsec,netdata,dpi,mesh}/health\` all return 200
- [x] \`stat /run/secubox\` = 1777 root:root
- [ ] After merge + rebuild + redeploy 2.0.4 on gk2 : verify \`/run/secubox\` perms still 1777 root:root (i.e. postinst no longer touches the parent)

## Files

- \`packages/secubox-mesh/debian/postinst\` — 1 line removed, 4-line comment added
- \`packages/secubox-mesh/debian/changelog\` — 2.0.4 entry, urgency=high

## References

- Memory : project_etc_secubox_traversal.md (related — also about /etc/secubox traversal)
- Root cause for #471