### PR TITLE
feat(toolbox): Phase 2a + 2a+ — SOC scoring multi-signal + geo flags + nDPI class + cookies + avatar

### DIFF
--- a/packages/secubox-toolbox/conf/nft-toolbox.nft.j2
+++ b/packages/secubox-toolbox/conf/nft-toolbox.nft.j2
@@ -29,7 +29,14 @@ table inet toolbox {
 
     chain prerouting_nat {
         type nat hook prerouting priority dstnat;
-        # Captive portal pour MAC non validées (HTTP/HTTPS hijacked vers splash :8088)
+        # Règle 1 (priorité haute) : tout trafic destiné à l'IP du portail
+        # (http://village3b résout vers {{ dhcp.gateway }}) → portail direct.
+        # Bypass mitmproxy : le portail est HTTP only, pas besoin de TLS-break.
+        ip daddr {{ dhcp.gateway }} tcp dport 80 dnat ip to {{ dhcp.gateway }}:{{ portal.listen_port }}
+        # Règle 2 : MAC R2-consented → MITM transparent (sauf pour le portail lui-même).
+        iifname "{{ ap.iface }}" ether saddr @consented_r2_macs ip daddr != {{ dhcp.gateway }} tcp dport { 80, 443 } \
+            dnat ip to {{ dhcp.gateway }}:8080
+        # Règle 3 : MAC non validées → captive portal (HTTP/HTTPS hijacked vers splash :8088).
         iifname "{{ ap.iface }}" ether saddr != @validated_macs tcp dport { 80, 443 } \
             dnat ip to {{ dhcp.gateway }}:{{ portal.listen_port }}
     }

--- a/packages/secubox-toolbox/conf/report-live.html.j2
+++ b/packages/secubox-toolbox/conf/report-live.html.j2
@@ -105,7 +105,7 @@ li::before{content:"▸ ";color:var(--phos);text-shadow:0 0 4px var(--phos)}
   <h2 class="pin">🚨 Threat-intel : matches feeds malware</h2>
   <ul>
     {% for m in threat_intel_matches[:10] %}
-      <li><span style="color:var(--red)">[{{ m.source }}/{{ m.weight }}]</span> <b>{{ m.label }}</b> : <code>{{ m.ioc[:60] }}</code></li>
+      <li>{{ m.flag }} <span style="color:var(--red)">[{{ m.source }}/{{ m.weight }}]</span> <b>{{ m.label }}</b> : <code>{{ m.ioc[:60] }}</code>{% if m.asn_org %} <span style="font-size:0.75rem;color:var(--dim)">({{ m.asn_org }})</span>{% endif %}</li>
     {% endfor %}
   </ul>
 </div>
@@ -113,10 +113,10 @@ li::before{content:"▸ ";color:var(--phos);text-shadow:0 0 4px var(--phos)}
 
 {% if dga_candidates %}
 <div class="card">
-  <h2 class="pin">🔠 DGA — domaines suspects (générés algorithmiquement)</h2>
+  <h2 class="pin">🔠 DGA — domaines suspects</h2>
   <ul>
     {% for d in dga_candidates[:8] %}
-      <li><span style="color:var(--amber)">[{{ d.score }}]</span> <code>{{ d.host[:60] }}</code> <span style="font-size:0.75rem;color:var(--dim)">({{ d.indicators|join(', ') }})</span></li>
+      <li>{{ d.flag }} <span style="color:var(--amber)">[{{ d.score }}]</span> <code>{{ d.host[:60] }}</code> <span style="font-size:0.75rem;color:var(--dim)">({{ d.indicators|join(', ') }})</span></li>
     {% endfor %}
   </ul>
 </div>
@@ -127,21 +127,95 @@ li::before{content:"▸ ";color:var(--phos);text-shadow:0 0 4px var(--phos)}
   <h2 class="pin">📡 Beaconing — patterns périodiques suspects</h2>
   <table style="width:100%;font-size:0.82rem">
     <thead><tr style="color:var(--dim);text-align:left">
-      <th>Score</th><th>Host</th><th style="text-align:right">Median</th><th style="text-align:right">CV</th>
+      <th>🚩</th><th>Score</th><th>Host</th><th style="text-align:right">Median</th><th style="text-align:right">CV</th><th>ASN</th>
     </tr></thead>
     <tbody>
     {% for b in beaconing_candidates[:8] %}
-      <tr><td style="color:var(--amber)">{{ b.score }}</td><td><code>{{ b.host[:50] }}</code></td>
+      <tr><td>{{ b.flag }}</td><td style="color:var(--amber)">{{ b.score }}</td><td><code>{{ b.host[:40] }}</code></td>
           <td style="text-align:right">{{ b.median_seconds }}s</td>
-          <td style="text-align:right">{{ b.cv }}</td></tr>
+          <td style="text-align:right">{{ b.cv }}</td>
+          <td style="font-size:0.78rem;color:var(--dim)">{{ b.asn_org[:30] if b.asn_org else '' }}</td></tr>
     {% endfor %}
     </tbody>
   </table>
 </div>
 {% endif %}
 
+{% if dpi_classified and dpi_classified.top_apps %}
 <div class="card">
-  <h2>📱 Apps détectées</h2>
+  <h2>🧭 Apps détectées (classification nDPI-style)</h2>
+  <p style="font-size:0.78rem;color:var(--dim);margin-bottom:0.5rem">
+    Catégories : {% for cat, n in dpi_classified.by_category.items() %}{{ dpi_classified.category_emoji.get(cat, '❔') }} {{ cat }}({{ n }}){% if not loop.last %} · {% endif %}{% endfor %}
+  </p>
+  <table style="width:100%;font-size:0.85rem">
+    <thead><tr style="color:var(--dim);text-align:left">
+      <th>App</th><th>Catégorie</th><th style="text-align:right">Connexions</th>
+    </tr></thead>
+    <tbody>
+    {% for a in dpi_classified.top_apps[:15] %}
+      <tr><td>{{ a.emoji }} <b>{{ a.app }}</b></td><td style="font-size:0.78rem;color:var(--dim)">{{ a.category }}</td>
+          <td style="text-align:right;color:var(--phos);text-shadow:0 0 4px var(--phos)">{{ a.count }}</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
+{% if geo_top_hosts %}
+<div class="card">
+  <h2>🌍 Hôtes contactés (par pays + ASN + app)</h2>
+  <table style="width:100%;font-size:0.82rem">
+    <thead><tr style="color:var(--dim);text-align:left">
+      <th>🚩</th><th>App</th><th>Hôte</th><th>ASN</th><th style="text-align:right">Hits</th>
+    </tr></thead>
+    <tbody>
+    {% for h in geo_top_hosts[:15] %}
+      <tr><td>{{ h.flag }}</td><td>{{ h.emoji }} {{ h.app[:18] }}</td><td><code style="font-size:0.78rem">{{ h.host[:45] }}</code></td>
+          <td style="font-size:0.75rem;color:var(--dim)">{{ h.asn_org[:25] if h.asn_org else '' }}</td>
+          <td style="text-align:right;color:var(--phos)">{{ h.count }}</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
+{% if avatar_analysis and avatar_analysis.devices %}
+<div class="card">
+  <h2>{{ avatar_analysis.most_common_emoji }} Avatar / device fingerprint</h2>
+  <p style="margin-bottom:0.5rem">
+    <span style="font-size:1.2rem">{{ avatar_analysis.most_common_emoji }}</span>
+    <b>{{ avatar_analysis.most_common }}</b> (le plus représenté)
+  </p>
+  <div style="display:flex;flex-wrap:wrap;gap:1rem;font-size:0.85rem">
+    <div>
+      <div style="color:var(--dim);font-size:0.78rem;margin-bottom:0.3rem">Devices :</div>
+      {% for dev, info in avatar_analysis.devices.items() %}
+        <div>{{ info.emoji }} <b>{{ info.os_label }}</b> <span style="color:var(--dim)">({{ info.count }})</span></div>
+      {% endfor %}
+    </div>
+    <div>
+      <div style="color:var(--dim);font-size:0.78rem;margin-bottom:0.3rem">Browsers :</div>
+      {% for br, info in avatar_analysis.browsers.items() %}
+        <div>{{ info.emoji }} <b>{{ info.label }}</b> <span style="color:var(--dim)">({{ info.count }})</span></div>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+{% endif %}
+
+{% if cookies_providers %}
+<div class="card">
+  <h2>🍪 Trackers / providers cookies (Phase 2a+)</h2>
+  <ul>
+    {% for p in cookies_providers[:10] %}
+      <li>{{ p.emoji }} <b>{{ p.provider }}</b> <span style="font-size:0.78rem;color:var(--dim)">({{ p.category }})</span> <span style="color:var(--phos)">×{{ p.count }}</span></li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}
+
+<div class="card">
+  <h2>📱 Apps détectées (vue IP forensics)</h2>
   <ul>
     {% for app in apps_detected %}<li>{{ app }}</li>{% endfor %}
   </ul>

--- a/packages/secubox-toolbox/conf/report-live.html.j2
+++ b/packages/secubox-toolbox/conf/report-live.html.j2
@@ -60,17 +60,85 @@ li::before{content:"▸ ";color:var(--phos);text-shadow:0 0 4px var(--phos)}
   <h2>🎯 Analyse compromission</h2>
   <p style="text-align:center;margin:0.5rem 0">
     {% if risk_score < 30 %}
-      <span class="score low">Score : {{ risk_score }}/100 — LOW</span>
+      <span class="score low">Score : {{ risk_score }}/100 — {{ risk_label|default('LOW') }}</span>
     {% elif risk_score < 70 %}
-      <span class="score med">Score : {{ risk_score }}/100 — MEDIUM</span>
+      <span class="score med">Score : {{ risk_score }}/100 — {{ risk_label|default('MEDIUM') }}</span>
     {% else %}
-      <span class="score high">Score : {{ risk_score }}/100 — HIGH</span>
+      <span class="score high">Score : {{ risk_score }}/100 — {{ risk_label|default('HIGH') }}</span>
     {% endif %}
   </p>
+  {% if risk_explanation %}
+  <p style="font-size:0.85rem;color:var(--text);margin-bottom:0.8rem;padding:0.5rem;background:rgba(0,221,68,0.05);border-left:2px solid var(--phos)">{{ risk_explanation }}</p>
+  {% endif %}
   <ul>
     {% for ind in indicators %}<li>{{ ind }}</li>{% endfor %}
   </ul>
 </div>
+
+{% if scoring and scoring.breakdown %}
+<div class="card">
+  <h2>🔬 Breakdown du score (transparent)</h2>
+  <table style="width:100%;font-size:0.82rem;border-collapse:collapse">
+    <thead><tr style="color:var(--dim);border-bottom:1px solid var(--dim)">
+      <th style="padding:0.2rem 0.4rem;text-align:left">Catégorie</th>
+      <th style="padding:0.2rem 0.4rem;text-align:right">Signaux</th>
+      <th style="padding:0.2rem 0.4rem;text-align:right">Poids</th>
+    </tr></thead>
+    <tbody>
+    {% for b in scoring.breakdown %}
+      <tr><td style="padding:0.15rem 0.4rem">{{ b.category }}</td>
+          <td style="padding:0.15rem 0.4rem;text-align:right">{{ b.raw_signal_count }}</td>
+          <td style="padding:0.15rem 0.4rem;text-align:right;color:var(--amber);text-shadow:0 0 4px var(--amber)">+{{ b.weight_subtotal }}</td></tr>
+      {% if b.examples %}
+        <tr><td colspan="3" style="padding:0;font-size:0.75rem;color:var(--text)">
+          {% for ex in b.examples[:3] %}<div style="margin-left:1rem;padding:0.1rem 0">▸ <code>{{ ex }}</code></div>{% endfor %}
+        </td></tr>
+      {% endif %}
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
+{% if threat_intel_matches %}
+<div class="card">
+  <h2 class="pin">🚨 Threat-intel : matches feeds malware</h2>
+  <ul>
+    {% for m in threat_intel_matches[:10] %}
+      <li><span style="color:var(--red)">[{{ m.source }}/{{ m.weight }}]</span> <b>{{ m.label }}</b> : <code>{{ m.ioc[:60] }}</code></li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}
+
+{% if dga_candidates %}
+<div class="card">
+  <h2 class="pin">🔠 DGA — domaines suspects (générés algorithmiquement)</h2>
+  <ul>
+    {% for d in dga_candidates[:8] %}
+      <li><span style="color:var(--amber)">[{{ d.score }}]</span> <code>{{ d.host[:60] }}</code> <span style="font-size:0.75rem;color:var(--dim)">({{ d.indicators|join(', ') }})</span></li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}
+
+{% if beaconing_candidates %}
+<div class="card">
+  <h2 class="pin">📡 Beaconing — patterns périodiques suspects</h2>
+  <table style="width:100%;font-size:0.82rem">
+    <thead><tr style="color:var(--dim);text-align:left">
+      <th>Score</th><th>Host</th><th style="text-align:right">Median</th><th style="text-align:right">CV</th>
+    </tr></thead>
+    <tbody>
+    {% for b in beaconing_candidates[:8] %}
+      <tr><td style="color:var(--amber)">{{ b.score }}</td><td><code>{{ b.host[:50] }}</code></td>
+          <td style="text-align:right">{{ b.median_seconds }}s</td>
+          <td style="text-align:right">{{ b.cv }}</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
 
 <div class="card">
   <h2>📱 Apps détectées</h2>

--- a/packages/secubox-toolbox/debian/changelog
+++ b/packages/secubox-toolbox/debian/changelog
@@ -1,3 +1,33 @@
+secubox-toolbox (2.0.0-1~bookworm1) bookworm; urgency=medium
+
+  * Phase 2a : real SOC scoring multi-signal — major bump 1.5→2.0.
+  * threat_intel.py : pull asynchrone des feeds abuse.ch (ThreatFox 5k IoCs
+    cap, Feodo botnet C2, SSLBL TLS cert blacklist). Cache SQLite,
+    refresh 1h. API : is_malicious_ip(), is_malicious_domain(), feed_stats().
+  * dga.py : heuristique DGA (Shannon entropy, sub-domain length, vowel/digit
+    ratio) avec allowlist 2LD pour reduire FP (akamai, cloudflare, apple, etc.)
+  * beaconing.py : cadence analysis (median interval + coefficient of variation
+    sur DPI events SQLite par mac_hash). Detection beacons C2 (interval 5-300s
+    + cv < 0.20).
+  * scoring.py : aggregation multi-signal transparente. Categories ponderees
+    (threat_intel 0-80, dga 0-40, beaconing 0-50, raw_soc 0-40). Score capped
+    100. Label LOW/MEDIUM/HIGH + explication phrase complete + breakdown
+    detaille (every signal explainable).
+  * api.py _aggregate_session : integre les 3 nouveaux modules + scoring.
+    Returns scoring.{score,label,explanation,breakdown}, threat_intel_matches[],
+    dga_candidates[], beaconing_candidates[].
+  * app.py : asyncio task refresh threat-intel au startup + hourly.
+  * reports.py PDF : nouvelles sections Breakdown + Threat-intel matches + DGA +
+    Beaconing avec details lisibles.
+  * report-live.html.j2 : memes sections + breakdown table coloree + explication
+    encadree.
+
+  Closes #485 (Phase 2a parent #474). Phase 2b = wire to existing modules
+  (cookies.sock/dpi.sock/avatar.sock/threat-analyst.sock/soc.sock) reste a faire.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 05 Jun 2026 06:30:00 +0200
+
+
 secubox-toolbox (1.5.0-1~bookworm1) bookworm; urgency=medium
 
   * Add ap-iface.network.j2 Jinja template + toolbox-up renders it to

--- a/packages/secubox-toolbox/debian/changelog
+++ b/packages/secubox-toolbox/debian/changelog
@@ -1,3 +1,30 @@
+secubox-toolbox (2.1.0-1~bookworm1) bookworm; urgency=medium
+
+  * Phase 2a+ : GeoIP flags + ASN + nDPI-style classification + cookie
+    providers + avatar (UA) fingerprint analysis.
+  * geo.py : IP/hostname → ISO country code (emoji flag) + ASN org via
+    python3-geoip2 + GeoLite2 mmdb (fallback legacy GeoIP.dat). Cache
+    SQLite 24h.
+  * cookie_analysis.py : 40+ patterns trackers (Google Analytics,
+    Facebook Pixel, LinkedIn, TikTok, HubSpot, Hotjar, Cloudflare, etc.)
+    par catégorie (analytics/advertising/social/session/infra) + emoji.
+  * avatar_analysis.py : UA → device (iPhone/iPad/Pixel/Samsung/Mac/Win/
+    Linux/PlayStation/Xbox...) + browser (Chrome/Firefox/Safari/Edge/...) +
+    OS version + emoji par device.
+  * dpi_class.py : 60+ patterns hostnames → app category (streaming/
+    social/messaging-e2e/cloud/dev/banking/email/anon/vpn/cdn/apple) +
+    emoji par app (YouTube 📺, Signal 🔒, GitHub 🐙, etc.).
+  * api.py _aggregate_session : enrich threat_intel/dga/beaconing avec
+    flag + asn ; ajoute dpi_classified, geo_top_hosts, avatar_analysis,
+    cookies_providers.
+  * Reports PDF + HTML live : nouvelles sections avec drapeaux pays,
+    emojis par catégorie, tableau apps détectées, fingerprint avatar.
+
+  Bump 2.0.0 → 2.1.0-1~bookworm1. Closes #486.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 05 Jun 2026 07:30:00 +0200
+
+
 secubox-toolbox (2.0.0-1~bookworm1) bookworm; urgency=medium
 
   * Phase 2a : real SOC scoring multi-signal — major bump 1.5→2.0.

--- a/packages/secubox-toolbox/debian/postinst
+++ b/packages/secubox-toolbox/debian/postinst
@@ -46,6 +46,29 @@ case "$1" in
     install -d -m 0750 -o secubox-toolbox -g secubox-toolbox /var/lib/secubox/toolbox
     install -d -m 0750 -o secubox-toolbox -g secubox-toolbox /var/log/secubox
 
+    # 4b. GeoLite2 databases (Phase 2a+ : flag emojis + ASN org)
+    # ASN DB from geoipupdate or Debian package geoip-database
+    # Country DB from db-ip.com CC-BY (no MaxMind account required)
+    install -d -m 0755 /usr/share/GeoIP /var/lib/GeoIP
+    if [ ! -f /usr/share/GeoIP/GeoLite2-Country.mmdb ] && [ ! -f /var/lib/GeoIP/GeoLite2-Country.mmdb ]; then
+      DBIP_DATE=$(date +%Y-%m)
+      DBIP_URL="https://download.db-ip.com/free/dbip-country-lite-${DBIP_DATE}.mmdb.gz"
+      TMPF=$(mktemp --suffix=.mmdb.gz)
+      if command -v wget >/dev/null 2>&1; then
+        if wget -q --timeout=15 --tries=2 "$DBIP_URL" -O "$TMPF" && [ -s "$TMPF" ]; then
+          gunzip -f "$TMPF"
+          TMPF_RAW="${TMPF%.gz}"
+          install -m 0644 "$TMPF_RAW" /usr/share/GeoIP/GeoLite2-Country.mmdb
+          install -m 0644 "$TMPF_RAW" /var/lib/GeoIP/GeoLite2-Country.mmdb
+          rm -f "$TMPF_RAW"
+          echo "[secubox-toolbox] GeoLite2-Country.mmdb installed from db-ip.com CC-BY"
+        else
+          rm -f "$TMPF"
+          echo "[secubox-toolbox] GeoLite2-Country.mmdb download failed (network ?) — flag emojis disabled until manual install"
+        fi
+      fi
+    fi
+
     # 5. systemd : enable mais ne PAS start automatiquement (l'AP doit être configuré d'abord)
     if [ -d /run/systemd/system ]; then
       systemctl daemon-reload || true

--- a/packages/secubox-toolbox/mitmproxy_addons/local_store.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/local_store.py
@@ -119,14 +119,33 @@ class LocalStore:
         mac_hash = _hash_mac(_mac_of(ip))
         if not mac_hash:
             return
-        # Cookies event
+        # Cookies event — Phase 2a+ : capture names (NOT values) for provider mapping
         set_cookies = flow.response.headers.get_all("set-cookie") or []
         req_cookies = flow.request.headers.get_all("cookie") or []
         if set_cookies or req_cookies:
+            # Extract names only (truncated, max 32 chars each) — privacy-safe metadata
+            set_names = []
+            for sc in set_cookies[:30]:
+                # Set-Cookie format: "name=value; Path=/; ..."
+                head = sc.split(";", 1)[0]
+                if "=" in head:
+                    n = head.split("=", 1)[0].strip()[:32]
+                    if n:
+                        set_names.append(n)
+            sent_names = []
+            for cookie_hdr in req_cookies:
+                # Cookie format: "name1=v1; name2=v2; ..."
+                for part in cookie_hdr.split(";"):
+                    if "=" in part:
+                        n = part.split("=", 1)[0].strip()[:32]
+                        if n and len(sent_names) < 50:
+                            sent_names.append(n)
             _insert(mac_hash, "cookies", {
                 "url": flow.request.pretty_url[:300],
                 "set_cookie_count": len(set_cookies),
                 "cookie_count": len(req_cookies),
+                "set_cookie_names": set_names,
+                "cookie_names": sent_names,
                 "status": flow.response.status_code,
             })
         # SOC trivial indicator (suspicious patterns)

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -12,7 +12,17 @@ import jinja2
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, Response
 
-from . import ca, mac as macmod, nft, reports, store
+from . import (
+    beaconing,
+    ca,
+    dga,
+    mac as macmod,
+    nft,
+    reports,
+    scoring,
+    store,
+    threat_intel,
+)
 from .config import load_config, resolve_secret
 from .models import AcceptResp, ClientRow, Config, StatusResp
 
@@ -293,8 +303,38 @@ def _aggregate_session(mac_hash: str) -> dict:
     except Exception:
         pass
 
-    # ── 3. Risk score from SOC indicators ──
-    risk_score = min(100, sum(i.get("weight", 0) for i in soc_indicators))
+    # ── 3. Phase 2a SOC scoring : threat-intel + DGA + beaconing ──
+    # Threat-intel : match IPs in feeds (resolve hosts isn't done here — match domains
+    # directly). On DPI hosts (which are domain names from SNI/Host) we check both.
+    ti_matches: list[dict] = []
+    unique_hosts_list = list(dpi_hosts.keys())
+    for host in unique_hosts_list:
+        for m in threat_intel.is_malicious_domain(host):
+            m["ioc"] = host
+            ti_matches.append(m)
+    # Also check raw IPs seen in mitm logs
+    for h in hosts:
+        ip = h.split(":")[0]
+        # crude IP detection : has dot + all digits
+        if ip.replace(".", "").isdigit():
+            for m in threat_intel.is_malicious_ip(ip):
+                m["ioc"] = ip
+                ti_matches.append(m)
+
+    # DGA heuristic on domains
+    dga_candidates = dga.analyze_hosts(unique_hosts_list)
+
+    # Beaconing analysis from SQLite cadence
+    beacon_candidates = beaconing.analyze_beaconing(mac_hash)
+
+    # Multi-signal score
+    score_result = scoring.compute_score(
+        threat_intel_matches=ti_matches,
+        dga_candidates=dga_candidates,
+        beaconing_candidates=beacon_candidates,
+        raw_soc_events=soc_indicators,
+    )
+    risk_score = score_result["score"]
 
     # ── 4. Top DPI hosts (Phase 1.5 = simple ranking) ──
     top_dpi = sorted(dpi_hosts.items(), key=lambda x: -x[1])[:15]
@@ -309,14 +349,10 @@ def _aggregate_session(mac_hash: str) -> dict:
         },
         "apps_detected": _classify_apps(hosts),
         "risk_score": risk_score,
-        "indicators": [
-            "Aucune connexion vers feeds ThreatFox/Feodo/SSLBL"
-            if not soc_indicators else
-            f"{len(soc_indicators)} indicateur(s) SOC detecte(s) — voir section SOC",
-            "Aucun pattern DGA detecte" if not any(i.get("kind") == "dga" for i in soc_indicators) else "DGA pattern detecte",
-            "Aucun beaconing periodique anormal",
-            "Aucune connexion DoH suspecte (C2)",
-            f"User agents detectes : {len(user_agents)}",
+        "risk_label": score_result["label"],
+        "risk_explanation": score_result["explanation"],
+        "indicators": score_result["indicators_summary"] or [
+            "Aucun signal de compromission détecté.",
         ],
         "pinned_apps": [
             "Signal Messenger : E2E chiffre - ToolBox NE PEUT PAS lire tes messages",
@@ -350,6 +386,16 @@ def _aggregate_session(mac_hash: str) -> dict:
             "snis_seen": list(ja4_snis)[:10],
             "alpns_seen": list(ja4_alpns),
         },
+        # ── Phase 2a SOC scoring ──
+        "scoring": {
+            "score": score_result["score"],
+            "label": score_result["label"],
+            "explanation": score_result["explanation"],
+            "breakdown": score_result["breakdown"],
+        },
+        "threat_intel_matches": ti_matches[:10],
+        "dga_candidates": dga_candidates[:10],
+        "beaconing_candidates": beacon_candidates[:10],
     }
 
 

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -287,6 +287,8 @@ def _aggregate_session(mac_hash: str) -> dict:
                             "url": p.get("url", "?")[:120],
                             "set": p.get("set_cookie_count", 0),
                             "sent": p.get("cookie_count", 0),
+                            "set_cookie_names": p.get("set_cookie_names", []),
+                            "cookie_names": p.get("cookie_names", []),
                             "status": p.get("status"),
                         })
                 elif source == "soc":
@@ -307,11 +309,18 @@ def _aggregate_session(mac_hash: str) -> dict:
     except Exception:
         pass
 
+    # Phase 2a+ : combine DPI hosts (HTTP host or IP) with JA4 SNIs to get
+    # real hostnames for classification. iOS captive probes + cert-pinned apps
+    # only expose SNIs ; we lose ~80% of classification data without this merge.
+    classifiable_hosts: dict[str, int] = dict(dpi_hosts)
+    for sni in ja4_snis:
+        classifiable_hosts[sni] = classifiable_hosts.get(sni, 0) + 1
+
     # ── 3. Phase 2a SOC scoring : threat-intel + DGA + beaconing ──
     # Threat-intel : match IPs in feeds (resolve hosts isn't done here — match domains
     # directly). On DPI hosts (which are domain names from SNI/Host) we check both.
     ti_matches: list[dict] = []
-    unique_hosts_list = list(dpi_hosts.keys())
+    unique_hosts_list = list(classifiable_hosts.keys())
     for host in unique_hosts_list:
         for m in threat_intel.is_malicious_domain(host):
             m["ioc"] = host
@@ -341,7 +350,8 @@ def _aggregate_session(mac_hash: str) -> dict:
     risk_score = score_result["score"]
 
     # ── 4. Top DPI hosts (Phase 1.5 = simple ranking) ──
-    top_dpi = sorted(dpi_hosts.items(), key=lambda x: -x[1])[:15]
+    # Use combined (DPI + SNI) so classification works on FQDNs not IPs
+    top_dpi = sorted(classifiable_hosts.items(), key=lambda x: -x[1])[:15]
 
     return {
         "device_type": "Smartphone (auto-detected)",

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -13,9 +13,13 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, Response
 
 from . import (
+    avatar_analysis,
     beaconing,
     ca,
+    cookie_analysis,
     dga,
+    dpi_class,
+    geo,
     mac as macmod,
     nft,
     reports,
@@ -393,10 +397,61 @@ def _aggregate_session(mac_hash: str) -> dict:
             "explanation": score_result["explanation"],
             "breakdown": score_result["breakdown"],
         },
-        "threat_intel_matches": ti_matches[:10],
-        "dga_candidates": dga_candidates[:10],
-        "beaconing_candidates": beacon_candidates[:10],
+        "threat_intel_matches": _enrich_with_geo(ti_matches[:10]),
+        "dga_candidates": _enrich_dga_with_geo(dga_candidates[:10]),
+        "beaconing_candidates": _enrich_beacon_with_geo(beacon_candidates[:10]),
+        # ── Phase 2a+ (#486) geo + app classification + UA analyzer ──
+        "dpi_classified": dpi_class.analyze_hosts(unique_hosts_list[:50]),
+        "geo_top_hosts": _enrich_top_dpi_with_geo(top_dpi),
+        "avatar_analysis": avatar_analysis.analyze_user_agents(user_agents),
+        "cookies_providers": cookie_analysis.top_providers(cookies_urls, limit=10),
     }
+
+
+def _enrich_with_geo(matches: list[dict]) -> list[dict]:
+    """Add geo info to threat_intel matches."""
+    out = []
+    for m in matches:
+        ioc = m.get("ioc") or ""
+        info = geo.lookup(ioc) if ioc else {}
+        out.append({**m, "flag": info.get("flag", ""), "country": info.get("country_iso", ""), "asn_org": info.get("asn_org", "")})
+    return out
+
+
+def _enrich_dga_with_geo(candidates: list[dict]) -> list[dict]:
+    out = []
+    for c in candidates:
+        info = geo.lookup(c.get("host", ""))
+        out.append({**c, "flag": info.get("flag", ""), "country": info.get("country_iso", ""), "asn_org": info.get("asn_org", "")})
+    return out
+
+
+def _enrich_beacon_with_geo(candidates: list[dict]) -> list[dict]:
+    out = []
+    for c in candidates:
+        info = geo.lookup(c.get("host", ""))
+        out.append({**c, "flag": info.get("flag", ""), "country": info.get("country_iso", ""), "asn_org": info.get("asn_org", "")})
+    return out
+
+
+def _enrich_top_dpi_with_geo(top_dpi: list[tuple]) -> list[dict]:
+    """Enrich top_dpi with geo + dpi_class + emoji."""
+    out = []
+    for host, count in top_dpi:
+        info = geo.lookup(host)
+        cls = dpi_class.classify_host(host)
+        out.append({
+            "host": host,
+            "count": count,
+            "flag": info.get("flag", ""),
+            "country": info.get("country_iso", ""),
+            "asn": info.get("asn", 0),
+            "asn_org": info.get("asn_org", ""),
+            "app": cls["app"],
+            "category": cls["category"],
+            "emoji": cls["emoji"],
+        })
+    return out
 
 
 def _classify_apps(hosts: set[str]) -> list[str]:

--- a/packages/secubox-toolbox/secubox_toolbox/app.py
+++ b/packages/secubox-toolbox/secubox_toolbox/app.py
@@ -9,7 +9,7 @@ import logging
 
 from fastapi import FastAPI
 
-from . import __version__, store
+from . import __version__, store, threat_intel
 from .api import router as toolbox_router
 
 _log = logging.getLogger("secubox.toolbox")
@@ -29,12 +29,14 @@ app.include_router(toolbox_router)
 
 @app.on_event("startup")
 async def _startup() -> None:
-    """Spawn periodic purge task."""
-    async def loop() -> None:
+    """Spawn periodic purge task + threat-intel refresh loop."""
+    async def purge_loop() -> None:
         while True:
             try:
                 store.purge_expired()
             except Exception as e:
                 _log.error("purge failed: %s", e)
             await asyncio.sleep(3600)
-    asyncio.create_task(loop())
+    asyncio.create_task(purge_loop())
+    # Threat-intel feeds : kick off immediate refresh + hourly loop
+    asyncio.create_task(threat_intel.refresh_loop())

--- a/packages/secubox-toolbox/secubox_toolbox/avatar_analysis.py
+++ b/packages/secubox-toolbox/secubox_toolbox/avatar_analysis.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""Avatar analysis : UA + Client Hints → device emoji + readable name."""
+from __future__ import annotations
+
+import re
+
+# Devices identification patterns. Order = priority (first match wins).
+DEVICE_PATTERNS = [
+    # ── iPhone ──
+    (re.compile(r"iPhone\s?OS\s?(\d+_\d+)|iPhone.*OS\s?(\d+_\d+)", re.I),
+     "iPhone", "📱", "iPhone iOS {}"),
+    (re.compile(r"iPhone", re.I), "iPhone", "📱", "iPhone"),
+    # ── iPad ──
+    (re.compile(r"iPad", re.I), "iPad", "📱", "iPad"),
+    # ── Mac ──
+    (re.compile(r"Mac OS X (\d+[._]\d+)", re.I), "Mac", "💻", "macOS {}"),
+    (re.compile(r"Macintosh", re.I), "Mac", "💻", "Mac"),
+    # ── Android ──
+    (re.compile(r"Pixel\s?(\d+)", re.I), "Pixel", "📱", "Pixel {}"),
+    (re.compile(r"SM-[A-Z]\d+", re.I), "Samsung", "📱", "Samsung"),
+    (re.compile(r"Android (\d+)", re.I), "Android", "📱", "Android {}"),
+    (re.compile(r"Android", re.I), "Android", "📱", "Android"),
+    # ── Windows ──
+    (re.compile(r"Windows NT 11"), "Windows", "💻", "Windows 11"),
+    (re.compile(r"Windows NT 10"), "Windows", "💻", "Windows 10"),
+    (re.compile(r"Windows NT"), "Windows", "💻", "Windows"),
+    # ── Linux ──
+    (re.compile(r"Linux", re.I), "Linux", "🐧", "Linux"),
+    # ── Game / IoT ──
+    (re.compile(r"PlayStation", re.I), "PlayStation", "🎮", "PlayStation"),
+    (re.compile(r"Xbox", re.I), "Xbox", "🎮", "Xbox"),
+    (re.compile(r"Nintendo", re.I), "Nintendo", "🎮", "Nintendo"),
+    (re.compile(r"AppleTV", re.I), "Apple TV", "📺", "Apple TV"),
+    (re.compile(r"Roku", re.I), "Roku", "📺", "Roku"),
+    # ── Bot / known clients ──
+    (re.compile(r"curl/", re.I), "curl", "🛠", "curl"),
+    (re.compile(r"wget/", re.I), "wget", "🛠", "wget"),
+]
+
+BROWSER_PATTERNS = [
+    (re.compile(r"Edg/(\d+)"),       "Edge",   "🪟", "Edge {}"),
+    (re.compile(r"Chrome/(\d+)"),    "Chrome", "🟢", "Chrome {}"),
+    (re.compile(r"Firefox/(\d+)"),   "Firefox","🦊", "Firefox {}"),
+    (re.compile(r"Safari/(\d+)"),    "Safari", "🧭", "Safari"),
+    (re.compile(r"OPR/(\d+)|Opera/(\d+)"), "Opera", "🔴", "Opera"),
+    (re.compile(r"DuckDuckGo/(\d+)"), "DuckDuckGo", "🦆", "DuckDuckGo {}"),
+]
+
+
+def classify_user_agent(ua: str) -> dict:
+    """Returns {device, device_emoji, os_label, browser, browser_emoji, browser_label, raw}."""
+    if not ua:
+        return {"device": "unknown", "device_emoji": "❔", "os_label": "?",
+                "browser": "unknown", "browser_emoji": "❔", "browser_label": "?",
+                "raw": ""}
+    device_match = None
+    device_label = "unknown"
+    for pattern, label, emoji, template in DEVICE_PATTERNS:
+        m = pattern.search(ua)
+        if m:
+            # Try to fill the template with first non-None group
+            groups = [g for g in m.groups() if g]
+            if groups and "{}" in template:
+                device_label = template.format(groups[0].replace("_", "."))
+            else:
+                device_label = template
+            device_match = {"device": label, "device_emoji": emoji,
+                             "os_label": device_label}
+            break
+    if not device_match:
+        device_match = {"device": "unknown", "device_emoji": "❔",
+                         "os_label": ua[:50]}
+    browser_match = None
+    for pattern, label, emoji, template in BROWSER_PATTERNS:
+        m = pattern.search(ua)
+        if m:
+            groups = [g for g in m.groups() if g]
+            if groups and "{}" in template:
+                bl = template.format(groups[0])
+            else:
+                bl = template
+            browser_match = {"browser": label, "browser_emoji": emoji, "browser_label": bl}
+            break
+    if not browser_match:
+        browser_match = {"browser": "unknown", "browser_emoji": "❔", "browser_label": "?"}
+
+    return {**device_match, **browser_match, "raw": ua[:200]}
+
+
+def analyze_user_agents(ua_set: set[str] | list[str]) -> dict:
+    """Aggregate a set of UAs : returns {devices, browsers, most_common, raw_count}."""
+    if not ua_set:
+        return {"devices": {}, "browsers": {}, "most_common": None, "raw_count": 0}
+    devices: dict[str, dict] = {}
+    browsers: dict[str, dict] = {}
+    for ua in ua_set:
+        cls = classify_user_agent(ua)
+        d = cls["device"]
+        if d not in devices:
+            devices[d] = {"count": 0, "emoji": cls["device_emoji"], "os_label": cls["os_label"]}
+        devices[d]["count"] += 1
+        b = cls["browser"]
+        if b not in browsers:
+            browsers[b] = {"count": 0, "emoji": cls["browser_emoji"], "label": cls["browser_label"]}
+        browsers[b]["count"] += 1
+    # Most common device
+    most_common = max(devices.items(), key=lambda x: x[1]["count"])[0] if devices else None
+    return {
+        "devices": devices,
+        "browsers": browsers,
+        "most_common": most_common,
+        "most_common_emoji": devices[most_common]["emoji"] if most_common else "❔",
+        "raw_count": len(ua_set),
+    }

--- a/packages/secubox-toolbox/secubox_toolbox/beaconing.py
+++ b/packages/secubox-toolbox/secubox_toolbox/beaconing.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""Beaconing pattern detection.
+
+A C2 beacon is characterized by REGULAR periodic communications to the same
+host with low jitter. Even on encrypted traffic, the CADENCE betrays it.
+
+Phase 2a heuristic :
+- For each (mac_hash, host), compute median interval + stdev between consecutive
+  DPI events.
+- Beacon score if : median_interval in [5s, 300s] AND coefficient_of_variation < 0.20
+  (jitter < 20% of median).
+- Real apps (Skype keepalive, MQTT, Apple push) often beacon too but at longer
+  intervals (5+ minutes) or with bursty patterns — those score lower.
+
+Phase 3 will add ML clustering.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import statistics
+import time
+from collections import defaultdict
+from pathlib import Path
+
+log = logging.getLogger("secubox.toolbox.beaconing")
+
+DB = Path("/var/lib/secubox/toolbox/toolbox.db")
+
+
+def _load_events(mac_hash: str, lookback_seconds: int = 1800) -> dict[str, list[int]]:
+    """Return {host: [ts1, ts2, ...sorted]} from DPI events for mac_hash."""
+    if not mac_hash:
+        return {}
+    out: dict[str, list[int]] = defaultdict(list)
+    try:
+        since = int(time.time()) - lookback_seconds
+        with sqlite3.connect(DB, timeout=2) as c:
+            rows = c.execute(
+                "SELECT ts, payload FROM events WHERE mac_hash=? AND source='dpi' AND ts > ? "
+                "ORDER BY ts ASC",
+                (mac_hash, since),
+            ).fetchall()
+        for ts, payload_json in rows:
+            try:
+                p = json.loads(payload_json)
+            except Exception:
+                continue
+            host = p.get("host")
+            if host:
+                out[host].append(int(ts))
+    except Exception as e:
+        log.debug("beaconing load failed: %s", e)
+    return out
+
+
+def _analyze_series(timestamps: list[int]) -> dict:
+    """Compute median interval + coefficient of variation."""
+    if len(timestamps) < 4:
+        return {"count": len(timestamps), "median": 0, "stdev": 0, "cv": 1.0}
+    timestamps = sorted(timestamps)
+    intervals = [timestamps[i + 1] - timestamps[i] for i in range(len(timestamps) - 1)]
+    if not intervals:
+        return {"count": len(timestamps), "median": 0, "stdev": 0, "cv": 1.0}
+    med = statistics.median(intervals)
+    sd = statistics.stdev(intervals) if len(intervals) > 1 else 0
+    cv = (sd / med) if med > 0 else 1.0
+    return {
+        "count": len(timestamps),
+        "median": int(med),
+        "stdev": int(sd),
+        "cv": round(cv, 3),
+    }
+
+
+def analyze_beaconing(mac_hash: str) -> list[dict]:
+    """Returns suspect beacon candidates : list of {host, count, median_seconds, cv, score}.
+    Sorted by score desc."""
+    series = _load_events(mac_hash)
+    out = []
+    for host, ts_list in series.items():
+        stats = _analyze_series(ts_list)
+        count = stats["count"]
+        median = stats["median"]
+        cv = stats["cv"]
+        if count < 4:
+            continue  # not enough samples
+        if median == 0:
+            continue
+        # Score : interval in [5, 300] + low CV → beacon-like
+        score = 0
+        indicators: list[str] = []
+        if 5 <= median <= 300:
+            if cv < 0.10:
+                score = 50
+                indicators.append(f"very_regular_cadence(cv={cv})")
+            elif cv < 0.20:
+                score = 35
+                indicators.append(f"regular_cadence(cv={cv})")
+            elif cv < 0.35:
+                score = 20
+                indicators.append(f"loosely_regular(cv={cv})")
+        if score > 0:
+            out.append({
+                "host": host,
+                "count": count,
+                "median_seconds": median,
+                "cv": cv,
+                "score": score,
+                "indicators": indicators,
+            })
+    return sorted(out, key=lambda x: -x["score"])

--- a/packages/secubox-toolbox/secubox_toolbox/cookie_analysis.py
+++ b/packages/secubox-toolbox/secubox_toolbox/cookie_analysis.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""Cookie analysis : identify trackers + providers + categorize.
+
+Phase 2a+ heuristic: pattern matching sur les noms de cookies bien connus,
+mapping vers fournisseur + catégorie (analytics / advertising / social / etc.).
+
+Database extensible — pour Phase 3 on chargera depuis cookiepedia ou EasyList.
+"""
+from __future__ import annotations
+
+import re
+
+# Pattern → (provider, category, emoji)
+COOKIE_PATTERNS = [
+    # ── Analytics ──
+    (re.compile(r"^_ga(_|$|t)"),         "Google Analytics",       "analytics",  "📊"),
+    (re.compile(r"^_gid$"),              "Google Analytics",       "analytics",  "📊"),
+    (re.compile(r"^_gat"),               "Google Analytics",       "analytics",  "📊"),
+    (re.compile(r"^_gcl_au$"),           "Google Ads conversion",  "advertising", "💰"),
+    (re.compile(r"^_pk_(id|ses|cvar)"),  "Matomo / Piwik",         "analytics",  "📊"),
+    (re.compile(r"^plausible_"),         "Plausible",              "analytics",  "📊"),
+    (re.compile(r"^_mkto_trk$"),         "Marketo",                "analytics",  "📊"),
+    (re.compile(r"^__hssc$|^__hstc$"),   "HubSpot",                "analytics",  "📊"),
+    (re.compile(r"^mp_[a-z0-9]+_mixpanel"), "Mixpanel",            "analytics",  "📊"),
+    (re.compile(r"^amplitude_"),         "Amplitude",              "analytics",  "📊"),
+    (re.compile(r"^optimizelyEndUserId$"), "Optimizely",           "analytics",  "📊"),
+    (re.compile(r"^_hjSession"),         "Hotjar",                 "analytics",  "📊"),
+    (re.compile(r"^_hjFirstSeen$"),      "Hotjar",                 "analytics",  "📊"),
+    (re.compile(r"^crisp-client/session/"), "Crisp Chat",          "analytics",  "💬"),
+    # ── Advertising / Tracking ──
+    (re.compile(r"^_fbp$|^fr$"),         "Facebook Pixel",         "advertising","🎯"),
+    (re.compile(r"^IDE$"),               "Google DoubleClick",     "advertising","🎯"),
+    (re.compile(r"^NID$"),               "Google",                 "advertising","🎯"),
+    (re.compile(r"^DSID$"),              "Google DoubleClick",     "advertising","🎯"),
+    (re.compile(r"^uid$|^bcookie$|^lidc$"), "LinkedIn Insight",    "advertising","💼"),
+    (re.compile(r"^MUID$|^_uetsid$|^_uetvid$"), "Microsoft Clarity / Bing Ads", "advertising", "🎯"),
+    (re.compile(r"^_pin_unauth$|^_pinterest_ct_"),  "Pinterest",   "advertising","📌"),
+    (re.compile(r"^tt_appInfo$|^tt_webid"),  "TikTok",             "advertising","🎵"),
+    (re.compile(r"^_ttp$"),              "TikTok Pixel",           "advertising","🎵"),
+    (re.compile(r"^ANID$"),              "Google",                 "advertising","🎯"),
+    (re.compile(r"^__qca$"),             "Quantcast",              "advertising","🎯"),
+    (re.compile(r"^__gads$|^__gpi$"),    "Google AdSense",         "advertising","💰"),
+    (re.compile(r"^test_cookie$"),       "Google",                 "advertising","🎯"),
+    # ── Social ──
+    (re.compile(r"^c_user$|^xs$|^datr$"), "Facebook",              "social",     "👥"),
+    (re.compile(r"^sb$|^locale$|^wd$"),  "Facebook",               "social",     "👥"),
+    (re.compile(r"^twid$|^ct0$|^auth_token$"), "Twitter / X",      "social",     "👥"),
+    (re.compile(r"^li_at$"),             "LinkedIn",               "social",     "👥"),
+    (re.compile(r"^IG_"),                "Instagram",              "social",     "👥"),
+    # ── Auth / Session (legit, no tracker) ──
+    (re.compile(r"^session(_id)?$|^sessionid$"), "Session generic", "session",   "🔑"),
+    (re.compile(r"^csrftoken$|^_csrf$"), "CSRF token",             "session",    "🔒"),
+    (re.compile(r"^XSRF-TOKEN$"),        "XSRF token",             "session",    "🔒"),
+    (re.compile(r"^remember_token$"),    "Remember-me",            "session",    "🔑"),
+    (re.compile(r"^PHPSESSID$"),         "PHP session",            "session",    "🔑"),
+    (re.compile(r"^JSESSIONID$"),        "Java session",           "session",    "🔑"),
+    (re.compile(r"^connect\.sid$"),      "Express.js session",     "session",    "🔑"),
+    # ── CDN / infra ──
+    (re.compile(r"^__cf_bm$|^cf_clearance$"), "Cloudflare",        "infra",      "☁"),
+    (re.compile(r"^_dd_s$"),             "Datadog RUM",            "monitoring", "📈"),
+]
+
+
+def classify_cookie_name(name: str) -> dict:
+    """Returns {provider, category, emoji} for a single cookie name.
+    Unknown → {provider: 'unknown', category: 'other', emoji: '❔'}."""
+    for pattern, provider, category, emoji in COOKIE_PATTERNS:
+        if pattern.search(name):
+            return {"provider": provider, "category": category, "emoji": emoji}
+    return {"provider": "unknown", "category": "other", "emoji": "❔"}
+
+
+def parse_cookie_header(header_value: str) -> list[str]:
+    """Parse 'Cookie:' or 'Set-Cookie:' value, return list of cookie NAMES."""
+    if not header_value:
+        return []
+    names = []
+    for part in header_value.split(";"):
+        if "=" in part:
+            n = part.split("=", 1)[0].strip()
+            if n:
+                names.append(n)
+    return names
+
+
+def analyze_cookie_events(cookie_events: list[dict]) -> dict:
+    """Aggregate cookie events into stats + per-provider breakdown.
+
+    Input : list of {url, set_cookie_count, cookie_count, ...} from local_store
+    (note : Phase 1.5 stored only counts, not names. Phase 2a+ local_store
+    should store names. Until then, this function works on whatever's present.)
+
+    Returns :
+      {
+        providers: {provider: {count, category, emoji}, ...},
+        categories: {category: count, ...},
+        unknown_count: int,
+      }
+    """
+    providers: dict[str, dict] = {}
+    categories: dict[str, int] = {}
+    unknown_count = 0
+
+    for ev in cookie_events:
+        # The cookie name might be in `set_cookie_names` or `cookie_names` if Phase 2a+
+        # local_store. Backward-compat : skip if absent.
+        for key in ("set_cookie_names", "cookie_names"):
+            names = ev.get(key, [])
+            if not isinstance(names, list):
+                continue
+            for n in names:
+                cls = classify_cookie_name(n)
+                p = cls["provider"]
+                if p == "unknown":
+                    unknown_count += 1
+                else:
+                    if p not in providers:
+                        providers[p] = {"count": 0, "category": cls["category"],
+                                        "emoji": cls["emoji"]}
+                    providers[p]["count"] += 1
+                cat = cls["category"]
+                categories[cat] = categories.get(cat, 0) + 1
+
+    return {
+        "providers": providers,
+        "categories": categories,
+        "unknown_count": unknown_count,
+    }
+
+
+# Quick lookup for live use in /report endpoints
+def top_providers(cookie_events: list[dict], limit: int = 10) -> list[dict]:
+    """Returns top providers by hit count : [{provider, count, category, emoji}, ...]"""
+    stats = analyze_cookie_events(cookie_events)
+    return sorted(
+        [{"provider": p, **v} for p, v in stats["providers"].items()],
+        key=lambda x: -x["count"],
+    )[:limit]

--- a/packages/secubox-toolbox/secubox_toolbox/dga.py
+++ b/packages/secubox-toolbox/secubox_toolbox/dga.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""DGA (Domain Generation Algorithm) detection — heuristic.
+
+Simple, low-false-positive heuristic adapté à un device user :
+- Shannon entropy of the subdomain (high entropy = random-ish chars)
+- Length of randomly-generated subdomain (> 20 chars suspicious)
+- Vowel/consonant ratio (very low = random)
+- Digit ratio (very high = random)
+- Common-LD allowlist exception (skip well-known TLDs/SLDs)
+
+Returns a score (0-100) + indicators list (human-readable reasons).
+"""
+from __future__ import annotations
+
+import math
+from collections import Counter
+
+# Allowlist : domains we always trust (TLD or 2LD). Reduces noise on legit CDN.
+ALLOWLIST_2LD = {
+    "akamai.net", "akamaiedge.net", "akamaitechnologies.com", "akamaized.net",
+    "amazonaws.com", "cloudfront.net", "cloudflare.com", "cloudflare.net",
+    "fastly.net", "fastlylb.net", "azureedge.net", "azurefd.net",
+    "windowsupdate.com", "microsoft.com", "office.com", "office365.com",
+    "google.com", "googleusercontent.com", "googleapis.com", "gstatic.com",
+    "apple.com", "icloud.com", "icloud-content.com", "itunes.apple.com",
+    "github.com", "githubusercontent.com", "githubassets.com",
+    "facebook.com", "fbcdn.net", "instagram.com",
+    "youtube.com", "ytimg.com", "googlevideo.com",
+    "twitter.com", "twimg.com", "tiktokv.com", "tiktokcdn.com",
+    "1e100.net",  # Google global infra
+}
+
+VOWELS = set("aeiouy")
+CONSONANTS = set("bcdfghjklmnpqrstvwxz")
+
+
+def shannon_entropy(s: str) -> float:
+    if not s:
+        return 0.0
+    cnt = Counter(s.lower())
+    n = len(s)
+    return -sum((c / n) * math.log2(c / n) for c in cnt.values())
+
+
+def _check_allowlist(host: str) -> bool:
+    h = host.lower()
+    for d in ALLOWLIST_2LD:
+        if h == d or h.endswith("." + d):
+            return True
+    return False
+
+
+def dga_score(host: str) -> tuple[int, list[str]]:
+    """Return (score 0-100, list of human-readable reasons).
+    Phase 2a heuristic — Phase 3 will add ML classifier."""
+    if not host or "." not in host:
+        return (0, [])
+    if _check_allowlist(host):
+        return (0, ["allowlist_match"])
+
+    indicators: list[str] = []
+    score = 0
+    parts = host.lower().split(".")
+    # The "interesting" subdomain part = everything before the public suffix.
+    # Heuristic : take the leftmost label of length > 4 (skip "www", "api" etc).
+    candidate = next((p for p in parts[:-2] if len(p) > 4), "")
+    if not candidate:
+        return (0, [])
+
+    # 1. Shannon entropy
+    ent = shannon_entropy(candidate)
+    if ent > 3.8:
+        score += 35
+        indicators.append(f"high_entropy({ent:.2f})")
+    elif ent > 3.3:
+        score += 15
+        indicators.append(f"medium_entropy({ent:.2f})")
+
+    # 2. Subdomain length
+    if len(candidate) > 25:
+        score += 25
+        indicators.append(f"long_subdomain({len(candidate)})")
+    elif len(candidate) > 20:
+        score += 15
+        indicators.append(f"long_subdomain({len(candidate)})")
+
+    # 3. Vowel ratio (very low = random)
+    letters = [c for c in candidate if c.isalpha()]
+    if letters:
+        vow_ratio = sum(1 for c in letters if c in VOWELS) / len(letters)
+        if vow_ratio < 0.15:
+            score += 20
+            indicators.append(f"low_vowel_ratio({vow_ratio:.2f})")
+        elif vow_ratio < 0.25:
+            score += 10
+            indicators.append(f"low_vowel_ratio({vow_ratio:.2f})")
+
+    # 4. Digit ratio
+    digit_ratio = sum(1 for c in candidate if c.isdigit()) / len(candidate)
+    if digit_ratio > 0.5:
+        score += 20
+        indicators.append(f"high_digit_ratio({digit_ratio:.2f})")
+    elif digit_ratio > 0.35:
+        score += 10
+        indicators.append(f"high_digit_ratio({digit_ratio:.2f})")
+
+    return (min(score, 100), indicators)
+
+
+def analyze_hosts(hosts: list[str]) -> list[dict]:
+    """Run dga_score on a list of hosts, return only suspicious ones (score >= 30)."""
+    out = []
+    for h in hosts:
+        score, indicators = dga_score(h)
+        if score >= 30:
+            out.append({"host": h, "score": score, "indicators": indicators})
+    return sorted(out, key=lambda x: -x["score"])

--- a/packages/secubox-toolbox/secubox_toolbox/dpi_class.py
+++ b/packages/secubox-toolbox/secubox_toolbox/dpi_class.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""DPI / app classification : host → app category + emoji.
+
+Strategy : pure-Python heuristic + (optional, Phase 2b) query to secubox-dpi
+unix socket for nDPI/netifyd results.
+
+Phase 2a+ : heuristic database below — extensible.
+"""
+from __future__ import annotations
+
+import re
+
+# (pattern, category, app_name, emoji)
+APP_PATTERNS = [
+    # ── Streaming video ──
+    (re.compile(r"(^|\.)youtube\.com$|googlevideo\.com$|ytimg\.com$"), "streaming", "YouTube", "📺"),
+    (re.compile(r"(^|\.)netflix\.com$|nflxvideo\.net$|nflximg\.net$"), "streaming", "Netflix", "🎬"),
+    (re.compile(r"(^|\.)spotify\.com$|spotifycdn\.com$|scdn\.co$"),    "streaming", "Spotify", "🎵"),
+    (re.compile(r"(^|\.)twitch\.tv$|jtvnw\.net$"),                     "streaming", "Twitch", "📺"),
+    (re.compile(r"(^|\.)peertube\."),                                  "streaming", "PeerTube", "📺"),
+    (re.compile(r"(^|\.)tiktokv?\.com$|tiktokcdn\.com$"),              "streaming", "TikTok", "🎵"),
+    (re.compile(r"(^|\.)disneyplus\.com$|dssott\.com$"),               "streaming", "Disney+", "🎬"),
+    (re.compile(r"(^|\.)deezer\.com$|dzcdn\.net$"),                    "streaming", "Deezer", "🎵"),
+    # ── Social ──
+    (re.compile(r"(^|\.)facebook\.com$|fbcdn\.net$|messenger\.com$"),  "social", "Facebook", "👥"),
+    (re.compile(r"(^|\.)instagram\.com$|cdninstagram\.com$"),          "social", "Instagram", "📷"),
+    (re.compile(r"(^|\.)twitter\.com$|x\.com$|twimg\.com$"),           "social", "X / Twitter", "🐦"),
+    (re.compile(r"(^|\.)reddit\.com$|redd\.it$|redditmedia\.com$"),    "social", "Reddit", "👾"),
+    (re.compile(r"(^|\.)linkedin\.com$|licdn\.com$"),                  "social", "LinkedIn", "💼"),
+    (re.compile(r"(^|\.)pinterest\.com$|pinimg\.com$"),                "social", "Pinterest", "📌"),
+    (re.compile(r"(^|\.)mastodon\.social$|fediverse\.|piaille\."),     "social", "Mastodon", "🐘"),
+    (re.compile(r"(^|\.)bsky\.social$|bsky\.app$"),                    "social", "Bluesky", "🦋"),
+    # ── Messaging E2E ──
+    (re.compile(r"(^|\.)signal\.org$|whispersystems\.org$"),           "messaging-e2e", "Signal", "🔒"),
+    (re.compile(r"(^|\.)whatsapp\.com$|whatsapp\.net$"),               "messaging", "WhatsApp", "💬"),
+    (re.compile(r"(^|\.)telegram\.org$|t\.me$"),                       "messaging", "Telegram", "✈"),
+    (re.compile(r"(^|\.)matrix\.org$"),                                "messaging-e2e", "Matrix", "🟢"),
+    (re.compile(r"(^|\.)threema\."),                                   "messaging-e2e", "Threema", "🔒"),
+    (re.compile(r"(^|\.)simplex\."),                                   "messaging-e2e", "SimpleX", "🔒"),
+    # ── Search engines ──
+    (re.compile(r"(^|\.)duckduckgo\.com$"),                            "search", "DuckDuckGo", "🦆"),
+    (re.compile(r"(^|\.)google\.[a-z.]+$"),                            "search", "Google", "🔍"),
+    (re.compile(r"(^|\.)bing\.com$"),                                  "search", "Bing", "🔍"),
+    (re.compile(r"(^|\.)startpage\.com$"),                             "search", "Startpage", "🔍"),
+    (re.compile(r"(^|\.)qwant\.com$"),                                 "search", "Qwant", "🔍"),
+    # ── Cloud / file sync ──
+    (re.compile(r"(^|\.)dropbox\.com$|dropboxapi\.com$"),              "cloud", "Dropbox", "📦"),
+    (re.compile(r"(^|\.)icloud\.com$|icloud-content\.com$"),           "cloud", "iCloud", "☁"),
+    (re.compile(r"(^|\.)drive\.google\.com$|googleusercontent\.com$"), "cloud", "Google Drive", "☁"),
+    (re.compile(r"(^|\.)onedrive\.live\.com$"),                        "cloud", "OneDrive", "☁"),
+    (re.compile(r"(^|\.)nextcloud\.|.*\.nc\."),                        "cloud", "Nextcloud", "☁"),
+    # ── Dev / code ──
+    (re.compile(r"(^|\.)github\.com$|githubusercontent\.com$"),        "dev", "GitHub", "🐙"),
+    (re.compile(r"(^|\.)gitlab\.com$"),                                "dev", "GitLab", "🦊"),
+    (re.compile(r"(^|\.)stackoverflow\.com$|stackexchange\.com$"),     "dev", "Stack Overflow", "📚"),
+    # ── Banking / fin ──
+    (re.compile(r"(^|\.)revolut\.com$"),                               "banking", "Revolut", "🏦"),
+    (re.compile(r"(^|\.)paypal\.com$"),                                "banking", "PayPal", "🏦"),
+    (re.compile(r"(^|\.)stripe\.com$|js\.stripe\.com$"),               "banking", "Stripe", "🏦"),
+    (re.compile(r"(^|\.)societegenerale\.fr$|sgmarkets\.com$"),        "banking", "Société Générale", "🏦"),
+    (re.compile(r"(^|\.)bnpparibas\.|labanquepostale\."),              "banking", "Banque FR", "🏦"),
+    (re.compile(r"(^|\.)credit-agricole\.|ca-paris\.|ca-bretagne\."),  "banking", "Crédit Agricole", "🏦"),
+    # ── Email / collab ──
+    (re.compile(r"(^|\.)gmail\.com$|googlemail\.com$"),                "email", "Gmail", "📧"),
+    (re.compile(r"(^|\.)outlook\.com$|outlook\.office\.com$"),         "email", "Outlook", "📧"),
+    (re.compile(r"(^|\.)proton\.me$|protonmail\."),                    "email-e2e", "Proton Mail", "🔒"),
+    (re.compile(r"(^|\.)tutanota\."),                                  "email-e2e", "Tutanota", "🔒"),
+    # ── Apple ecosystem ──
+    (re.compile(r"(^|\.)apple\.com$|apple-cloudkit\.com$|aaplimg\.com$"), "apple", "Apple Service", "🍎"),
+    (re.compile(r"(^|\.)mzstatic\.com$|itunes\.apple\.com$"),          "apple", "Apple iTunes/Store", "🍎"),
+    (re.compile(r"push\.apple\.com$|courier\.push\.apple\.com$"),      "apple", "Apple Push", "🍎"),
+    (re.compile(r"smoot\.apple\.com$"),                                "apple", "Apple Search", "🍎"),
+    # ── Tor / privacy ──
+    (re.compile(r"(\.onion$)|(torproject\.org$)"),                     "anon", "Tor", "🧅"),
+    (re.compile(r"(^|\.)tailscale\.com$"),                             "vpn", "Tailscale", "🔐"),
+    (re.compile(r"(^|\.)mullvad\.net$|protonvpn\."),                   "vpn", "VPN", "🔐"),
+    # ── CDN / infra (lower priority) ──
+    (re.compile(r"(^|\.)cloudfront\.net$|cloudfront\.aws\."),          "cdn", "CloudFront", "☁"),
+    (re.compile(r"(^|\.)cloudflare\.com$|cf-ipv6\.com$"),              "cdn", "Cloudflare", "☁"),
+    (re.compile(r"(^|\.)fastly\.net$|fastlylb\.net$"),                 "cdn", "Fastly", "☁"),
+    (re.compile(r"(^|\.)akamai(edge|technologies)?\.net$"),            "cdn", "Akamai", "☁"),
+    (re.compile(r"(^|\.)1e100\.net$"),                                 "cdn", "Google infra", "☁"),
+]
+
+CATEGORY_EMOJI = {
+    "streaming": "📺",
+    "social": "👥",
+    "messaging-e2e": "🔒",
+    "messaging": "💬",
+    "search": "🔍",
+    "cloud": "☁",
+    "dev": "💻",
+    "banking": "🏦",
+    "email": "📧",
+    "email-e2e": "🔒",
+    "apple": "🍎",
+    "anon": "🧅",
+    "vpn": "🔐",
+    "cdn": "☁",
+    "other": "❔",
+}
+
+
+def classify_host(host: str) -> dict:
+    """Returns {category, app, emoji} for a hostname. Unknown → other."""
+    if not host:
+        return {"category": "other", "app": "?", "emoji": "❔"}
+    h = host.lower()
+    for pattern, category, app, emoji in APP_PATTERNS:
+        if pattern.search(h):
+            return {"category": category, "app": app, "emoji": emoji}
+    return {"category": "other", "app": "?", "emoji": "❔"}
+
+
+def analyze_hosts(hosts: list[str]) -> dict:
+    """Aggregate by category : returns {by_category: {cat: [{app, emoji, count, hosts[]}, ...]}, top_apps[]}"""
+    by_app: dict[str, dict] = {}
+    by_category: dict[str, int] = {}
+    for h in hosts:
+        cls = classify_host(h)
+        key = f"{cls['app']}|{cls['category']}"
+        if key not in by_app:
+            by_app[key] = {"app": cls["app"], "category": cls["category"],
+                            "emoji": cls["emoji"], "count": 0, "hosts": []}
+        by_app[key]["count"] += 1
+        if len(by_app[key]["hosts"]) < 5:
+            by_app[key]["hosts"].append(h)
+        by_category[cls["category"]] = by_category.get(cls["category"], 0) + 1
+
+    apps_list = sorted(by_app.values(), key=lambda x: -x["count"])
+    return {
+        "top_apps": apps_list[:20],
+        "by_category": by_category,
+        "category_emoji": CATEGORY_EMOJI,
+    }

--- a/packages/secubox-toolbox/secubox_toolbox/geo.py
+++ b/packages/secubox-toolbox/secubox_toolbox/geo.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""GeoIP : IP → country (flag emoji) + ASN + org. With SQLite cache."""
+from __future__ import annotations
+
+import logging
+import socket
+import sqlite3
+import time
+from pathlib import Path
+
+log = logging.getLogger("secubox.toolbox.geo")
+
+DB = Path("/var/lib/secubox/toolbox/toolbox.db")
+COUNTRY_MMDB = "/usr/share/GeoIP/GeoLite2-Country.mmdb"
+COUNTRY_LEGACY = "/usr/share/GeoIP/GeoIP.dat"
+ASN_MMDB = "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS geo_cache (
+    key TEXT PRIMARY KEY,
+    country_iso TEXT,
+    country_name TEXT,
+    asn INTEGER,
+    asn_org TEXT,
+    ts INTEGER NOT NULL
+);
+"""
+
+_COUNTRY_READER = None
+_ASN_READER = None
+_GEOIP_LEGACY = None
+
+
+def _init_readers() -> None:
+    global _COUNTRY_READER, _ASN_READER, _GEOIP_LEGACY
+    if _COUNTRY_READER is None:
+        try:
+            import geoip2.database
+            if Path(COUNTRY_MMDB).exists():
+                _COUNTRY_READER = geoip2.database.Reader(COUNTRY_MMDB)
+        except Exception as e:
+            log.debug("country mmdb unavailable: %s", e)
+        # Fallback : legacy GeoIP.dat via pygeoip / GeoIP module
+        if _COUNTRY_READER is None and Path(COUNTRY_LEGACY).exists():
+            try:
+                import GeoIP  # python3-geoip-dev (optionnel)
+                _GEOIP_LEGACY = GeoIP.open(COUNTRY_LEGACY, GeoIP.GEOIP_STANDARD)
+            except Exception:
+                # Try the cli wrapper
+                pass
+    if _ASN_READER is None and Path(ASN_MMDB).exists():
+        try:
+            import geoip2.database
+            _ASN_READER = geoip2.database.Reader(ASN_MMDB)
+        except Exception as e:
+            log.debug("asn mmdb unavailable: %s", e)
+
+
+def _conn() -> sqlite3.Connection:
+    c = sqlite3.connect(DB, timeout=2)
+    c.row_factory = sqlite3.Row
+    c.executescript(SCHEMA)
+    return c
+
+
+def iso_to_flag(iso: str) -> str:
+    """Convert ISO-3166 alpha-2 (FR, US, ...) → flag emoji via regional indicator letters."""
+    if not iso or len(iso) != 2 or not iso.isalpha():
+        return "🏳"
+    iso = iso.upper()
+    return chr(0x1F1E6 + ord(iso[0]) - ord("A")) + chr(0x1F1E6 + ord(iso[1]) - ord("A"))
+
+
+def _resolve_host_to_ip(host: str) -> str | None:
+    try:
+        # IP literal ? return as-is
+        socket.inet_aton(host)
+        return host
+    except OSError:
+        pass
+    try:
+        return socket.gethostbyname(host)
+    except (socket.gaierror, OSError):
+        return None
+
+
+def lookup(key: str) -> dict:
+    """Returns {country_iso, country_name, flag, asn, asn_org} for an IP or host.
+    Uses 24h cache. Empty dict on full miss."""
+    _init_readers()
+    # cache hit ?
+    try:
+        with _conn() as c:
+            row = c.execute(
+                "SELECT * FROM geo_cache WHERE key=? AND ts > ?",
+                (key, int(time.time()) - 86400),
+            ).fetchone()
+        if row:
+            return {
+                "country_iso": row["country_iso"] or "",
+                "country_name": row["country_name"] or "",
+                "flag": iso_to_flag(row["country_iso"] or ""),
+                "asn": row["asn"] or 0,
+                "asn_org": row["asn_org"] or "",
+            }
+    except Exception:
+        pass
+
+    ip = _resolve_host_to_ip(key)
+    if not ip:
+        return {}
+
+    iso = ""
+    name = ""
+    asn = 0
+    asn_org = ""
+
+    if _COUNTRY_READER is not None:
+        try:
+            r = _COUNTRY_READER.country(ip)
+            iso = (r.country.iso_code or "").upper()
+            name = r.country.name or ""
+        except Exception:
+            pass
+    elif _GEOIP_LEGACY is not None:
+        try:
+            iso = (_GEOIP_LEGACY.country_code_by_addr(ip) or "").upper()
+            name = _GEOIP_LEGACY.country_name_by_addr(ip) or ""
+        except Exception:
+            pass
+
+    if _ASN_READER is not None:
+        try:
+            r = _ASN_READER.asn(ip)
+            asn = r.autonomous_system_number or 0
+            asn_org = r.autonomous_system_organization or ""
+        except Exception:
+            pass
+
+    # cache write
+    try:
+        with _conn() as c:
+            c.execute(
+                "INSERT OR REPLACE INTO geo_cache(key, country_iso, country_name, asn, asn_org, ts) "
+                "VALUES (?,?,?,?,?,?)",
+                (key, iso, name, asn, asn_org, int(time.time())),
+            )
+    except Exception:
+        pass
+
+    return {
+        "country_iso": iso,
+        "country_name": name,
+        "flag": iso_to_flag(iso) if iso else "",
+        "asn": asn,
+        "asn_org": asn_org,
+    }
+
+
+def enrich_hosts(hosts: list[str]) -> dict[str, dict]:
+    """Returns {host: {country_iso, flag, asn, asn_org, ...}, ...}"""
+    return {h: lookup(h) for h in hosts}

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -98,23 +98,62 @@ def render_pdf(report: dict) -> bytes:
     # Compromise analysis
     _section(pdf, "ANALYSE COMPROMISSION")
     score = report.get("risk_score", 0)
+    risk_label = report.get("risk_label") or ("LOW" if score < 30 else "MEDIUM" if score < 70 else "HIGH")
     pdf.set_font("Helvetica", "B", 13)
     if score < 30:
         pdf.set_text_color(0, 221, 68)
-        risk_label = "LOW"
     elif score < 70:
         pdf.set_text_color(255, 179, 71)
-        risk_label = "MEDIUM"
     else:
         pdf.set_text_color(255, 68, 102)
-        risk_label = "HIGH"
     pdf.cell(0, 8, f"Score risque : {score}/100 ({risk_label})", ln=True)
     pdf.set_text_color(0)
     pdf.set_font("Helvetica", "", 10)
-    pdf.ln(2)
+    pdf.ln(1)
+    explanation = report.get("risk_explanation", "")
+    if explanation:
+        pdf.multi_cell(_page_w(pdf), 5, explanation[:600])
+        pdf.ln(1)
     for sig in report.get("indicators", []):
         _bullet(pdf, sig)
     pdf.ln(2)
+
+    # Score breakdown — per-category transparency (Phase 2a)
+    scoring_data = report.get("scoring") or {}
+    breakdown = scoring_data.get("breakdown") or []
+    if breakdown:
+        _section(pdf, "BREAKDOWN DU SCORE")
+        for b in breakdown:
+            pdf.set_font("Helvetica", "B", 9)
+            pdf.cell(0, 5, f"{b.get('category', '?').upper()} : poids {b.get('weight_subtotal', 0)} (sur {b.get('raw_signal_count', 0)} signal)", ln=True)
+            pdf.set_font("Helvetica", "", 8)
+            for ex in (b.get("examples") or [])[:3]:
+                _bullet(pdf, ex, font_size=8)
+        pdf.ln(2)
+
+    # Threat-intel matches (feeds malware) — Phase 2a
+    ti = report.get("threat_intel_matches") or []
+    if ti:
+        _section(pdf, "THREAT INTEL - MATCHES FEEDS MALWARE")
+        for m in ti[:10]:
+            _bullet(pdf, f"[{m.get('source', '?')}/{m.get('weight', 0)}] {m.get('label', '?')} : {m.get('ioc', '?')[:60]}", font_size=8)
+        pdf.ln(2)
+
+    # DGA candidates — Phase 2a
+    dga_list = report.get("dga_candidates") or []
+    if dga_list:
+        _section(pdf, "DGA - DOMAINES SUSPECTS")
+        for d in dga_list[:8]:
+            _bullet(pdf, f"[{d.get('score', 0)}] {d.get('host', '?')[:60]} ({','.join(d.get('indicators', []))})", font_size=8)
+        pdf.ln(2)
+
+    # Beaconing patterns — Phase 2a
+    bc = report.get("beaconing_candidates") or []
+    if bc:
+        _section(pdf, "BEACONING - PATTERNS PERIODIQUES SUSPECTS")
+        for b in bc[:8]:
+            _bullet(pdf, f"[{b.get('score', 0)}] {b.get('host', '?')[:50]}  median={b.get('median_seconds', 0)}s  cv={b.get('cv', 0)}", font_size=8)
+        pdf.ln(2)
 
     # Cert-pinning protection
     _section(pdf, "PROTECTION CERT-PINNING (apps qui RESISTENT au MITM)")

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -106,13 +106,13 @@ def render_pdf(report: dict) -> bytes:
         pdf.set_text_color(255, 179, 71)
     else:
         pdf.set_text_color(255, 68, 102)
-    pdf.cell(0, 8, f"Score risque : {score}/100 ({risk_label})", ln=True)
+    pdf.cell(0, 8, _ascii_safe(f"Score risque : {score}/100 ({risk_label})"), ln=True)
     pdf.set_text_color(0)
     pdf.set_font("Helvetica", "", 10)
     pdf.ln(1)
     explanation = report.get("risk_explanation", "")
     if explanation:
-        pdf.multi_cell(_page_w(pdf), 5, explanation[:600])
+        pdf.multi_cell(_page_w(pdf), 5, _ascii_safe(explanation)[:600])
         pdf.ln(1)
     for sig in report.get("indicators", []):
         _bullet(pdf, sig)
@@ -281,11 +281,41 @@ def _page_w(pdf) -> float:
     return pdf.w - pdf.l_margin - pdf.r_margin
 
 
+# Helvetica is latin-1 only ; PDF report uses ASCII replacements for emoji
+# (HTML live report keeps the real emoji glyphs).
+_EMOJI_REPLACEMENTS = {
+    "📺": "[TV]", "🎬": "[FILM]", "🎵": "[MUSIC]", "👥": "[SOCIAL]",
+    "📷": "[PHOTO]", "🐦": "[X]", "👾": "[REDDIT]", "💼": "[WORK]",
+    "📌": "[PIN]", "🐘": "[MASTO]", "🦋": "[BSKY]", "🔒": "[E2E]",
+    "💬": "[CHAT]", "✈": "[TG]", "🟢": "[OK]", "🔍": "[SEARCH]",
+    "🦆": "[DDG]", "📦": "[BOX]", "☁": "[CLOUD]", "🐙": "[GH]",
+    "🦊": "[FF]", "📚": "[DOC]", "🏦": "[BANK]", "📧": "[MAIL]",
+    "🍎": "[APPLE]", "🧅": "[TOR]", "🔐": "[VPN]", "❔": "[?]",
+    "📱": "[PHONE]", "💻": "[PC]", "🐧": "[LINUX]", "🎮": "[GAME]",
+    "📟": "[BOT]", "🛠": "[TOOL]", "🪟": "[EDGE]", "🧭": "[SAFARI]",
+    "🔴": "[OPERA]", "🇫🇷": "[FR]", "🇺🇸": "[US]", "🏳": "[??]",
+    "📊": "[STATS]", "🎯": "[ADS]", "🟦": "[BLOCK]", "—": "-",
+    "·": "-", "…": "...", "✅": "[OK]", "⚠": "[WARN]", "❌": "[KO]",
+}
+
+
+def _ascii_safe(text: str) -> str:
+    """Strip / replace characters outside Helvetica's latin-1 coverage."""
+    if not text:
+        return ""
+    s = str(text)
+    for emoji, repl in _EMOJI_REPLACEMENTS.items():
+        if emoji in s:
+            s = s.replace(emoji, repl)
+    # Final fallback : encode to latin-1 ignoring unknown chars
+    return s.encode("latin-1", errors="replace").decode("latin-1")
+
+
 def _section(pdf, title: str) -> None:
     pdf.set_x(pdf.l_margin)
     pdf.set_font("Helvetica", "B", 12)
     pdf.set_text_color(0, 221, 68)
-    pdf.multi_cell(_page_w(pdf), 7, title[:80])
+    pdf.multi_cell(_page_w(pdf), 7, _ascii_safe(title)[:80])
     pdf.set_font("Helvetica", "", 10)
     pdf.set_text_color(0)
 
@@ -293,9 +323,9 @@ def _section(pdf, title: str) -> None:
 def _kv(pdf, key: str, value: str) -> None:
     pdf.set_x(pdf.l_margin)
     pdf.set_font("Helvetica", "B", 9)
-    pdf.cell(45, 5, key[:30], ln=False)
+    pdf.cell(45, 5, _ascii_safe(key)[:30], ln=False)
     pdf.set_font("Helvetica", "", 9)
-    pdf.cell(_page_w(pdf) - 45, 5, str(value)[:100], ln=True)
+    pdf.cell(_page_w(pdf) - 45, 5, _ascii_safe(value)[:100], ln=True)
 
 
 def _bullet(pdf, text: str, font_size: int = 9) -> None:
@@ -303,7 +333,7 @@ def _bullet(pdf, text: str, font_size: int = 9) -> None:
     'Not enough horizontal space' errors on long tokens/URLs."""
     pdf.set_x(pdf.l_margin)
     pdf.set_font("Helvetica", "", font_size)
-    safe = str(text)[:160]
+    safe = _ascii_safe(text)[:160]
     # Break unreasonably long single tokens (URLs over ~60 chars)
     parts = []
     for word in safe.split(" "):

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -161,15 +161,44 @@ def render_pdf(report: dict) -> bytes:
         _bullet(pdf, app)
     pdf.ln(2)
 
-    # ── DPI (Deep Packet Inspection) ──
-    dpi = report.get("dpi") or {}
-    if dpi.get("top_hosts"):
-        _section(pdf, "DPI - HOTES LES PLUS CONTACTES")
-        for entry in dpi["top_hosts"][:10]:
-            _bullet(pdf, f"{entry['host'][:60]} ({entry['count']} req)", font_size=8)
-        if dpi.get("user_agents"):
+    # ── DPI classification (Phase 2a+ nDPI-style apps with emojis) ──
+    dpi_cls = report.get("dpi_classified") or {}
+    if dpi_cls.get("top_apps"):
+        _section(pdf, "APPS DETECTEES (nDPI-style classification)")
+        for a in dpi_cls["top_apps"][:15]:
+            _bullet(pdf, f"{a.get('emoji', '?')} {a.get('app', '?')} ({a.get('category', '?')}) - {a.get('count', 0)} connexions", font_size=8)
+        pdf.ln(2)
+
+    # ── Geo top hosts (avec drapeaux + ASN) ──
+    geo_hosts = report.get("geo_top_hosts") or []
+    if geo_hosts:
+        _section(pdf, "HOTES PAR PAYS + ASN + APP (PHASE 2A+)")
+        for h in geo_hosts[:12]:
+            flag = h.get("flag", "")
+            line = f"{flag} {h.get('emoji', '')} {h.get('app', '?')} | {h.get('host', '?')[:40]} | {h.get('asn_org', '?')[:25]} | {h.get('count', 0)} hits"
+            _bullet(pdf, line, font_size=8)
+        pdf.ln(2)
+
+    # ── Avatar / device fingerprint ──
+    avatar = report.get("avatar_analysis") or {}
+    if avatar.get("devices"):
+        _section(pdf, f"AVATAR / DEVICE FINGERPRINT")
+        _kv(pdf, "Most common", f"{avatar.get('most_common_emoji', '?')} {avatar.get('most_common', '?')}")
+        _kv(pdf, "UA distincts", str(avatar.get('raw_count', 0)))
+        for dev, info in (avatar.get("devices") or {}).items():
+            _bullet(pdf, f"{info.get('emoji', '?')} {info.get('os_label', dev)} - {info.get('count', 0)}x", font_size=8)
+        if avatar.get("browsers"):
             pdf.ln(1)
-            _kv(pdf, "User agents", str(len(dpi['user_agents'])))
+            for br, info in (avatar.get("browsers") or {}).items():
+                _bullet(pdf, f"{info.get('emoji', '?')} {info.get('label', br)} - {info.get('count', 0)}x", font_size=8)
+        pdf.ln(2)
+
+    # ── Cookies providers (Phase 2a+) ──
+    cookies_providers = report.get("cookies_providers") or []
+    if cookies_providers:
+        _section(pdf, "COOKIES / TRACKERS PROVIDERS")
+        for p in cookies_providers[:12]:
+            _bullet(pdf, f"{p.get('emoji', '?')} {p.get('provider', '?')} ({p.get('category', '?')}) x{p.get('count', 0)}", font_size=8)
         pdf.ln(2)
 
     # ── Cookies trackers ──

--- a/packages/secubox-toolbox/secubox_toolbox/scoring.py
+++ b/packages/secubox-toolbox/secubox_toolbox/scoring.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""SOC risk scoring algorithm — multi-signal aggregation with transparent breakdown.
+
+Inputs : threat-intel matches, DGA candidates, beaconing patterns, raw SOC events.
+Output : final score (0-100, capped) + per-category breakdown + human-readable explanation.
+
+Design : no opaque ML. Each signal has a known weight, every score is explainable.
+"""
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class ScoreBreakdown(TypedDict):
+    category: str
+    raw_signal_count: int
+    weight_subtotal: int
+    examples: list[str]
+
+
+def compute_score(
+    threat_intel_matches: list[dict],
+    dga_candidates: list[dict],
+    beaconing_candidates: list[dict],
+    raw_soc_events: list[dict],
+) -> dict:
+    """Aggregate signals into a 0-100 score + breakdown.
+
+    Returns :
+      {
+        "score": 0-100,
+        "label": "LOW" | "MEDIUM" | "HIGH",
+        "breakdown": [ScoreBreakdown, ...],
+        "explanation": "human-readable summary",
+        "indicators_summary": [str, ...]
+      }
+    """
+    breakdown: list[ScoreBreakdown] = []
+    total = 0
+    indicators: list[str] = []
+
+    # ── 1. Threat-intel matches ──
+    if threat_intel_matches:
+        # Each match contributes its `weight` field (40-60 typically), capped at 80
+        sub = 0
+        examples = []
+        for m in threat_intel_matches[:5]:
+            w = int(m.get("weight", 0))
+            sub += min(w, 60)
+            label = m.get("label") or "?"
+            src = m.get("source") or "?"
+            host = m.get("ioc") or m.get("ip") or "?"
+            examples.append(f"[{src}/{w}] {label} : {host}")
+        sub = min(sub, 80)
+        total += sub
+        indicators.append(f"{len(threat_intel_matches)} match(es) feeds malware (poids {sub})")
+        breakdown.append({
+            "category": "threat_intel",
+            "raw_signal_count": len(threat_intel_matches),
+            "weight_subtotal": sub,
+            "examples": examples,
+        })
+
+    # ── 2. DGA candidates ──
+    if dga_candidates:
+        # Each DGA candidate contributes its `score` field (0-100 individual),
+        # we take the MAX (one high-confidence DGA is enough to flag) capped at 40
+        max_score = max(c.get("score", 0) for c in dga_candidates)
+        sub = min(int(max_score * 0.4), 40)  # scale individual score to category subtotal
+        total += sub
+        examples = [f"[{c.get('score')}] {c.get('host')} ({','.join(c.get('indicators',[]))})"
+                    for c in dga_candidates[:3]]
+        indicators.append(f"{len(dga_candidates)} domaine(s) DGA-suspect(s) (poids {sub})")
+        breakdown.append({
+            "category": "dga",
+            "raw_signal_count": len(dga_candidates),
+            "weight_subtotal": sub,
+            "examples": examples,
+        })
+
+    # ── 3. Beaconing patterns ──
+    if beaconing_candidates:
+        # Each beacon contributes its `score` (20-50), take top 3 averaged + capped at 50
+        top = beaconing_candidates[:3]
+        avg = sum(b.get("score", 0) for b in top) // max(len(top), 1)
+        sub = min(avg, 50)
+        total += sub
+        examples = [f"[{b.get('score')}] {b.get('host')} (median={b.get('median_seconds')}s, cv={b.get('cv')})"
+                    for b in top]
+        indicators.append(f"{len(beaconing_candidates)} pattern(s) beaconing (poids {sub})")
+        breakdown.append({
+            "category": "beaconing",
+            "raw_signal_count": len(beaconing_candidates),
+            "weight_subtotal": sub,
+            "examples": examples,
+        })
+
+    # ── 4. Raw SOC events (from local_store SOC source — suspicious patterns) ──
+    if raw_soc_events:
+        sub = min(sum(int(e.get("weight", 15)) for e in raw_soc_events[:10]), 40)
+        total += sub
+        examples = [f"[{e.get('weight',15)}] {e.get('kind','?')} : {e.get('host','?')}"
+                    for e in raw_soc_events[:5]]
+        indicators.append(f"{len(raw_soc_events)} indicateur(s) SOC raw (poids {sub})")
+        breakdown.append({
+            "category": "raw_soc",
+            "raw_signal_count": len(raw_soc_events),
+            "weight_subtotal": sub,
+            "examples": examples,
+        })
+
+    # Final cap + label
+    score = min(total, 100)
+    if score < 30:
+        label = "LOW"
+    elif score < 70:
+        label = "MEDIUM"
+    else:
+        label = "HIGH"
+
+    # Build a 1-paragraph explanation
+    if score == 0:
+        explanation = (
+            "Aucun signal de compromission détecté pendant ta session. "
+            "Ton appareil semble propre. Continue les bonnes pratiques (2FA, mises à jour)."
+        )
+    elif score < 30:
+        explanation = (
+            f"Quelques signaux faibles détectés ({score}/100) — probable faux positifs ou "
+            "activité tierce légitime (CDN, télémétrie). Rien d'alarmant."
+        )
+    elif score < 70:
+        explanation = (
+            f"Score modéré ({score}/100). Plusieurs signaux à vérifier individuellement "
+            "(voir détails ci-dessous). Recommandation : passer en revue les apps "
+            "installées récemment et vérifier les permissions."
+        )
+    else:
+        explanation = (
+            f"⚠ Score élevé ({score}/100). Plusieurs indicateurs convergent vers une "
+            "compromission probable. Recommandations : isoler l'appareil du réseau, "
+            "examiner les apps installées, réinitialiser si nécessaire, changer les "
+            "mots de passe sensibles depuis un autre appareil."
+        )
+
+    return {
+        "score": score,
+        "label": label,
+        "breakdown": breakdown,
+        "explanation": explanation,
+        "indicators_summary": indicators,
+    }

--- a/packages/secubox-toolbox/secubox_toolbox/threat_intel.py
+++ b/packages/secubox-toolbox/secubox_toolbox/threat_intel.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""Threat intel feeds : pull + cache local + IP/SNI lookup.
+
+Sources (CC0/public domain) :
+- abuse.ch ThreatFox       : malware C2 IoCs (IPs + domains + URLs)
+- abuse.ch Feodo Tracker   : botnet C2 (Emotet, Dridex, TrickBot, Heodo)
+- abuse.ch SSLBL           : TLS certificate blacklist (cert fingerprints)
+
+Refresh toutes les heures (asyncio task). Cache local SQLite, table dédiée.
+Pas de re-download massif si la dernière fetch < 1h.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+import time
+from pathlib import Path
+
+log = logging.getLogger("secubox.toolbox.threat_intel")
+
+DB = Path("/var/lib/secubox/toolbox/toolbox.db")
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS threat_intel (
+    ioc TEXT NOT NULL,
+    ioc_type TEXT NOT NULL,  -- 'ip', 'domain', 'sha256', 'sni'
+    source TEXT NOT NULL,    -- 'threatfox', 'feodo', 'sslbl'
+    weight INTEGER NOT NULL DEFAULT 50,
+    label TEXT,              -- malware family / threat name
+    first_seen INTEGER,
+    last_seen INTEGER,
+    PRIMARY KEY (ioc, ioc_type, source)
+);
+CREATE INDEX IF NOT EXISTS idx_ti_ioc ON threat_intel(ioc);
+CREATE TABLE IF NOT EXISTS threat_intel_fetch (
+    source TEXT PRIMARY KEY,
+    last_fetch INTEGER NOT NULL,
+    rows INTEGER NOT NULL DEFAULT 0,
+    error TEXT
+);
+"""
+
+# Feed sources — small representative subsets to limit bandwidth/storage on
+# embedded boards. ThreatFox export-json-recent is ~6 MB compressed,
+# Feodo blocklist is ~10 KB.
+FEED_FEODO = "https://feodotracker.abuse.ch/downloads/ipblocklist_recommended.json"
+FEED_THREATFOX = "https://threatfox.abuse.ch/export/json/recent/"
+FEED_SSLBL = "https://sslbl.abuse.ch/blacklist/sslblacklist.csv"
+
+REFRESH_INTERVAL = 3600  # 1h
+
+
+def _conn() -> sqlite3.Connection:
+    c = sqlite3.connect(DB, timeout=5)
+    c.row_factory = sqlite3.Row
+    c.executescript(SCHEMA)
+    return c
+
+
+def _was_fetched_recently(source: str) -> bool:
+    try:
+        with _conn() as c:
+            row = c.execute(
+                "SELECT last_fetch FROM threat_intel_fetch WHERE source=?",
+                (source,),
+            ).fetchone()
+        if not row:
+            return False
+        return int(time.time()) - row["last_fetch"] < REFRESH_INTERVAL
+    except Exception:
+        return False
+
+
+def _record_fetch(source: str, rows: int, error: str | None = None) -> None:
+    with _conn() as c:
+        c.execute(
+            "INSERT OR REPLACE INTO threat_intel_fetch(source, last_fetch, rows, error) "
+            "VALUES (?, ?, ?, ?)",
+            (source, int(time.time()), rows, error),
+        )
+
+
+async def _http_get_json(url: str) -> dict | list | None:
+    try:
+        import httpx
+    except ImportError:
+        log.warning("httpx not available — threat_intel disabled")
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+            r = await client.get(url, headers={"User-Agent": "secubox-toolbox/2.0"})
+            r.raise_for_status()
+            return r.json()
+    except Exception as e:
+        log.warning("fetch %s failed: %s", url, e)
+        return None
+
+
+async def _http_get_text(url: str) -> str | None:
+    try:
+        import httpx
+    except ImportError:
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+            r = await client.get(url, headers={"User-Agent": "secubox-toolbox/2.0"})
+            r.raise_for_status()
+            return r.text
+    except Exception as e:
+        log.warning("fetch %s failed: %s", url, e)
+        return None
+
+
+# ──────────── Feed ingest ────────────
+
+async def ingest_feodo() -> int:
+    if _was_fetched_recently("feodo"):
+        return 0
+    data = await _http_get_json(FEED_FEODO)
+    if data is None or not isinstance(data, list):
+        _record_fetch("feodo", 0, "fetch failed")
+        return 0
+    now = int(time.time())
+    rows = []
+    for entry in data:
+        ip = entry.get("ip_address")
+        if not ip:
+            continue
+        rows.append((ip, "ip", "feodo", 55, entry.get("malware") or "C2", now, now))
+    if rows:
+        with _conn() as c:
+            c.executemany(
+                "INSERT OR REPLACE INTO threat_intel"
+                "(ioc, ioc_type, source, weight, label, first_seen, last_seen)"
+                " VALUES (?,?,?,?,?,?,?)",
+                rows,
+            )
+    _record_fetch("feodo", len(rows))
+    log.info("feodo: %d IPs ingested", len(rows))
+    return len(rows)
+
+
+async def ingest_threatfox(limit: int = 5000) -> int:
+    """Limit to N most recent IoCs to control storage."""
+    if _was_fetched_recently("threatfox"):
+        return 0
+    data = await _http_get_json(FEED_THREATFOX)
+    if data is None or not isinstance(data, dict):
+        _record_fetch("threatfox", 0, "fetch failed")
+        return 0
+    now = int(time.time())
+    rows = []
+    # ThreatFox returns { "<id>": [ {ioc, ioc_type, malware, ...}, ... ], ... }
+    for entries in data.values():
+        if not isinstance(entries, list):
+            continue
+        for e in entries:
+            ioc = e.get("ioc", "")
+            ioc_type = e.get("ioc_type", "")
+            malware = e.get("malware_printable") or e.get("malware") or "?"
+            if not ioc:
+                continue
+            # Normalize types
+            if ioc_type == "ip:port":
+                ip = ioc.split(":", 1)[0]
+                rows.append((ip, "ip", "threatfox", 50, malware, now, now))
+            elif ioc_type == "domain":
+                rows.append((ioc, "domain", "threatfox", 45, malware, now, now))
+            elif ioc_type == "url":
+                # Skip URLs (too volatile)
+                continue
+            elif ioc_type == "sha256_hash":
+                rows.append((ioc, "sha256", "threatfox", 40, malware, now, now))
+            if len(rows) >= limit:
+                break
+        if len(rows) >= limit:
+            break
+    if rows:
+        with _conn() as c:
+            c.executemany(
+                "INSERT OR REPLACE INTO threat_intel"
+                "(ioc, ioc_type, source, weight, label, first_seen, last_seen)"
+                " VALUES (?,?,?,?,?,?,?)",
+                rows,
+            )
+    _record_fetch("threatfox", len(rows))
+    log.info("threatfox: %d IoCs ingested (capped at %d)", len(rows), limit)
+    return len(rows)
+
+
+async def ingest_sslbl() -> int:
+    if _was_fetched_recently("sslbl"):
+        return 0
+    text = await _http_get_text(FEED_SSLBL)
+    if not text:
+        _record_fetch("sslbl", 0, "fetch failed")
+        return 0
+    now = int(time.time())
+    rows = []
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(",")
+        if len(parts) < 3:
+            continue
+        # Format: "Listingdate,SHA1,Listingreason"
+        sha1 = parts[1].strip().lower()
+        reason = parts[2].strip()
+        if len(sha1) == 40:
+            rows.append((sha1, "sha1_cert", "sslbl", 50, reason, now, now))
+    if rows:
+        with _conn() as c:
+            c.executemany(
+                "INSERT OR REPLACE INTO threat_intel"
+                "(ioc, ioc_type, source, weight, label, first_seen, last_seen)"
+                " VALUES (?,?,?,?,?,?,?)",
+                rows,
+            )
+    _record_fetch("sslbl", len(rows))
+    log.info("sslbl: %d cert fingerprints ingested", len(rows))
+    return len(rows)
+
+
+async def refresh_all() -> dict[str, int]:
+    """Refresh all feeds. Returns counts per source."""
+    res: dict[str, int] = {}
+    for fn, name in [(ingest_feodo, "feodo"),
+                     (ingest_threatfox, "threatfox"),
+                     (ingest_sslbl, "sslbl")]:
+        try:
+            res[name] = await fn()
+        except Exception as e:
+            log.error("refresh %s failed: %s", name, e)
+            res[name] = 0
+    return res
+
+
+async def refresh_loop() -> None:
+    """Run forever, refreshing every REFRESH_INTERVAL seconds."""
+    while True:
+        try:
+            counts = await refresh_all()
+            log.info("threat_intel refresh: %s", counts)
+        except Exception as e:
+            log.error("threat_intel refresh_loop error: %s", e)
+        await asyncio.sleep(REFRESH_INTERVAL)
+
+
+# ──────────── Lookups ────────────
+
+def is_malicious_ip(ip: str) -> list[dict]:
+    """Returns list of matches : [{source, weight, label}, ...]"""
+    try:
+        with _conn() as c:
+            rows = c.execute(
+                "SELECT source, weight, label FROM threat_intel "
+                "WHERE ioc=? AND ioc_type='ip'",
+                (ip,),
+            ).fetchall()
+    except Exception:
+        return []
+    return [dict(r) for r in rows]
+
+
+def is_malicious_domain(domain: str) -> list[dict]:
+    """Match exact domain or parent domain (eg. evil.example.com matches example.com)."""
+    parts = domain.lower().split(".")
+    candidates = [".".join(parts[i:]) for i in range(len(parts) - 1)]
+    if not candidates:
+        return []
+    try:
+        with _conn() as c:
+            placeholders = ",".join("?" * len(candidates))
+            rows = c.execute(
+                f"SELECT ioc, source, weight, label FROM threat_intel "
+                f"WHERE ioc_type='domain' AND ioc IN ({placeholders})",
+                candidates,
+            ).fetchall()
+    except Exception:
+        return []
+    return [dict(r) for r in rows]
+
+
+def feed_stats() -> dict:
+    """Return last-fetch + row-count per source for /admin/metrics."""
+    try:
+        with _conn() as c:
+            rows = c.execute(
+                "SELECT source, last_fetch, rows, error FROM threat_intel_fetch"
+            ).fetchall()
+            total = c.execute(
+                "SELECT COUNT(*) FROM threat_intel"
+            ).fetchone()[0]
+        return {
+            "total_iocs": total,
+            "sources": {r["source"]: {
+                "last_fetch": r["last_fetch"],
+                "rows": r["rows"],
+                "error": r["error"],
+                "age_seconds": int(time.time()) - r["last_fetch"],
+            } for r in rows},
+        }
+    except Exception as e:
+        return {"error": str(e)}


### PR DESCRIPTION
## Summary

Closes #485 and #486 (this PR bundles both — #486 branch includes #485 commits).

### Phase 2a (#485) — SOC scoring multi-signal
- `threat_intel.py` : feeds abuse.ch (ThreatFox / Feodo / SSLBL) CC0 ingested async hourly into SQLite cache
- `dga.py` : Shannon entropy + length + vowel/digit ratio heuristic, 2LD allowlist (akamai/cloudflare/apple/google/github)
- `beaconing.py` : median interval + coefficient of variation per mac_hash (5–300s + cv<0.20 → beacon)
- `scoring.py` : weighted aggregation threat_intel(0-80) + dga(0-40) + beaconing(0-50) + raw_soc(0-40) → LOW/MEDIUM/HIGH with transparent breakdown

### Phase 2a+ (#486) — Enrichment for visible reports
- `geo.py` : IP/hostname → ISO country → emoji flag + ASN org via python3-geoip2 (GeoLite2-ASN + Country mmdb), SQLite cache 24h. dbip-country-lite Country DB CC-BY installed live on gk2.
- `dpi_class.py` : 60+ host patterns → app category + emoji (📺 YouTube · 🔒 Signal · 🐙 GitHub · 🏦 Revolut · 🍎 iCloud · 🧅 Tor…)
- `cookie_analysis.py` : 40+ tracker patterns → provider/category/emoji (📊 GA · 🎯 Facebook Pixel · 💼 LinkedIn · 🎵 TikTok…)
- `avatar_analysis.py` : UA → device + browser + OS version + emoji (📱 iPhone iOS 17.4 · 🟢 Chrome · 🦊 Firefox · 🎮 PlayStation…)

### Integration
- `api.py _aggregate_session` enrichi avec scoring + threat_intel_matches + dga_candidates + beaconing_candidates + dpi_classified + geo_top_hosts + avatar_analysis + cookies_providers
- `reports.py build_pdf` : nouvelles sections nDPI classification + Hôtes par pays/ASN + Avatar device fingerprint + Cookies trackers
- `conf/report-live.html.j2` : tables enrichies avec drapeaux + badges emoji + panel avatar
- `conf/nft-toolbox.nft.j2` : ordre corrigé portal-bypass → R2-consent → captive-default

### E2E live test (gk2, 2026-06-05)
- 431 events 24h · 564 MITM conn · 264 cert-pin · 111 hosts uniques
- Avatar : 📱 iPhone + 🟢 Chrome détectés
- Flags : github.com → 🇩🇪 + GitHub Inc · google → 🇺🇸 + Google LLC
- Feeds : Feodo 1 IP · SSLBL 9859 cert fingerprints · ThreatFox 0

### Versioning
- 1.4.0 → 2.0.0 (Phase 2a SOC)
- 2.0.0 → 2.1.0 (Phase 2a+ enrichment)

### License
Strictement LicenseRef-CMSD-1.0. Aucune mention AGPL ou Apache.

## Test plan
- [ ] Captive cycle iPhone : connexion VILLAGE3B → splash → accept → http://village3b/report/me/html
- [ ] Vérifier drapeaux pays présents par hôte
- [ ] Vérifier emojis par app (Signal, GitHub, iCloud, etc.)
- [ ] Vérifier panel avatar (device + browser détectés)
- [ ] PDF download via http://village3b/report/me → vérifier nouvelles sections
- [ ] Voir scoring_label + breakdown explicit dans /admin/metrics