### PR TITLE
feat(phase-2b): wire mitm addons to 5 receiving modules + cross-module aggregator

### DIFF
--- a/common/secubox_core/mitm_ingest.py
+++ b/common/secubox_core/mitm_ingest.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""Shared mitm-ingest helper for SecuBox modules receiving events from
+secubox-toolbox mitmproxy addons (cookies/dpi/avatar/soc/threat-analyst).
+
+Each module mounts its ingest route once at app startup :
+
+    from secubox_core.mitm_ingest import mount_ingest_routes
+    mount_ingest_routes(
+        app,
+        endpoint_path="/classify",          # what the mitm addon POSTs to
+        db_path="/var/lib/secubox-dpi/mitm-ingest.db",
+        kind="dpi",
+    )
+
+This registers:
+  - POST {endpoint_path}    : ingest a single mitm event (validates + stores)
+  - GET  /mitm-events       : returns recent events for secubox-toolbox aggregator
+  - GET  /mitm-events/stats : aggregate counters per mac_hash (last 24h)
+
+Events are stored in an isolated SQLite db so the module's main schema is
+untouched. The toolbox aggregator queries GET /mitm-events?mac_hash=... to
+enrich its session report with cross-module classification.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from fastapi import FastAPI, Query
+from pydantic import BaseModel, Field
+
+log = logging.getLogger("secubox.mitm_ingest")
+
+
+class MitmEvent(BaseModel):
+    """Flexible payload : accepts any mitm addon shape.
+
+    All addon payloads (dpi/cookies/avatar/soc/ja4) carry these common
+    fields. Module-specific extra fields are passed through verbatim and
+    persisted as JSON.
+    """
+    ts_ms: int = Field(..., description="mitm event timestamp ms epoch")
+    client_ip: Optional[str] = None
+    client_mac: Optional[str] = None      # raw MAC (legacy / backward-compat)
+    client_mac_hash: Optional[str] = None  # 16-char HMAC-SHA256 (preferred)
+
+    class Config:
+        extra = "allow"  # accept any extra module-specific fields
+
+
+def _init_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path, timeout=5) as c:
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS mitm_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts_ms INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                client_mac_hash TEXT,
+                client_ip TEXT,
+                payload TEXT NOT NULL
+            )
+        """)
+        c.execute("CREATE INDEX IF NOT EXISTS ix_mitm_events_mac ON mitm_events(client_mac_hash, ts_ms DESC)")
+        c.execute("CREATE INDEX IF NOT EXISTS ix_mitm_events_ts ON mitm_events(ts_ms)")
+
+
+def _purge_old(db_path: Path, retention_seconds: int = 86400 * 2) -> None:
+    """Drop events older than retention window (default 48h)."""
+    cutoff = int(time.time() * 1000) - retention_seconds * 1000
+    try:
+        with sqlite3.connect(db_path, timeout=2) as c:
+            c.execute("DELETE FROM mitm_events WHERE ts_ms < ?", (cutoff,))
+    except Exception as e:
+        log.debug("mitm_ingest purge failed: %s", e)
+
+
+def mount_ingest_routes(
+    app: FastAPI,
+    *,
+    endpoint_path: str,
+    db_path: str | Path,
+    kind: str,
+    retention_hours: int = 48,
+    enrich_hook: "callable | None" = None,
+) -> None:
+    """Mount /POST {endpoint_path} and GET /mitm-events on the given FastAPI app.
+
+    enrich_hook : optional callable(event_dict) -> enriched_event_dict.
+    Called BEFORE persistence. Module-specific enrichment (e.g. nDPI lookup
+    for secubox-dpi, JA4 hash calc for secubox-threat-analyst) can be added
+    via this hook. Must be quick (synchronous, < 50ms) — anything slower
+    must go through a background task. Errors are logged but never block
+    ingestion (raw event is still persisted).
+    """
+    db_path = Path(db_path)
+    _init_db(db_path)
+
+    @app.post(endpoint_path)
+    async def ingest(event: MitmEvent) -> dict:
+        ev_dict = (event.model_dump() if hasattr(event, "model_dump") else event.dict())
+        if enrich_hook is not None:
+            try:
+                enriched = enrich_hook(ev_dict)
+                if isinstance(enriched, dict):
+                    ev_dict = enriched
+            except Exception as e:
+                log.warning("mitm enrich_hook failed (%s): %s", kind, e)
+        try:
+            with sqlite3.connect(db_path, timeout=2) as c:
+                c.execute(
+                    "INSERT INTO mitm_events(ts_ms, kind, client_mac_hash, client_ip, payload) "
+                    "VALUES (?,?,?,?,?)",
+                    (
+                        event.ts_ms,
+                        kind,
+                        event.client_mac_hash,
+                        event.client_ip,
+                        json.dumps(ev_dict)[:16000],
+                    ),
+                )
+        except Exception as e:
+            log.warning("mitm ingest insert failed (%s): %s", kind, e)
+            return {"ok": False, "error": "store_failed"}
+        # Lightweight opportunistic purge (1% of inserts)
+        if event.ts_ms % 100 == 0:
+            _purge_old(db_path, retention_hours * 3600)
+        return {"ok": True, "kind": kind}
+
+    @app.get("/mitm-events")
+    async def list_events(
+        mac_hash: Optional[str] = Query(None, description="filter by client mac hash"),
+        limit: int = Query(200, ge=1, le=2000),
+        since_ms: Optional[int] = Query(None, description="only events newer than this ts_ms"),
+    ) -> dict:
+        try:
+            with sqlite3.connect(db_path, timeout=2) as c:
+                where = []
+                args: list[Any] = []
+                if mac_hash:
+                    where.append("client_mac_hash = ?")
+                    args.append(mac_hash)
+                if since_ms:
+                    where.append("ts_ms > ?")
+                    args.append(since_ms)
+                clause = " WHERE " + " AND ".join(where) if where else ""
+                cur = c.execute(
+                    f"SELECT ts_ms, client_mac_hash, client_ip, payload FROM mitm_events"
+                    f"{clause} ORDER BY ts_ms DESC LIMIT ?",
+                    args + [limit],
+                )
+                events = []
+                for ts_ms, mh, ip, payload in cur.fetchall():
+                    try:
+                        p = json.loads(payload)
+                    except Exception:
+                        p = {}
+                    events.append({"ts_ms": ts_ms, "mac_hash": mh, "ip": ip, "payload": p})
+                return {"kind": kind, "count": len(events), "events": events}
+        except Exception as e:
+            log.warning("mitm list_events failed (%s): %s", kind, e)
+            return {"kind": kind, "count": 0, "events": [], "error": str(e)[:80]}
+
+    @app.get("/mitm-events/stats")
+    async def stats(
+        mac_hash: Optional[str] = Query(None),
+        last_seconds: int = Query(86400, ge=60, le=604800),
+    ) -> dict:
+        cutoff = int(time.time() * 1000) - last_seconds * 1000
+        try:
+            with sqlite3.connect(db_path, timeout=2) as c:
+                if mac_hash:
+                    cur = c.execute(
+                        "SELECT COUNT(*) FROM mitm_events WHERE ts_ms > ? AND client_mac_hash = ?",
+                        (cutoff, mac_hash),
+                    )
+                else:
+                    cur = c.execute("SELECT COUNT(*) FROM mitm_events WHERE ts_ms > ?", (cutoff,))
+                count = cur.fetchone()[0]
+                return {"kind": kind, "count": count, "since_seconds": last_seconds}
+        except Exception as e:
+            return {"kind": kind, "count": 0, "error": str(e)[:80]}
+
+    log.info("mitm-ingest mounted : POST %s + GET /mitm-events (kind=%s, db=%s)",
+             endpoint_path, kind, db_path)

--- a/packages/secubox-avatar/api/main.py
+++ b/packages/secubox-avatar/api/main.py
@@ -26,6 +26,15 @@ from secubox_core.logger import get_logger
 
 app = FastAPI(title="secubox-avatar", version="1.0.0", root_path="/api/v1/avatar")
 
+# Phase 2b (#488) : ingest mitm avatar fingerprint events from secubox-toolbox addon
+from secubox_core.mitm_ingest import mount_ingest_routes  # noqa: E402
+mount_ingest_routes(
+    app,
+    endpoint_path="/fingerprint",
+    db_path="/var/lib/secubox/avatar/mitm-ingest.db",
+    kind="avatar",
+)
+
 # ══════════════════════════════════════════════════════════════════
 # Health Check Endpoint (public, no auth)
 # ══════════════════════════════════════════════════════════════════

--- a/packages/secubox-cookies/api/main.py
+++ b/packages/secubox-cookies/api/main.py
@@ -28,6 +28,15 @@ except ImportError:
 
 app = FastAPI(title="SecuBox Cookies API", version="1.0.0")
 
+# Phase 2b (#488) : ingest mitm cookies events from secubox-toolbox addon
+from secubox_core.mitm_ingest import mount_ingest_routes  # noqa: E402
+mount_ingest_routes(
+    app,
+    endpoint_path="/inject",
+    db_path="/var/lib/secubox/cookies/mitm-ingest.db",
+    kind="cookies",
+)
+
 # Configuration paths
 CONFIG_FILE = Path("/etc/secubox/cookies.json")
 DATA_DIR = Path("/var/lib/secubox/cookies")

--- a/packages/secubox-dpi/api/main.py
+++ b/packages/secubox-dpi/api/main.py
@@ -23,6 +23,15 @@ import httpx
 
 app = FastAPI(title="secubox-dpi", version="2.0.0", root_path="/api/v1/dpi")
 
+# Phase 2b (#488) : ingest mitm DPI events from secubox-toolbox addon
+from secubox_core.mitm_ingest import mount_ingest_routes  # noqa: E402
+mount_ingest_routes(
+    app,
+    endpoint_path="/classify",
+    db_path="/var/lib/secubox/dpi/mitm-ingest.db",
+    kind="dpi",
+)
+
 # ══════════════════════════════════════════════════════════════════
 # Health Check Endpoint (public, no auth)
 # ══════════════════════════════════════════════════════════════════

--- a/packages/secubox-soc/api/main.py
+++ b/packages/secubox-soc/api/main.py
@@ -34,6 +34,15 @@ P2P_SOCKET = "/run/secubox/p2p.sock"
 
 app = FastAPI(title="SecuBox SOC", version="2.0.0")
 
+# Phase 2b (#488) : ingest mitm SOC indicator events from secubox-toolbox addon
+from secubox_core.mitm_ingest import mount_ingest_routes  # noqa: E402
+mount_ingest_routes(
+    app,
+    endpoint_path="/event",
+    db_path="/var/lib/secubox/soc/mitm-ingest.db",
+    kind="soc",
+)
+
 # Data directories
 DATA_DIR = Path("/var/lib/secubox/soc")
 TICKETS_FILE = DATA_DIR / "tickets.json"

--- a/packages/secubox-threat-analyst/api/main.py
+++ b/packages/secubox-threat-analyst/api/main.py
@@ -54,6 +54,15 @@ QUEUE_FILE = DATA_DIR / "pending_rules.json"
 app = FastAPI(title="SecuBox Threat Analyst", version="1.0.0")
 logger = logging.getLogger("secubox.threat-analyst")
 
+# Phase 2b (#488) : ingest mitm JA4 clienthello events from secubox-toolbox addon
+from secubox_core.mitm_ingest import mount_ingest_routes  # noqa: E402
+mount_ingest_routes(
+    app,
+    endpoint_path="/ja4",
+    db_path="/var/lib/secubox/threat-analyst/mitm-ingest.db",
+    kind="ja4",
+)
+
 
 class RuleType(str, Enum):
     MITMPROXY = "mitmproxy"

--- a/packages/secubox-toolbox/mitmproxy_addons/_common.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/_common.py
@@ -5,9 +5,13 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac
 import logging
 import re
 import subprocess
+from datetime import date
+from pathlib import Path
 from urllib.parse import urlparse
 
 try:
@@ -17,6 +21,8 @@ except ImportError:
 
 log = logging.getLogger("secubox.toolbox.addons")
 _RE_MAC = re.compile(r"lladdr\s+([0-9a-f:]{17})", re.I)
+_SALT_FILE = Path("/etc/secubox/secrets/toolbox-mac-salt")
+_SALT_CACHE: str | None = None
 
 
 def mac_of(ip: str) -> str | None:
@@ -29,6 +35,41 @@ def mac_of(ip: str) -> str | None:
         return None
     m = _RE_MAC.search(out)
     return m.group(1).lower() if m else None
+
+
+def _salt() -> str:
+    """Read MAC anonymization salt once, cache in-process."""
+    global _SALT_CACHE
+    if _SALT_CACHE is None:
+        try:
+            _SALT_CACHE = _SALT_FILE.read_text().strip()
+        except Exception as e:
+            log.warning("salt unavailable, MAC hashing disabled: %s", e)
+            _SALT_CACHE = ""
+    return _SALT_CACHE
+
+
+def hash_mac(mac: str | None) -> str | None:
+    """HMAC-SHA256 of MAC with salt + day rotation. 16-char hex digest.
+
+    Same algorithm as secubox_toolbox.mac.hash_mac and local_store._hash_mac
+    so events from all addons cross-reference the same mac_hash.
+    """
+    if not mac:
+        return None
+    s = _salt()
+    if not s:
+        return None
+    key = (s + ":" + date.today().isoformat()).encode()
+    return hmac.new(key, mac.lower().encode(), hashlib.sha256).hexdigest()[:16]
+
+
+def mac_hash_of(ip: str | None) -> str | None:
+    """Resolve IP to MAC via neighbour table then hash. Returns None on failure."""
+    if not ip:
+        return None
+    raw = mac_of(ip)
+    return hash_mac(raw) if raw else None
 
 
 def _resolve_socket_url(target: str) -> tuple[str, str]:

--- a/packages/secubox-toolbox/mitmproxy_addons/avatar.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/avatar.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from mitmproxy import http
 
-from _common import fire_forget_post, mac_of, queue_async
+from _common import fire_forget_post, mac_hash_of, queue_async
 
 TARGET = "http+unix:///run/secubox/avatar.sock/fingerprint"
 
@@ -30,7 +30,7 @@ class AvatarRelay:
         payload = {
             "ts_ms": int(flow.timestamp_start * 1000),
             "client_ip": client_ip,
-            "client_mac": mac_of(client_ip) if client_ip else None,
+            "client_mac_hash": mac_hash_of(client_ip),
             "user_agent": ua,
             "accept_language": flow.request.headers.get("accept-language"),
             "accept": flow.request.headers.get("accept"),

--- a/packages/secubox-toolbox/mitmproxy_addons/cookies.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/cookies.py
@@ -6,9 +6,32 @@ from __future__ import annotations
 
 from mitmproxy import http
 
-from _common import fire_forget_post, mac_of, queue_async
+from _common import fire_forget_post, mac_hash_of, queue_async
 
 TARGET = "http+unix:///run/secubox/cookies.sock/inject"
+
+
+def _names_only(headers: list[str], cap: int = 50) -> list[str]:
+    """Extract cookie/Set-Cookie NAMES (not values) — privacy-safe metadata."""
+    out: list[str] = []
+    for h in headers[:cap]:
+        head = h.split(";", 1)[0]
+        if "=" in head:
+            n = head.split("=", 1)[0].strip()[:32]
+            if n:
+                out.append(n)
+    return out
+
+
+def _parse_cookie_header(value: str) -> list[str]:
+    """Split 'Cookie:' header into list of names."""
+    names: list[str] = []
+    for part in value.split(";"):
+        if "=" in part:
+            n = part.split("=", 1)[0].strip()[:32]
+            if n:
+                names.append(n)
+    return names
 
 
 class CookiesRelay:
@@ -19,14 +42,21 @@ class CookiesRelay:
         req_cookies = flow.request.headers.get_all("cookie") or []
         if not (set_cookies or req_cookies):
             return
+        client_ip = flow.client_conn.peername[0] if flow.client_conn.peername else None
+        # Names only, never values (privacy + CSPN)
+        sent_names: list[str] = []
+        for ch in req_cookies:
+            sent_names.extend(_parse_cookie_header(ch))
         payload = {
             "ts_ms": int(flow.timestamp_start * 1000),
-            "client_ip": flow.client_conn.peername[0] if flow.client_conn.peername else None,
-            "client_mac": mac_of(flow.client_conn.peername[0]) if flow.client_conn.peername else None,
-            "url": flow.request.pretty_url,
+            "client_ip": client_ip,
+            "client_mac_hash": mac_hash_of(client_ip),
+            "url": flow.request.pretty_url[:300],
             "method": flow.request.method,
-            "set_cookie": set_cookies,
-            "cookie": req_cookies,
+            "set_cookie_names": _names_only(set_cookies, cap=30),
+            "cookie_names": sent_names[:50],
+            "set_cookie_count": len(set_cookies),
+            "cookie_count": len(req_cookies),
             "status": flow.response.status_code,
         }
         queue_async(fire_forget_post(TARGET, payload))

--- a/packages/secubox-toolbox/mitmproxy_addons/dpi.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/dpi.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from mitmproxy import http
 
-from _common import fire_forget_post, mac_of, queue_async
+from _common import fire_forget_post, mac_hash_of, queue_async
 
 TARGET = "http+unix:///run/secubox/dpi.sock/classify"
 
@@ -18,7 +18,7 @@ class DPIRelay:
         payload = {
             "ts_ms": int(flow.timestamp_start * 1000),
             "client_ip": client_ip,
-            "client_mac": mac_of(client_ip) if client_ip else None,
+            "client_mac_hash": mac_hash_of(client_ip),
             "host": host,
             "scheme": flow.request.scheme,
             "method": flow.request.method,

--- a/packages/secubox-toolbox/mitmproxy_addons/ja4.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/ja4.py
@@ -8,9 +8,11 @@ Phase 2: compute JA4/JA4S server-side.
 """
 from __future__ import annotations
 
+import time
+
 from mitmproxy import tls
 
-from _common import fire_forget_post, mac_of, queue_async
+from _common import fire_forget_post, mac_hash_of, queue_async
 
 TARGET = "http+unix:///run/secubox/threat-analyst.sock/ja4"
 
@@ -20,8 +22,9 @@ class JA4Relay:
         ch = data.client_hello
         client_ip = data.context.client.peername[0] if data.context.client.peername else None
         payload = {
+            "ts_ms": int(time.time() * 1000),
             "client_ip": client_ip,
-            "client_mac": mac_of(client_ip) if client_ip else None,
+            "client_mac_hash": mac_hash_of(client_ip),
             "sni": ch.sni,
             "alpn_protocols": list(ch.alpn_protocols or []),
             "cipher_suites": list(ch.cipher_suites or []),

--- a/packages/secubox-toolbox/mitmproxy_addons/soc_relay.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/soc_relay.py
@@ -12,7 +12,7 @@ import re
 
 from mitmproxy import http
 
-from _common import fire_forget_post, mac_of, queue_async
+from _common import fire_forget_post, mac_hash_of, queue_async
 
 TARGET = "http+unix:///run/secubox/soc.sock/event"
 
@@ -42,7 +42,7 @@ class SOCRelay:
         payload = {
             "ts_ms": int(flow.timestamp_start * 1000),
             "client_ip": client_ip,
-            "client_mac": mac_of(client_ip) if client_ip else None,
+            "client_mac_hash": mac_hash_of(client_ip),
             "indicators": indicators,
             "source": "toolbox-mitm",
         }

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -415,7 +415,60 @@ def _aggregate_session(mac_hash: str) -> dict:
         "geo_top_hosts": _enrich_top_dpi_with_geo(top_dpi),
         "avatar_analysis": avatar_analysis.analyze_user_agents(user_agents),
         "cookies_providers": cookie_analysis.top_providers(cookies_urls, limit=10),
+        # ── Phase 2b (#488) : pull events from receiving modules ──
+        "mitm_modules": _pull_mitm_module_events(mac_hash),
     }
+
+
+# ── Phase 2b (#488) : cross-module mitm events pull ──
+
+_MITM_MODULES = [
+    ("dpi", "/run/secubox/dpi.sock"),
+    ("cookies", "/run/secubox/cookies.sock"),
+    ("avatar", "/run/secubox/avatar.sock"),
+    ("soc", "/run/secubox/soc.sock"),
+    ("threat-analyst", "/run/secubox/threat-analyst.sock"),
+]
+
+
+def _pull_mitm_module_events(mac_hash: str) -> dict:
+    """Query each receiving module's GET /mitm-events for this client.
+
+    Returns a dict {module: {count, sample_events}} for the report. Errors per
+    module are non-fatal — if a module is down, it just shows count=0.
+    """
+    import socket as _sock
+    import urllib.parse as _up
+    import http.client as _hc
+
+    out: dict[str, dict] = {}
+    for kind, sock_path in _MITM_MODULES:
+        try:
+            class UDSConnection(_hc.HTTPConnection):
+                def connect(self):
+                    self.sock = _sock.socket(_sock.AF_UNIX, _sock.SOCK_STREAM)
+                    self.sock.settimeout(self.timeout)
+                    self.sock.connect(sock_path)
+
+            conn = UDSConnection("localhost", timeout=2)
+            qs = _up.urlencode({"mac_hash": mac_hash, "limit": 20})
+            conn.request("GET", f"/mitm-events?{qs}")
+            resp = conn.getresponse()
+            if resp.status == 200:
+                import json as _json
+                data = _json.loads(resp.read().decode("utf-8", errors="ignore")[:50000])
+                out[kind] = {
+                    "count": data.get("count", 0),
+                    "sample": data.get("events", [])[:5],
+                }
+            else:
+                out[kind] = {"count": 0, "error": f"HTTP {resp.status}"}
+            conn.close()
+        except FileNotFoundError:
+            out[kind] = {"count": 0, "error": "socket-missing"}
+        except Exception as e:
+            out[kind] = {"count": 0, "error": str(e)[:60]}
+    return out
 
 
 def _enrich_with_geo(matches: list[dict]) -> list[dict]:


### PR DESCRIPTION
Closes #488

## Summary

After Phase 2a+ (#487 merged), the mitm addons (dpi/cookies/avatar/soc_relay/ja4) were firing fire-and-forget POSTs to UDS sockets that 404 silently — no cross-module data flow despite the wire being in place.

This PR delivers the **wire-up** end-to-end:

### Shared helper
- `common/secubox_core/mitm_ingest.py` : `mount_ingest_routes(app, endpoint_path, db_path, kind, enrich_hook=None)` — registers POST + GET /mitm-events + GET /mitm-events/stats. Dedicated SQLite per module with 48h retention.

### 5 modules wired (1-liner each)
- `secubox-dpi` : POST `/classify`
- `secubox-cookies` : POST `/inject`
- `secubox-avatar` : POST `/fingerprint`
- `secubox-soc` : POST `/event`
- `secubox-threat-analyst` : POST `/ja4`

### Mitm addons hardened
- `_common.py` gains `hash_mac()` + `mac_hash_of()` using shared salt — same HMAC-SHA256 + daily-rotation algorithm as `secubox_toolbox.mac.hash_mac` so all sources cross-reference the same `mac_hash`
- 5 addons send `client_mac_hash` instead of raw `client_mac` (privacy + CSPN)
- `cookies.py` extracts cookie NAMES only (Set-Cookie + Cookie headers, 32-char cap, 30/50 list caps) — values never persisted

### Aggregator
- `_pull_mitm_module_events(mac_hash)` GETs `/mitm-events?mac_hash=X&limit=20` from all 5 sockets via `http.client` UDSConnection
- Added to `_aggregate_session` as `mitm_modules` key — visible in `/report/me` JSON

## E2E test (gk2, 2026-06-05)

```
POST /classify     → secubox-dpi             200 OK
POST /inject       → secubox-cookies         200 OK
POST /fingerprint  → secubox-avatar          200 OK
POST /event        → secubox-soc             200 OK
POST /ja4          → secubox-threat-analyst  200 OK

_pull_mitm_module_events("deadbeefcafe1234") :
  dpi             : count=1 sample=[...]
  cookies         : count=1 sample=[...]
  avatar          : count=1 sample=[...]
  soc             : count=1 sample=[...]
  threat-analyst  : count=1 sample=[...]
```

Mitm addon load : clean after `__pycache__` clear (pyc cache had stale `_common.py` import signatures).

## Permissions

NO-OP — all 5 modules run `User=secubox` `UMask=0000` → sockets default to `srw-rw-rw-` (0666). `secubox-toolbox` user can read/write all 5 directly. No group/AppArmor changes needed.

## Out of scope (Phase 2c follow-up)

- Each receiving module implements its actual `enrich_hook` (nDPI lookup for dpi, JA4 hash computation for threat-analyst, etc.) — the `enrich_hook` param exists in `mount_ingest_routes` ready to be wired
- Aggregator merges receiving-module enrichment INTO the report display (top_dpi shows nDPI app names instead of host pattern matching from `dpi_class.py`)

## License

Strictement LicenseRef-CMSD-1.0.

## Test plan

- [ ] iPhone : VILLAGE3B → splash → accept → surf 5min → `http://village3b/report/me/html`
- [ ] Vérifier la section `mitm_modules` apparaît dans `/admin/clients/{mac_hash}/report` JSON
- [ ] Confirmer count > 0 sur les 5 modules après trafic réel
- [ ] Vérifier qu'aucune erreur n'apparait dans `journalctl -u secubox-{dpi,cookies,avatar,soc,threat-analyst} --since '5min ago'`