### PR TITLE
feat(phase-3): transparency layer (whitelist + analysis-status + security quality scoring)

### DIFF
--- a/common/secubox_core/classifiers/security_quality.py
+++ b/common/secubox_core/classifiers/security_quality.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""Security quality scorer (#492) : grade a destination on observable signals.
+
+Two modes :
+  - PASSIVE  : TLS version + JA4 + SNI presence + ALPN (no decryption needed)
+  - ACTIVE   : adds HTTPS headers (HSTS, CSP) + cookies attrs (Secure/HttpOnly/SameSite)
+
+Output : A+/A/B/C/D/F grade + per-criterion breakdown.
+
+Phase 4 will add live cert chain analysis + CT log lookup + HSTS preload check.
+"""
+from __future__ import annotations
+
+
+# Cipher categories — TLS 1.3 only uses AEAD ciphers (good). TLS 1.2 mix.
+_WEAK_CIPHERS = {
+    # CBC mode = vulnerable to padding oracle attacks
+    "RSA_WITH_AES_128_CBC", "RSA_WITH_AES_256_CBC",
+    "RSA_WITH_3DES_EDE_CBC",
+    # RC4 deprecated
+    "RSA_WITH_RC4_128",
+    # Export-grade — should never see in 2025+
+    "RSA_EXPORT",
+}
+
+
+def _grade_to_score(grade: str) -> int:
+    return {"A+": 100, "A": 90, "B": 75, "C": 60, "D": 40, "F": 0}.get(grade, 50)
+
+
+def _score_to_grade(score: int) -> str:
+    if score >= 95:
+        return "A+"
+    if score >= 85:
+        return "A"
+    if score >= 70:
+        return "B"
+    if score >= 55:
+        return "C"
+    if score >= 35:
+        return "D"
+    return "F"
+
+
+def grade_passive(
+    *,
+    tls_version: str | None = None,
+    alpn_protocols: list | None = None,
+    sni: str | None = None,
+    ja4_known_client: bool = False,
+    is_e2e_messaging: bool = False,
+) -> dict:
+    """Grade a flow we can only observe transport-side (whitelisted/pinned/E2E)."""
+    score = 50
+    reasons: list[dict] = []
+
+    # TLS version
+    if tls_version in ("13", "1.3", "TLSv1.3"):
+        score += 30
+        reasons.append({"+": 30, "why": "TLS 1.3 (modern AEAD ciphers, no downgrade)"})
+    elif tls_version in ("12", "1.2", "TLSv1.2"):
+        score += 15
+        reasons.append({"+": 15, "why": "TLS 1.2 (acceptable but legacy)"})
+    elif tls_version in ("11", "1.1", "TLSv1.1", "10", "1.0", "TLSv1.0"):
+        score -= 30
+        reasons.append({"-": 30, "why": "TLS legacy (deprecated, vulnerable)"})
+    elif tls_version is None:
+        score += 5
+        reasons.append({"~": 0, "why": "TLS version unknown (HTTP or pre-handshake)"})
+
+    # ALPN
+    if alpn_protocols:
+        if "h3" in alpn_protocols or "h3-29" in alpn_protocols:
+            score += 10
+            reasons.append({"+": 10, "why": "HTTP/3 (QUIC, modern transport)"})
+        elif "h2" in alpn_protocols:
+            score += 5
+            reasons.append({"+": 5, "why": "HTTP/2"})
+
+    # SNI present (encrypted SNI / ECH not yet detectable here)
+    if sni:
+        score += 5
+        reasons.append({"+": 5, "why": "SNI present (standard practice)"})
+
+    # JA4 known-good
+    if ja4_known_client:
+        score += 10
+        reasons.append({"+": 10, "why": "JA4 fingerprint matches known-good client"})
+
+    # E2E bonus (Signal/Threema/etc. — even though opaque, the design is strong)
+    if is_e2e_messaging:
+        score += 5
+        reasons.append({"+": 5, "why": "E2E messaging design (Signal protocol or similar)"})
+
+    score = max(0, min(100, score))
+    return {
+        "grade": _score_to_grade(score),
+        "score": score,
+        "mode": "passive",
+        "reasons": reasons,
+    }
+
+
+def grade_active(
+    *,
+    tls_version: str | None = None,
+    alpn_protocols: list | None = None,
+    sni: str | None = None,
+    headers: dict | None = None,
+    cookies_attrs: list[dict] | None = None,
+    mixed_content_detected: bool = False,
+) -> dict:
+    """Grade a flow we fully inspected via MITM."""
+    base = grade_passive(tls_version=tls_version, alpn_protocols=alpn_protocols, sni=sni)
+    score = base["score"]
+    reasons = list(base["reasons"])
+    headers = {k.lower(): v for k, v in (headers or {}).items()}
+
+    # HSTS
+    hsts = headers.get("strict-transport-security", "")
+    if hsts:
+        if "max-age=31536000" in hsts or "max-age=63072000" in hsts:
+            score += 10
+            reasons.append({"+": 10, "why": "HSTS strong (1y+)"})
+            if "preload" in hsts.lower():
+                score += 5
+                reasons.append({"+": 5, "why": "HSTS preload eligible"})
+        else:
+            score += 3
+            reasons.append({"+": 3, "why": "HSTS present but weak max-age"})
+    else:
+        score -= 10
+        reasons.append({"-": 10, "why": "HSTS missing (downgrade attack possible)"})
+
+    # CSP
+    csp = headers.get("content-security-policy", "")
+    if csp:
+        if "default-src 'none'" in csp or "default-src 'self'" in csp:
+            score += 8
+            reasons.append({"+": 8, "why": "CSP strict"})
+        elif "unsafe-inline" not in csp and "unsafe-eval" not in csp:
+            score += 4
+            reasons.append({"+": 4, "why": "CSP present (moderate)"})
+    else:
+        score -= 5
+        reasons.append({"-": 5, "why": "CSP missing"})
+
+    # X-Frame-Options / X-Content-Type-Options (basic hardening)
+    if "x-content-type-options" in headers:
+        score += 2
+        reasons.append({"+": 2, "why": "X-Content-Type-Options: nosniff"})
+
+    # Cookies
+    if cookies_attrs:
+        weak_cookies = 0
+        strong_cookies = 0
+        for c in cookies_attrs:
+            if c.get("secure") and c.get("httponly") and c.get("samesite") in ("strict", "lax"):
+                strong_cookies += 1
+            else:
+                weak_cookies += 1
+        if strong_cookies and not weak_cookies:
+            score += 5
+            reasons.append({"+": 5, "why": f"All {strong_cookies} cookies have Secure+HttpOnly+SameSite"})
+        elif weak_cookies:
+            score -= 5
+            reasons.append({"-": 5, "why": f"{weak_cookies} cookies missing Secure/HttpOnly/SameSite"})
+
+    # Mixed content = critical demerit
+    if mixed_content_detected:
+        score -= 20
+        reasons.append({"-": 20, "why": "Mixed HTTP+HTTPS content (man-in-the-middle window)"})
+
+    score = max(0, min(100, score))
+    return {
+        "grade": _score_to_grade(score),
+        "score": score,
+        "mode": "active",
+        "reasons": reasons,
+    }
+
+
+def aggregate_per_host(events: list[dict]) -> dict:
+    """Compute per-host quality aggregate from a list of mitm events.
+
+    Each event payload should optionally have :
+      - tls_version, alpn_protocols, sni (from JA4 / handshake)
+      - headers, set_cookie_attrs (from MITM-inspected response)
+      - analysis_status ('inspected' | 'bypassed-*' | 'pinned-*' | 'e2e-opaque')
+
+    Returns {host: {grade, score, mode, samples_count, last_seen_ms}}.
+    """
+    by_host: dict[str, dict] = {}
+    for ev in events:
+        payload = ev.get("payload") or ev
+        host = payload.get("host") or payload.get("sni") or "?"
+        if host == "?" or not host:
+            continue
+        if host in by_host:
+            by_host[host]["samples_count"] += 1
+            by_host[host]["last_seen_ms"] = max(
+                by_host[host]["last_seen_ms"], payload.get("ts_ms", 0)
+            )
+            continue
+        analysis_status = payload.get("analysis_status", "")
+        if analysis_status.startswith("bypassed") or analysis_status.startswith("pinned"):
+            g = grade_passive(
+                tls_version=payload.get("tls_version"),
+                alpn_protocols=payload.get("alpn_protocols"),
+                sni=payload.get("sni"),
+                ja4_known_client=bool(payload.get("ja4_known_client")),
+            )
+        elif analysis_status == "e2e-opaque":
+            g = grade_passive(
+                tls_version=payload.get("tls_version") or "13",
+                sni=payload.get("sni"),
+                is_e2e_messaging=True,
+            )
+        else:
+            g = grade_active(
+                tls_version=payload.get("tls_version"),
+                alpn_protocols=payload.get("alpn_protocols"),
+                sni=payload.get("sni"),
+                headers=payload.get("response_headers"),
+                cookies_attrs=payload.get("set_cookie_attrs"),
+                mixed_content_detected=bool(payload.get("mixed_content")),
+            )
+        by_host[host] = {
+            **g,
+            "host": host,
+            "samples_count": 1,
+            "last_seen_ms": payload.get("ts_ms", 0),
+            "analysis_status": analysis_status or "inspected",
+        }
+    return by_host

--- a/common/secubox_core/rule_engine.py
+++ b/common/secubox_core/rule_engine.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""ToolBoX rule engine (#492) : generative whitelist + dynamic filtering sensitivity.
+
+Replaces the static whitelist.py with a 3-layer system :
+
+  1. STATIC rules   : operator-edited YAML patterns (whitelist-baseline.yaml
+                      + /etc/secubox/toolbox/whitelist.yaml)
+  2. GENERATIVE     : auto-learned rules at runtime :
+                      - persistent cert-pinning failures -> auto-whitelist
+                      - HSTS preload list match -> trust
+                      - high-reputation ASN + valid CT log -> soft trust
+  3. SENSITIVITY    : filtering profile that gates active blocking decisions :
+                      low / medium / high / paranoid
+
+Stored in :
+  /etc/secubox/toolbox/rule-engine.yaml          : sensitivity profile + custom rules
+  /var/lib/secubox/toolbox/learned-rules.json    : runtime-learned trust list
+
+The engine exposes :
+  evaluate(host, context) -> {action, reason, source}
+    action  = "trust" | "trust-warn" | "inspect" | "block"
+    source  = "static" | "generative" | "default"
+
+Used by :
+  - mitmproxy addons before deciding to MITM
+  - local_store.py to tag analysis_status
+  - aggregator to produce the inspection breakdown
+"""
+from __future__ import annotations
+
+import fnmatch
+import json
+import logging
+import re
+import time
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger("secubox.rule_engine")
+
+# Configurable paths
+BASELINE_PATH = Path("/usr/share/secubox/toolbox/whitelist-baseline.yaml")
+OVERRIDE_PATH = Path("/etc/secubox/toolbox/whitelist.yaml")
+RULES_PATH = Path("/etc/secubox/toolbox/rule-engine.yaml")
+LEARNED_PATH = Path("/var/lib/secubox/toolbox/learned-rules.json")
+
+# Cache
+_CACHE: dict | None = None
+_CACHE_MTIME: float = 0.0
+_LEARNED_CACHE: dict | None = None
+_LEARNED_CACHE_MTIME: float = 0.0
+
+
+# ────────── Sensitivity profiles ──────────
+
+SENSITIVITY_PROFILES = {
+    "low": {
+        "label": "🟢 Permissif",
+        "description": "Bloque seulement le malware confirmé. Aucun faux positif.",
+        "threat_intel_action": "block",     # block iff match in feeds
+        "dga_score_min": 90,                # block iff DGA confidence ≥ 90
+        "beaconing_score_min": 100,         # never block on beacon alone
+        "block_unknown": False,
+    },
+    "medium": {
+        "label": "🟡 Équilibré (défaut)",
+        "description": "Bloque malware + DGA fort + beaconing évident.",
+        "threat_intel_action": "block",
+        "dga_score_min": 70,
+        "beaconing_score_min": 75,
+        "block_unknown": False,
+    },
+    "high": {
+        "label": "🟠 Strict",
+        "description": "Bloque malware + DGA + beaconing + ASN faible réputation.",
+        "threat_intel_action": "block",
+        "dga_score_min": 50,
+        "beaconing_score_min": 50,
+        "block_unknown": False,
+        "block_low_reputation_asn": True,
+    },
+    "paranoid": {
+        "label": "🔴 Paranoïaque",
+        "description": "Bloque TOUT sauf si whitelisté (static OU généré).",
+        "threat_intel_action": "block",
+        "dga_score_min": 30,
+        "beaconing_score_min": 30,
+        "block_unknown": True,                # default-deny
+    },
+}
+
+
+# ────────── Generative rules ──────────
+
+# Predicate functions for generative rules. Each takes (host, context) and
+# returns True if the rule matches.
+
+def _is_french_gov(host: str, ctx: dict) -> bool:
+    """*.gouv.fr or *.service-public.fr : French gov, never MITM."""
+    return host.endswith(".gouv.fr") or host == "service-public.fr"
+
+
+def _is_french_health(host: str, ctx: dict) -> bool:
+    """*.fr health domains (CNAM/CPAM/ANS)."""
+    return any(host.endswith(s) for s in (
+        ".ameli.fr", ".cnam.fr", ".cpam.fr", ".ars.sante.fr",
+        ".dossier-medical.fr", ".sesam-vitale.fr",
+    ))
+
+
+def _is_persistent_pinning(host: str, ctx: dict) -> bool:
+    """Auto-learn : if we observed ≥3 cert-pinning failures, assume legit."""
+    pinning_count = ctx.get("pinning_history", {}).get(host, 0)
+    return pinning_count >= 3
+
+
+def _is_high_reputation_asn(host: str, ctx: dict) -> bool:
+    """ASN is in our high-reputation set (Cloudflare, Akamai, Google, etc.)."""
+    high_rep_asns = {
+        13335,  # Cloudflare
+        16509,  # Amazon
+        15169,  # Google
+        20940,  # Akamai
+        32934,  # Facebook
+        2906,   # Netflix
+        46489,  # Twitch
+        13414,  # Twitter
+        714,    # Apple
+        16276,  # OVH
+    }
+    asn = ctx.get("asn")
+    return asn in high_rep_asns if asn else False
+
+
+GENERATIVE_RULES = [
+    {
+        "name": "gov-fr",
+        "predicate": _is_french_gov,
+        "action": "trust",
+        "reason": "French gov ccTLD (*.gouv.fr / service-public.fr)",
+        "category": "government-auto",
+    },
+    {
+        "name": "health-fr",
+        "predicate": _is_french_health,
+        "action": "trust",
+        "reason": "French healthcare infrastructure",
+        "category": "health-auto",
+    },
+    {
+        "name": "persistent-pinning",
+        "predicate": _is_persistent_pinning,
+        "action": "trust-warn",
+        "reason": "Cert-pinning observed ≥3 times — auto-learned trust",
+        "category": "learned-cert-pinned",
+    },
+    {
+        "name": "high-rep-asn",
+        "predicate": _is_high_reputation_asn,
+        "action": "trust-warn",
+        "reason": "Hosted by high-reputation infrastructure provider",
+        "category": "infrastructure-auto",
+    },
+]
+
+
+# ────────── Static rules (YAML) ──────────
+
+def _load_yaml(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    try:
+        import yaml as _yaml
+    except ImportError:
+        log.warning("PyYAML unavailable")
+        return []
+    try:
+        data = _yaml.safe_load(path.read_text()) or {}
+        return data.get("whitelist", []) or []
+    except Exception as e:
+        log.warning("yaml load failed (%s): %s", path, e)
+        return []
+
+
+def _load_engine_config() -> dict:
+    """Load /etc/secubox/toolbox/rule-engine.yaml — sensitivity + custom rules."""
+    if not RULES_PATH.exists():
+        return {"sensitivity": "medium"}
+    try:
+        import yaml as _yaml
+        return _yaml.safe_load(RULES_PATH.read_text()) or {"sensitivity": "medium"}
+    except Exception as e:
+        log.warning("rule-engine config load failed: %s", e)
+        return {"sensitivity": "medium"}
+
+
+def _load_learned() -> dict:
+    """Load runtime-learned rules from disk."""
+    global _LEARNED_CACHE, _LEARNED_CACHE_MTIME
+    if not LEARNED_PATH.exists():
+        return {"hosts": {}, "pinning_history": {}}
+    try:
+        m = LEARNED_PATH.stat().st_mtime
+        if _LEARNED_CACHE is not None and m <= _LEARNED_CACHE_MTIME:
+            return _LEARNED_CACHE
+        _LEARNED_CACHE = json.loads(LEARNED_PATH.read_text())
+        _LEARNED_CACHE_MTIME = m
+        return _LEARNED_CACHE
+    except Exception as e:
+        log.warning("learned rules load failed: %s", e)
+        return {"hosts": {}, "pinning_history": {}}
+
+
+def record_pinning_failure(host: str) -> int:
+    """Auto-learn : called by mitm addons when a cert-pinning failure is detected.
+
+    Increments the host's pinning counter. Once ≥3, the host gets generatively
+    whitelisted on the next evaluate() call.
+    Returns the new count.
+    """
+    learned = _load_learned()
+    learned.setdefault("pinning_history", {})
+    learned["pinning_history"][host] = learned["pinning_history"].get(host, 0) + 1
+    learned.setdefault("hosts", {})[host] = {
+        "last_seen": int(time.time()),
+        "source": "auto-pinning-detected",
+    }
+    try:
+        LEARNED_PATH.parent.mkdir(parents=True, exist_ok=True)
+        LEARNED_PATH.write_text(json.dumps(learned, indent=2)[:200000])
+        # Bust the cache
+        global _LEARNED_CACHE_MTIME
+        _LEARNED_CACHE_MTIME = 0.0
+    except Exception as e:
+        log.warning("learned rules persist failed: %s", e)
+    return learned["pinning_history"][host]
+
+
+def _refresh_static_cache() -> dict:
+    """Reload static whitelist YAML if mtime changed."""
+    global _CACHE, _CACHE_MTIME
+    mtime = 0.0
+    for p in (BASELINE_PATH, OVERRIDE_PATH, RULES_PATH):
+        if p.exists():
+            mtime = max(mtime, p.stat().st_mtime)
+    if _CACHE is not None and mtime <= _CACHE_MTIME:
+        return _CACHE
+    entries = _load_yaml(BASELINE_PATH) + _load_yaml(OVERRIDE_PATH)
+    # Also load custom rules from engine config
+    cfg = _load_engine_config()
+    for e in cfg.get("static_rules") or []:
+        entries.append(e)
+    compiled: dict[str, dict] = {}
+    for e in entries:
+        p = e.get("pattern", "").lower().strip()
+        if p:
+            compiled[p] = e
+    _CACHE = {
+        "entries": compiled,
+        "count": len(compiled),
+        "sensitivity": (cfg.get("sensitivity") or "medium").lower(),
+    }
+    _CACHE_MTIME = mtime
+    log.info("rule-engine reloaded : %d static rules, sensitivity=%s",
+             len(compiled), _CACHE["sensitivity"])
+    return _CACHE
+
+
+# ────────── Public API ──────────
+
+def evaluate(host: str, context: Optional[dict] = None) -> dict:
+    """Decide what to do with a host. Order :
+      1. Static whitelist match -> trust
+      2. Generative rule match -> trust / trust-warn
+      3. Default -> inspect
+
+    Returns {action, reason, source, category}.
+    """
+    if not host:
+        return {"action": "inspect", "reason": "no host", "source": "default", "category": None}
+    h = host.lower().strip()
+    ctx = context or {}
+
+    # 1. Static rules
+    cache = _refresh_static_cache()
+    for pattern, entry in cache["entries"].items():
+        if fnmatch.fnmatch(h, pattern):
+            return {
+                "action": "trust",
+                "reason": entry.get("reason", "whitelisted"),
+                "source": "static",
+                "category": entry.get("category"),
+                "quality_expected": entry.get("quality_expected", "?"),
+            }
+
+    # 2. Generative rules — inject pinning history from learned store
+    learned = _load_learned()
+    enriched_ctx = {**ctx, "pinning_history": learned.get("pinning_history", {})}
+    for rule in GENERATIVE_RULES:
+        try:
+            if rule["predicate"](h, enriched_ctx):
+                return {
+                    "action": rule["action"],
+                    "reason": rule["reason"],
+                    "source": "generative",
+                    "category": rule["category"],
+                    "rule_name": rule["name"],
+                }
+        except Exception as e:
+            log.debug("generative rule %s eval failed: %s", rule["name"], e)
+
+    # 3. Default : inspect
+    return {"action": "inspect", "reason": "no rule matched", "source": "default", "category": None}
+
+
+def get_sensitivity() -> dict:
+    """Returns the active sensitivity profile dict (label/description/thresholds)."""
+    cache = _refresh_static_cache()
+    profile_name = cache.get("sensitivity", "medium")
+    return {
+        "name": profile_name,
+        **SENSITIVITY_PROFILES.get(profile_name, SENSITIVITY_PROFILES["medium"]),
+    }
+
+
+def should_block(*, threat_intel_matches: int = 0, dga_score: int = 0,
+                 beaconing_score: int = 0, asn_reputation: str | None = None,
+                 is_whitelisted: bool = False) -> tuple[bool, str]:
+    """Given signal values + active sensitivity, decide whether to block.
+
+    Returns (block_decision, reason).
+    """
+    profile = get_sensitivity()
+    if is_whitelisted:
+        return False, "whitelisted (rule_engine)"
+    if profile.get("threat_intel_action") == "block" and threat_intel_matches > 0:
+        return True, f"threat-intel match (sensitivity={profile['name']})"
+    if dga_score >= profile.get("dga_score_min", 999):
+        return True, f"DGA score {dga_score} ≥ threshold {profile['dga_score_min']}"
+    if beaconing_score >= profile.get("beaconing_score_min", 999):
+        return True, f"beaconing score {beaconing_score} ≥ threshold {profile['beaconing_score_min']}"
+    if profile.get("block_low_reputation_asn") and asn_reputation in ("D", "F"):
+        return True, f"low-reputation ASN ({asn_reputation})"
+    if profile.get("block_unknown"):
+        return True, "paranoid mode : default-deny"
+    return False, "no rule matched"
+
+
+def stats() -> dict:
+    """Returns engine stats : static rule count + sensitivity + learned count."""
+    cache = _refresh_static_cache()
+    learned = _load_learned()
+    return {
+        "static_rules": cache["count"],
+        "sensitivity": cache.get("sensitivity", "medium"),
+        "sensitivity_profile": get_sensitivity(),
+        "generative_rules": len(GENERATIVE_RULES),
+        "learned_hosts": len(learned.get("hosts", {})),
+        "learned_pinning_count": sum(learned.get("pinning_history", {}).values()),
+        "baseline_loaded": BASELINE_PATH.exists(),
+        "override_loaded": OVERRIDE_PATH.exists(),
+        "engine_config_loaded": RULES_PATH.exists(),
+    }
+
+
+# Backward-compatibility shim for callers still using whitelist.match/is_whitelisted
+def match(host: str) -> dict | None:
+    """Returns the matching rule dict for compat with whitelist.py. None if no
+    trust decision."""
+    result = evaluate(host)
+    if result["action"] in ("trust", "trust-warn"):
+        return {
+            "pattern": host,
+            "reason": result["reason"],
+            "category": result.get("category"),
+            "quality_expected": result.get("quality_expected", "?"),
+            "source": result["source"],
+        }
+    return None
+
+
+def is_whitelisted(host: str) -> bool:
+    return match(host) is not None

--- a/common/secubox_core/whitelist.py
+++ b/common/secubox_core/whitelist.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""ToolBoX whitelist (#492) : map host/SNI -> bypass-reason + category.
+
+YAML format (operator can override at /etc/secubox/toolbox/whitelist.yaml) :
+
+    whitelist:
+      - pattern: "*.push.apple.com"
+        reason: cert-pinning, no MITM possible
+        category: vendor-os
+        quality_expected: A+
+      - pattern: "signal.org"
+        reason: E2E messenger, transport-only observation
+        category: messaging-e2e
+        quality_expected: A+
+
+Patterns are fnmatch-style globs (Unix shell). Phase 4 will add regex/ASN/JA4 match.
+"""
+from __future__ import annotations
+
+import fnmatch
+import logging
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger("secubox.whitelist")
+
+BASELINE_PATH = Path("/usr/share/secubox/toolbox/whitelist-baseline.yaml")
+OVERRIDE_PATH = Path("/etc/secubox/toolbox/whitelist.yaml")
+
+_CACHE: dict | None = None
+_CACHE_MTIME: float = 0.0
+
+
+def _load_yaml(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    try:
+        import yaml as _yaml
+    except ImportError:
+        log.warning("PyYAML unavailable, whitelist disabled")
+        return []
+    try:
+        data = _yaml.safe_load(path.read_text()) or {}
+        return data.get("whitelist", []) or []
+    except Exception as e:
+        log.warning("whitelist load failed (%s): %s", path, e)
+        return []
+
+
+def _refresh_cache() -> dict:
+    """Hot-reload : combine baseline + override, re-read if either mtime changed."""
+    global _CACHE, _CACHE_MTIME
+    mtime = 0.0
+    for p in (BASELINE_PATH, OVERRIDE_PATH):
+        if p.exists():
+            mtime = max(mtime, p.stat().st_mtime)
+    if _CACHE is not None and mtime <= _CACHE_MTIME:
+        return _CACHE
+    entries = _load_yaml(BASELINE_PATH) + _load_yaml(OVERRIDE_PATH)
+    # Compile : map pattern -> entry. Override wins on dup (last in list).
+    compiled: dict[str, dict] = {}
+    for e in entries:
+        p = e.get("pattern", "").lower().strip()
+        if p:
+            compiled[p] = e
+    _CACHE = {"entries": compiled, "count": len(compiled)}
+    _CACHE_MTIME = mtime
+    log.info("whitelist reloaded : %d entries", len(compiled))
+    return _CACHE
+
+
+def match(host: str) -> Optional[dict]:
+    """Return the matching whitelist entry for a host, or None."""
+    if not host:
+        return None
+    h = host.lower().strip()
+    cache = _refresh_cache()
+    for pattern, entry in cache["entries"].items():
+        if fnmatch.fnmatch(h, pattern):
+            return entry
+    return None
+
+
+def is_whitelisted(host: str) -> bool:
+    return match(host) is not None
+
+
+def stats() -> dict:
+    """Returns {count, baseline_loaded, override_loaded}."""
+    cache = _refresh_cache()
+    return {
+        "count": cache["count"],
+        "baseline_loaded": BASELINE_PATH.exists(),
+        "override_loaded": OVERRIDE_PATH.exists(),
+    }

--- a/docs/AI-HANDOVER-cabine-evolution.md
+++ b/docs/AI-HANDOVER-cabine-evolution.md
@@ -1,0 +1,257 @@
+# Cabine Numérique VILLAGE3B — Brief technique pour LLM externe (GPT-5 / Gemini 2.x / Claude)
+
+> Self-contained prompt destiné à un autre assistant pour comprendre l'état + contribuer à l'évolution de la cabine SecuBox-Deb / Gondwana ToolBoX sans contexte préalable.
+
+---
+
+## 1. Mission produit
+
+**Cabine numérique VILLAGE3B** = AP WiFi captif sur MochaBin (Marvell Armada 7040 ARM64) qui propose à un utilisateur grand public :
+
+- Connexion réseau libre (R0)
+- Analyse passive de session (R1) avec rapport PDF + HTML
+- Inspection TLS-break opt-in éclairé (R2) avec bandeau injecté sur chaque page Safari
+- (Roadmap) Mode WireGuard portable (R3) qui marche hors-WiFi cabine
+
+Cible : CSPN ANSSI, déploiements collectivités, candidature France.gouv (ANCT, Beta.gouv, ANSSI, France2030, CNIL).
+
+**Licence** : LicenseRef-CMSD-1.0 (Source-Disclosed License — code ouvert pour audit citoyen, droits d'usage régis par licence CyberMind). **PAS** AGPL/Apache.
+
+---
+
+## 2. Stack technique
+
+| Couche | Choix | Notes |
+|--------|-------|-------|
+| OS | Debian 12 bookworm arm64 | MochaBin Armada 7040 |
+| Captive AP | hostapd open SSID `VILLAGE3B`, dnsmasq | wlxa854b2428fbb iface |
+| Transparent proxy | mitmproxy 8.1.1 transparent (HOST) | sur 10.99.0.1:8080 |
+| WAF mitm | mitmproxy 11.0.2 (LXC container `mitmproxy`) | sur 10.100.0.60:8080 — séparé |
+| FastAPI portal | uvicorn 10.99.0.1:8088 unix socket | secubox-toolbox.service |
+| nftables | table `inet toolbox` | sets validated_macs / consented_r2_macs / r2_banner_macs |
+| Storage | SQLite `/var/lib/secubox/toolbox/toolbox.db` | clients + events + reports |
+| PDF | fpdf2 + DejaVu + Symbola + NotoColorEmoji | drapeaux + emoji rendering OK |
+| Rule engine | `secubox_core.rule_engine` | static YAML + generative predicates + sensitivity profiles low/medium/high/paranoid |
+
+---
+
+## 3. Architecture mitm — 2 instances DISJOINTES
+
+```
+HOST gk2 (192.168.1.200)
+├─ ToolBox transparent mitm (PHASE 3 actuel)
+│   - mitmproxy 8.1.1 natif process
+│   - listen 10.99.0.1:8080 captive subnet
+│   - addons : dpi, cookies, avatar, soc_relay, ja4, inject_banner, local_store
+│   - CA : /etc/secubox/toolbox/ca/
+│
+├─ HAProxy frontal :443 + :80
+│   - termine TLS pour vhosts externes
+│   - route vers backend mitmproxy_inspector (LXC)
+│
+└─ LXC container "mitmproxy" (10.100.0.60)
+    - WAF mitm (mitmproxy 11.0.2)
+    - listen :8080
+    - addons : secubox_waf.py + cookie_audit.py
+    - inspecte vhosts externes (chess.maegia.tv, etc.)
+```
+
+**Règle d'or** : les 2 mitm ne se touchent PAS, certs séparés, addons séparés, IPs séparées.
+
+---
+
+## 4. Niveaux d'opt-in R0/R1/R2 (Phase 3 #492 — MERGED PR #493)
+
+| Niveau | nft sets | mitm | Banner inject | Cert installé requis |
+|--------|----------|------|---------------|----------------------|
+| R0 — Bypass complet | validated_macs | NON | NON | NON |
+| R1 — Analyse passive (défaut recommandé) | validated_macs + consented_r2_macs | OUI | NON | OUI sinon HTTPS fail |
+| R2 — Analyse + bandeau Safari | + r2_banner_macs | OUI | OUI (TCP only) | OUI sinon HTTPS fail |
+| R3 — WireGuard (#496 ROADMAP) | TBD | OUI (mode wireguard) | OUI (incl QUIC) | OUI (bundled WG profile) |
+
+**QUIC drop rule retirée** (commit a9db3144) car cassait surf iPhone en R2. Bandeau apparaît seulement sur TCP HTTPS HTML — limitation acceptée.
+
+---
+
+## 5. Phases roadmap
+
+```
+PHASE 1 (#475)   PoC captive + splash + accept
+PHASE 1.5 (#477) MITM transparency banner + reports + WebUI metrics
+PHASE 2 (#485)   SOC scoring multi-signal (threat-intel + DGA + beaconing)
+PHASE 2a+ (#486) geo flags + nDPI-style + cookies providers + avatar
+PHASE 2b (#488)  wire mitm addons -> 5 receiving modules
+PHASE 2c (#490)  receiving modules actual enrichment
+PHASE 3 (#492)   Transparency layer : whitelist + analysis-status + quality + R0/R1/R2 opt-in
+                 -> PR #493 ready pour merge
+PHASE 4 (TBD)    Active blocking via rule_engine.should_block() — mitm addon flow.kill()
+                 -> sensitivity profiles low/medium/high/paranoid
+PHASE 5 (#495)   ToolBox mitm dans LXC dédié (séparation host-native)
+                 -> Foundation pour Phase 6
+PHASE 6 (#496)   WireGuard + autocert + mitm R3 mode
+                 -> mitmproxy --mode wireguard sur UDP 51820
+                 -> Endpoint cabine : kbin.gk2.net:51820
+                 -> Profile WG bundled avec CA root, install via QR code
+                 -> Marche hors VILLAGE3B WiFi (4G/5G/autre WiFi)
+PHASE 7 (TBD)    Admin WebUI per-client level switch + config default_level + auto-mode
+PHASE 8 (TBD)    Multi-cabine cluster + WG mesh
+```
+
+---
+
+## 6. Endpoints API (Phase 3 actuel)
+
+```
+GET  /                                 splash (always rendered, Cache-Control no-store)
+POST /accept                            level=r0/r1/r2 → 303 → dashboard
+POST /change-level                      level=r0/r1/r2 → 303 → dashboard?switched=1
+GET  /status                            JSON ip + mac_hash + validated + r2_consented
+GET  /ca/mobileconfig                   iOS profile CA install
+GET  /ca/android.crt                    .crt download Android/PC
+GET  /ca/install-help                   HTML guide
+GET  /ca/fingerprint                    JSON sha1 + sha256 + subject
+GET  /ca/webclip-cabine.mobileconfig    iOS WebClip add-to-home-screen
+GET  /client-status                     anonymous client status
+GET  /report/me/html                    live dashboard (auto-refresh 15s)
+GET  /report/me                         PDF download (mac IP→ARP)
+GET  /report/{token}                    PDF via HMAC ephemeral token
+GET  /admin/config                      admin
+GET  /admin/clients                     admin
+GET  /admin/metrics                     admin
+GET  /admin/clients/{mh}/report         admin per-client report
+GET  /admin/clients/{mh}/events         admin per-client events
+GET  /health                            liveness probe
+```
+
+**Phase 6 (#496) ajoutera** :
+```
+POST /accept                            level=r3 → returns WG .conf + .mobileconfig + QR data URI
+GET  /wg/profile/new                    generates new client WG profile + CA bundle
+GET  /wg/profile/{token}                ephemeral profile retrieval
+GET  /wg/qr.png                         QR code PNG
+GET  /wg/status                         WG peer + handshake state
+```
+
+---
+
+## 7. Rule engine — sensitivity profiles (Phase 3 #492)
+
+`/etc/secubox/toolbox/rule-engine.yaml` :
+
+```yaml
+sensitivity: low | medium | high | paranoid
+
+# Operator can append static rules :
+static_rules:
+  - pattern: "*.example.com"
+    reason: "whitelisted by operator"
+    category: custom
+```
+
+| Profile | Threat-intel | DGA score | Beaconing score | Block unknown |
+|---------|--------------|-----------|-----------------|---------------|
+| 🟢 low | block | ≥90 | never | NO |
+| 🟡 medium (défaut) | block | ≥70 | ≥75 | NO |
+| 🟠 high | block | ≥50 | ≥50 | NO (+ low-rep ASN block) |
+| 🔴 paranoid | block | ≥30 | ≥30 | YES (default-deny) |
+
+Phase 4 wirera `should_block()` dans un mitm addon `block_known_bad.py` qui appelle `flow.kill()`.
+
+---
+
+## 8. Drapeaux + emojis (PDF + HTML)
+
+PDF embeds 5 fonts :
+- DejaVuSans Book/Bold/Oblique : texte + Unicode basique
+- Symbola : monochrome emoji (📱📡🔍🔒🎯🎵🐙📊🍪)
+- NotoColorEmoji : color bitmap, flags 🇫🇷🇺🇸🇩🇪 + recent emoji
+
+HTML utilise NCR entities `&#x1F50D;` etc. dans les banners injectés pour bypass tout charset issue.
+
+---
+
+## 9. Composants à installer côté iPhone (Splash quick-up menu)
+
+```
+🔐 Certificat iPhone     → /ca/mobileconfig (.mobileconfig)
+🤖 Certificat Android/PC → /ca/android.crt (.crt)
+📱 Icône Home iPhone     → /ca/webclip-cabine.mobileconfig (WebClip)
+📜 Guide pas-à-pas       → /ca/install-help
+🧪 Test certificat       → JS probe https://example.com/favicon.ico
+```
+
+**Phase 6 ajoutera** :
+```
+🌐 Profile WireGuard     → /wg/profile/new (.conf + bundled CA)
+📷 QR code WG            → modal scan
+```
+
+---
+
+## 10. Dette technique connue (à NE PAS confondre avec features)
+
+| Issue | Description | Plan |
+|-------|-------------|------|
+| #494 | secubox-core.service ExecStart écrase tmpfiles.d → /run/secubox perms drift | Worktree existant, à finir |
+| #494 bis | /var/log/suricata missing → secubox-threats 226/NAMESPACE crash loop | Inclus dans #494 |
+| WAF chess.maegia.tv | LXC mitm intermittent, 504 + ACME challenge fail | Hors scope ToolBox |
+| acme-monitor.sh | Bashisme [[ ]] mais script sh — FIXED live, source non-tracké | NA |
+| 5 certs expirés gk2 | arm/armada/chat/endlesslapse → wildcard fallback FIXED, diyegg.maegia.tv encore expiré (ACME fail) | Need WAF stable d'abord |
+| /etc/secubox/secrets perms | Drift bloquait salt access → banner inject KO en R2 — FIXED live via chmod 0750 + chown | Postinst gère déjà |
+
+---
+
+## 11. Comment contribuer (LLM external)
+
+Si tu lis ce brief et veux contribuer, voici les bonnes pratiques :
+
+1. **Worktree obligatoire** pour tout fix > 30min ou > 3 fichiers :
+   ```bash
+   bash scripts/agent-worktree.sh start --issue <NN>
+   cd /home/reepost/CyberMindStudio/secubox-deb-worktrees/<NN>-...
+   ```
+
+2. **Pas de master commit direct**. PR → user valide → user merge.
+
+3. **Licence header obligatoire** sur tout nouveau fichier Python/Bash :
+   ```python
+   # SPDX-License-Identifier: LicenseRef-CMSD-1.0
+   # Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+   ```
+
+4. **Pas de référence** "Claude Code", "Anthropic", "OpenAI" dans les commits/PRs (global ref CyberMind suffit).
+
+5. **Tests E2E réels sur board** gk2 (192.168.1.200) via SSH key. Pas de mock-only.
+
+6. **Honesty over magic** — si une analyse est partielle (cert-pinning, QUIC), le rapport DOIT le dire (transparency layer).
+
+7. **Conformité ANSSI CSPN** :
+   - JWT auth obligatoire sur tous endpoints (sauf splash/accept/health)
+   - Hash anonyme MAC quotidien rotatif (jamais MAC en clair sauf in-memory mitm)
+   - Logs audit immuables `/var/log/secubox/audit.log`
+   - AppArmor enforce par service
+   - HAProxy TLS 1.3 frontal pour exposition externe
+
+---
+
+## 12. Status au 2026-06-05
+
+- **Phase 3 (#492) PR #493 ready pour merge** : R0/R1/R2 + transparency + cert auto-check + filtering visibility + level switcher + hero widgets PDF/HTML + 4 quick install buttons + 108-pattern whitelist + sensitivity profiles + rule engine generative + jinja syntax fixes + R2 QUIC drop removal + 5 commits this week
+- **Phase 5 (#495) issue ouverte + worktree créé** : ToolBox mitm en LXC dédié
+- **Phase 6 (#496) issue ouverte + worktree créé** : WireGuard + autocert + R3 mode sur kbin.gk2.net:51820
+
+User direction Jun 5 : "go genial" + "prompt technique de rapport pour gpt et gemini" + "belle evolution".
+
+---
+
+## 13. Contact
+
+Gérald Kerma (Gandalf) — CyberMind
+devel@cybermind.fr
+Notre-Dame-du-Cruet, Savoie, FR
+https://cybermind.fr · https://secubox.in
+GitHub : https://github.com/CyberMind-FR/secubox-deb
+
+---
+
+**Fin du brief.** Tu peux maintenant lire ce document à vide et contribuer en cohérence avec l'écosystème.

--- a/docs/marketing/POSTER-grand-public-village3b.md
+++ b/docs/marketing/POSTER-grand-public-village3b.md
@@ -1,0 +1,173 @@
+# Poster grand public — Cabine Numérique VILLAGE3B 📡
+
+> Format : A2 portrait, lisible à 1m de distance. Police monospace style P31 phosphor green (#00ff55) sur fond noir cosmos (#0a0a0f). Accents Gold Hermétique (#c9a84c) pour éléments clés.
+
+---
+
+## 🎯 ZONE 1 — Titre principal (1/4 supérieur)
+
+```
+        📡 VILLAGE3B
+   CABINE NUMÉRIQUE GONDWANA
+
+   Diagnostic compromission iPhone
+   Anonyme · Gratuit · Open Source
+   ✓ Pas de pub · ✓ Pas de revente
+```
+
+---
+
+## 🎯 ZONE 2 — 3 niveaux d'opt-in (1/4 milieu-haut)
+
+```
+   👇 CHOISIS TON NIVEAU D'ANALYSE
+
+   ╔════════════════════════════════╗
+   ║  🌐 R0 — Bypass complet         ║
+   ║    Réseau seul, ZÉRO analyse    ║
+   ║    (comme un AP WiFi normal)    ║
+   ╚════════════════════════════════╝
+
+   ╔════════════════════════════════╗
+   ║  🛡 R1 — Analyse passive        ║
+   ║    ✓ DÉFAUT RECOMMANDÉ          ║
+   ║    Rapport sur ta session,      ║
+   ║    aucun impact sur le surf     ║
+   ╚════════════════════════════════╝
+
+   ╔════════════════════════════════╗
+   ║  🔍 R2 — Analyse + bandeau      ║
+   ║    Déchiffrement TLS opt-in     ║
+   ║    (installer notre CA d'abord) ║
+   ╚════════════════════════════════╝
+```
+
+---
+
+## 🎯 ZONE 3 — Ce que tu vas voir dans ton rapport (1/4 milieu-bas)
+
+```
+   📊 TON RAPPORT INCLURA :
+
+   🌐 N connexions HTTPS observées
+   📡 N hôtes uniques contactés
+   ✅ N requêtes 2xx réussies
+   🔒 N cert-pinning détectés (= bon signe)
+
+   📺 Apps détectées (YouTube, Signal, GitHub, iCloud...)
+   🍪 Trackers identifiés (Google Analytics, Facebook Pixel...)
+   🌍 Pays contactés (drapeaux + ASN)
+   🎯 Score de risque (🟢/🟡/🔴 0-100)
+   📱 Empreinte device (iPhone iOS X.X + Safari version)
+
+   🔎 INSPECTION TRANSPARENTE :
+   🔍 X% Inspecté (HTTPS via notre CA)
+   🛡 X% Bypassé whitelist (Apple/banque/Signal)
+   🔒 X% Cert-pinning (app refuse notre CA = normal)
+   🔐 X% E2E messaging (Signal/iMessage opaques)
+
+   📜 108 patterns whitelist actifs (Apple, banques FR,
+   gov.fr, santé, streaming, gaming, workplace...)
+```
+
+---
+
+## 🎯 ZONE 4 — Confidentialité / Conformité (1/8)
+
+```
+   🛡 CONFORMITÉ CSPN ANSSI + LCEN
+
+   ✓ Consentement explicite par appareil (R0/R1/R2)
+   ✓ Hash anonyme MAC quotidien rotatif
+   ✓ Données effacées après 24h
+   ✓ Rapport téléchargeable PDF
+   ✓ Aucun envoi externe (analyse 100% locale)
+   ✓ Open Source CMSD-1.0 (audit citoyen)
+
+   ⚠ La cabine N'INTERCEPTE PAS les tiers :
+       analyse uniquement ton trafic, avec ton accord.
+```
+
+---
+
+## 🎯 ZONE 5 — Bottom : QR codes (1/8)
+
+```
+   📥 INSTALLATION RAPIDE iPhone :
+
+   ┌──────────┐  ┌──────────┐  ┌──────────┐
+   │ QR code  │  │ QR code  │  │ QR code  │
+   │          │  │          │  │          │
+   │  Splash  │  │  Cert    │  │  Webclip │
+   │  village3b│  │  iPhone  │  │  Home    │
+   └──────────┘  └──────────┘  └──────────┘
+
+   Empreinte CA SHA-1 :
+   62:A1:E5:3B:1F:C2:B2:97:77:AE:BB:58:61:B2:39:5A:6E:82:71:FF
+```
+
+---
+
+## 🎯 ZONE 6 — Footer
+
+```
+   📡 Gondwana ToolBoX · CyberMind / Gérald Kerma
+   Notre-Dame-du-Cruet (73130) · Savoie · France
+   Source : github.com/CyberMind-FR/secubox-deb
+   Contact : devel@cybermind.fr · https://cybermind.fr
+
+   //  DIY · Open Source · Open Audit
+   //  Soutiens : liberapay.com/cybermind
+```
+
+---
+
+## Variantes A4 / A5 / dépliant 3-volets
+
+Le poster A2 ci-dessus peut être adapté :
+- **A4** : retirer Zone 3 détaillée, garder titre + 3 niveaux + QR codes + footer
+- **A5** : titre + invitation à scanner + 1 QR code
+- **Dépliant 3 volets** : volet 1 = titre + 3 niveaux ; volet 2 = exemple rapport ; volet 3 = conformité + QR + contact
+
+---
+
+## Choix typographiques + couleurs (charte DESIGN-CHARTER.md)
+
+```css
+--cosmos-black: #0a0a0f;        /* fond */
+--gold-hermetic: #c9a84c;       /* accents titre */
+--matrix-green: #00ff41;        /* texte principal */
+--phos: #00dd44;                /* bordures, P31 lab */
+--phos-hot: #00ff55;            /* highlights */
+--amber: #ffb347;               /* warning R2 */
+--cinnabar: #e63946;            /* alertes risque HIGH */
+
+font-family-titles: 'Cinzel', serif;
+font-family-body: 'IM Fell English', serif;
+font-family-mono: 'JetBrains Mono', monospace;
+```
+
+---
+
+## Print specs
+
+- **Format A2** : 420×594 mm, marges 15 mm
+- **Résolution** : 300 dpi minimum
+- **Bleed** : 3 mm
+- **Couleur** : CMYK (RGB pour digital)
+- **Papier** : mat 200 g/m² (pour outdoor : laminé)
+
+---
+
+## Output formats à générer
+
+- [ ] PDF print-ready A2 + A4 + A5
+- [ ] SVG éditable (Inkscape source)
+- [ ] PNG digital 1920×1080 (réseaux sociaux)
+- [ ] Story Instagram 1080×1920
+- [ ] LinkedIn banner 1584×396
+
+---
+
+**Status** : Draft v1 — 2026-06-05 — synchronisé avec Phase 3 (#492) actuelle.
+Update prévue après Phase 6 (#496 WireGuard R3 mode) pour inclure le 4ème niveau + bénéfice mobile-first.

--- a/docs/marketing/PROMPT-claude-presse-gouv.md
+++ b/docs/marketing/PROMPT-claude-presse-gouv.md
@@ -305,3 +305,93 @@ Tu produiras :
 ---
 
 Bonne rédaction. Pour toute question structurante, demande à l'auteur (Gérald Kerma, devel@cybermind.fr) plutôt que de deviner.
+
+---
+
+## ANNEXE — Mise à jour 2026-06-05 : architecture R0/R1/R2/R3
+
+Depuis la rédaction initiale de ce prompt, le produit a évolué. Intégrer ces éléments dans tes livrables :
+
+### Modèle d'opt-in à 3 niveaux + 1 mode portable (Phase 3 #492 mergeable + Phase 6 #496 roadmap)
+
+L'utilisateur choisit explicitement son niveau d'analyse sur le splash captif :
+
+| Niveau | Mode | Impact UX | Cas d'usage cible |
+|--------|------|-----------|-------------------|
+| 🌐 **R0** | Bypass complet | Aucune analyse, AP WiFi normal | Visiteur juste de passage, refus principiel d'analyse |
+| 🛡 **R1** | Analyse passive | Rapport généré, AUCUN impact surf | **Défaut recommandé** — bénéfice diagnostic sans coût UX |
+| 🔍 **R2** | TLS-break + bandeau | Déchiffrement, bandeau visible Safari | Curieux éclairé, audit personnel approfondi |
+| 🌐 **R3** | WireGuard mobile (roadmap Phase 6) | VPN tunnel, marche hors-WiFi cabine | Mobilité, mode portable, bénéfice élargi territorial |
+
+L'angle CSPN/ANSSI : le consentement n'est plus binaire (accept/refuse) mais **gradué**, **explicable**, **réversible à tout moment depuis le rapport**. C'est un argument fort pour la conformité **principe de proportionnalité** et **minimisation des données**.
+
+### Transparence radicale (Phase 3 #492)
+
+Le rapport montre **honnêtement** :
+- 🔍 X% du trafic inspecté (HTTPS via notre CA)
+- 🛡 X% bypassé par whitelist (Apple/banques/Signal — 108 patterns curés)
+- 🔒 X% cert-pinning détecté (app refuse notre CA = normal, bon signe)
+- 🔐 X% E2E messaging (Signal/iMessage opaques par design)
+
+**La cabine se sait se taire, et DIT QUAND elle se tait.** C'est le différenciateur fondamental contre les produits qui vendent "98% sécurisé" sans détailler les bypass.
+
+### Architecture mitm disjoints (Phase 5 #495)
+
+Roadmap : séparer le mitm cabine (analyse client iPhone) du WAF mitm (protection vhosts CyberMind) dans deux containers LXC distincts. **Isolation totale** des deux usages, certs séparés, addons séparés. Argument souveraineté : la cabine n'écoute QUE le trafic de son utilisateur, jamais celui d'un tiers.
+
+### Mode WireGuard portable (Phase 6 #496 — kbin.gk2.net:51820)
+
+Roadmap majeure pour 2026 :
+
+> **L'utilisateur scanne un QR code, installe un profil WireGuard sur son iPhone, et obtient l'analyse depuis n'importe où — pas besoin d'être physiquement à la cabine.**
+
+Bénéfices presse/gouv :
+- Inclusion territoriale : usage déporté en zone blanche, depuis le domicile, depuis un autre WiFi
+- Maillage léger : plusieurs cabines = plusieurs endpoints WireGuard, possible mutualisation
+- Conformité renforcée : profil VPN visible iOS, consentement encore plus explicite
+- Continuité de service : si la cabine physique est en maintenance, le profil installé continue de fonctionner
+
+### Engine de filtrage compromissions à sensibilité réglable
+
+`/etc/secubox/toolbox/rule-engine.yaml` permet à l'opérateur (collectivité, association de quartier, France Services) de choisir un profil :
+
+- 🟢 **Permissif** : bloque uniquement malware confirmé (zéro faux positif)
+- 🟡 **Équilibré** (défaut) : malware + DGA fort + beaconing évident
+- 🟠 **Strict** : ajoute ASN faible réputation
+- 🔴 **Paranoïaque** : default-deny sauf whitelist
+
+L'angle souveraineté : la cabine s'adapte au contexte (école, EHPAD, médiathèque) sans changer de produit. Un médiateur numérique peut ajuster la rigueur sans toucher au code.
+
+### Empreinte hardware & Open Source
+
+- Cible matérielle : MochaBin GlobalScale (Marvell Armada 7040 ARM64) — fabricant taïwanais avec écosystème ouvert
+- Debian 12 bookworm arm64 — distribution souveraine de facto
+- Code source intégral : `github.com/CyberMind-FR/secubox-deb` (licence CMSD-1.0, audit citoyen possible)
+- Coût matériel : ~250 € HT par cabine assemblée (sans WiFi USB ni boîtier décoratif)
+
+### Documentation technique
+
+Un brief auto-portant pour LLM externe (`docs/AI-HANDOVER-cabine-evolution.md`) existe désormais : un autre rédacteur ou contributeur (humain ou GPT/Gemini) peut comprendre l'architecture entière sans contexte préalable. **Continuité du commun numérique au-delà d'un seul auteur.**
+
+### Composants installables sur iPhone (splash quick-up menu)
+
+```
+🔐 Certificat iPhone     → /ca/mobileconfig
+🤖 Certificat Android/PC → /ca/android.crt
+📱 Icône Home iPhone     → /ca/webclip-cabine.mobileconfig
+📜 Guide pas-à-pas       → /ca/install-help
+🌐 Profil WireGuard (R3) → /wg/profile/new (roadmap #496)
+```
+
+Tous bundlés avec l'empreinte CA SHA-1 affichée pour vérification visuelle dans Réglages iOS.
+
+### Engagement de l'auteur
+
+> *« Je ne vends pas une boîte noire. Je publie un commun numérique que tu peux installer toi-même, auditer ligne par ligne, et adapter à ta collectivité. Si demain CyberMind disparaît, le code reste, la documentation reste, le brief LLM reste — quelqu'un d'autre peut reprendre. »*
+
+Cette posture est à intégrer dans la tribune et le communiqué de presse — c'est le différenciateur éthique face aux SaaS américains et aux solutions clé-en-main propriétaires.
+
+---
+
+**Status au 2026-06-05** : Phase 3 PR #493 prête à merge. Phases 5+6 ouvertes (#495, #496). Mise à jour livrables marketing avec les éléments ci-dessus avant publication.
+

--- a/packages/secubox-toolbox/conf/nft-toolbox.nft.j2
+++ b/packages/secubox-toolbox/conf/nft-toolbox.nft.j2
@@ -14,6 +14,14 @@ table inet toolbox {
         timeout 24h
     }
 
+    # Phase 3 (#492) : level R2 explicit opt-in subset. Membership triggers
+    # the QUIC reject rule + inject_banner. Subset of consented_r2_macs.
+    set r2_banner_macs {
+        type ether_addr
+        flags timeout
+        timeout 24h
+    }
+
     set quarantine_macs {
         type ether_addr
         flags timeout
@@ -50,14 +58,13 @@ table inet toolbox {
         type filter hook forward priority 10; policy accept;
         # Quarantine first (high priority drop)
         iifname "{{ ap.iface }}" ether saddr @quarantine_macs drop
-        # Phase 3 (#492) : DROP QUIC/HTTP3 for R2-consented clients.
-        # iOS+Android use QUIC (UDP 443) aggressively which bypasses our TCP
-        # mitm transparent proxy entirely. Forcing clients to fall back to
-        # TCP HTTPS means mitmproxy sees the flows -> banner injection + full
-        # analysis works. Performance impact is minor for browsing, and Apple
-        # services (iCloud/Push/FaceTime) which prefer QUIC still work fine
-        # over TCP. UDP 53/67 (DNS/DHCP) explicitly allowed below.
-        iifname "{{ ap.iface }}" ether saddr @consented_r2_macs udp dport 443 reject with icmpx type port-unreachable
+        # Phase 3 (#492) : OPTIONAL QUIC/HTTP3 reject for clients in the
+        # r2_banner_macs set (level=R2 explicit opt-in). This forces TCP
+        # fallback so mitmproxy sees the flows -> banner injection works.
+        # Apps that REQUIRE QUIC (some iCloud paths, FaceTime) may degrade.
+        # Default = empty set, no impact. /accept POST with level=r2 adds
+        # the MAC; user can revert to R1 to remove without losing R1 analysis.
+        iifname "{{ ap.iface }}" ether saddr @r2_banner_macs udp dport 443 reject with icmpx type port-unreachable
         # Validated MACs: forward to LAN/Internet
         iifname "{{ ap.iface }}" oifname "lan0" ether saddr @validated_macs accept
         iifname "lan0" oifname "{{ ap.iface }}" ct state established,related accept

--- a/packages/secubox-toolbox/conf/nft-toolbox.nft.j2
+++ b/packages/secubox-toolbox/conf/nft-toolbox.nft.j2
@@ -50,6 +50,14 @@ table inet toolbox {
         type filter hook forward priority 10; policy accept;
         # Quarantine first (high priority drop)
         iifname "{{ ap.iface }}" ether saddr @quarantine_macs drop
+        # Phase 3 (#492) : DROP QUIC/HTTP3 for R2-consented clients.
+        # iOS+Android use QUIC (UDP 443) aggressively which bypasses our TCP
+        # mitm transparent proxy entirely. Forcing clients to fall back to
+        # TCP HTTPS means mitmproxy sees the flows -> banner injection + full
+        # analysis works. Performance impact is minor for browsing, and Apple
+        # services (iCloud/Push/FaceTime) which prefer QUIC still work fine
+        # over TCP. UDP 53/67 (DNS/DHCP) explicitly allowed below.
+        iifname "{{ ap.iface }}" ether saddr @consented_r2_macs udp dport 443 reject with icmpx type port-unreachable
         # Validated MACs: forward to LAN/Internet
         iifname "{{ ap.iface }}" oifname "lan0" ether saddr @validated_macs accept
         iifname "lan0" oifname "{{ ap.iface }}" ct state established,related accept

--- a/packages/secubox-toolbox/conf/nft-toolbox.nft.j2
+++ b/packages/secubox-toolbox/conf/nft-toolbox.nft.j2
@@ -58,13 +58,13 @@ table inet toolbox {
         type filter hook forward priority 10; policy accept;
         # Quarantine first (high priority drop)
         iifname "{{ ap.iface }}" ether saddr @quarantine_macs drop
-        # Phase 3 (#492) : OPTIONAL QUIC/HTTP3 reject for clients in the
-        # r2_banner_macs set (level=R2 explicit opt-in). This forces TCP
-        # fallback so mitmproxy sees the flows -> banner injection works.
-        # Apps that REQUIRE QUIC (some iCloud paths, FaceTime) may degrade.
-        # Default = empty set, no impact. /accept POST with level=r2 adds
-        # the MAC; user can revert to R1 to remove without losing R1 analysis.
-        iifname "{{ ap.iface }}" ether saddr @r2_banner_macs udp dport 443 reject with icmpx type port-unreachable
+        # Phase 3 (#492) : QUIC drop REMOVED — too aggressive. iPhone Safari +
+        # Apple/Google heavily depend on QUIC ; rejecting UDP 443 for R2
+        # broke surf entirely for the iPhone session. Banner injection works
+        # on TCP HTTPS HTML responses (when those happen) without forcing
+        # the whole iOS stack to fall back from QUIC.
+        # The r2_banner_macs set is still used by inject_banner.py to gate
+        # the banner injection ; no nft rule needed for that.
         # Validated MACs: forward to LAN/Internet
         iifname "{{ ap.iface }}" oifname "lan0" ether saddr @validated_macs accept
         iifname "lan0" oifname "{{ ap.iface }}" ct state established,related accept

--- a/packages/secubox-toolbox/conf/report-live.html.j2
+++ b/packages/secubox-toolbox/conf/report-live.html.j2
@@ -104,10 +104,11 @@ li::before{content:"▸ ";color:var(--phos);text-shadow:0 0 4px var(--phos)}
   {% set top_dev_emj = avatar.most_common_emoji or '' %}
   {% set top_app = (dpi_cls.top_apps and dpi_cls.top_apps[0]) or {} %}
   {% set top_geo = (geo_h and geo_h[0]) or {} %}
+  {% set top_asn_raw = top_geo.asn_org if top_geo.asn_org else '?' %}
   <p style="font-size:0.78rem;color:var(--dim);margin-top:0.6rem;text-align:center;padding-top:0.5rem;border-top:1px solid var(--dim)">
     Top device : {{ top_dev_emj }} {{ top_dev }} ·
     Top app : {{ top_app.emoji|default('') }} {{ top_app.app|default('?') }} ·
-    Top ASN : {{ top_geo.flag|default('') }} {{ top_geo.asn_org|default('?')[:30] }}
+    Top ASN : {{ top_geo.flag|default('') }} {{ top_asn_raw[:30] }}
   </p>
 </div>
 

--- a/packages/secubox-toolbox/conf/report-live.html.j2
+++ b/packages/secubox-toolbox/conf/report-live.html.j2
@@ -333,6 +333,69 @@ li::before{content:"▸ ";color:var(--phos);text-shadow:0 0 4px var(--phos)}
   <a href="/status">📊 Statut JSON</a>
 </div>
 
+{# Phase 3 (#492) : transparency layer — inspection breakdown + per-host quality #}
+{% set t = transparency|default({}) %}
+{% if t and t.get('total_events', 0) > 0 %}
+<div class="card">
+  <h2>🔎 INSPECTION : CE QU'ON A REGARDÉ (et ce qu'on n'a PAS regardé)</h2>
+  <p style="font-size:0.78rem;color:var(--dim);margin-bottom:0.6rem;font-style:italic">
+    Honnêteté avant magie : la cabine te dit ce qu'elle a inspecté, ce qu'elle a sciemment bypassé, et pourquoi.
+  </p>
+  <div class="kv">
+    {% set b = t.get('breakdown_pct', {}) %}
+    {% if b.get('inspected') %}
+      <div class="k">🔍 Inspecté (HTTPS via notre CA)</div>
+      <div class="v">{{ b.get('inspected', 0) }}% — contenu visible</div>
+    {% endif %}
+    {% if b.get('bypassed-whitelist') %}
+      <div class="k">🛡 Bypass whitelist</div>
+      <div class="v">{{ b.get('bypassed-whitelist', 0) }}% — décision policy (cert-pinning vendor)</div>
+    {% endif %}
+    {% if b.get('pinned-failed-mitm') %}
+      <div class="k">🔒 Cert-pinning détecté</div>
+      <div class="v">{{ b.get('pinned-failed-mitm', 0) }}% — l'app refuse notre CA, normal+bon signe</div>
+    {% endif %}
+    {% if b.get('e2e-opaque') %}
+      <div class="k">🔐 E2E messaging</div>
+      <div class="v">{{ b.get('e2e-opaque', 0) }}% — opaque par design, ton chiffrement marche</div>
+    {% endif %}
+    <div class="k">📊 Total events analysés</div>
+    <div class="v">{{ t.get('total_events', 0) }}</div>
+    {% if t.get('whitelist_stats') %}
+      <div class="k">📜 Patterns whitelist actifs</div>
+      <div class="v">{{ t.get('whitelist_stats', {}).get('count', 0) }} (baseline + override)</div>
+    {% endif %}
+  </div>
+</div>
+
+{% if t.get('per_host') %}
+<div class="card">
+  <h2>🎯 QUALITÉ SÉCURITÉ PAR DESTINATION</h2>
+  <p style="font-size:0.78rem;color:var(--dim);margin-bottom:0.6rem;font-style:italic">
+    Grade A+/A/B/C/D/F basé sur TLS version + JA4 + headers + cookies. Worst-first :
+  </p>
+  <table style="width:100%;font-size:0.78rem;border-collapse:collapse">
+    <thead>
+      <tr style="color:var(--phos);text-align:left;border-bottom:1px solid var(--dim)">
+        <th style="padding:0.3rem">Grade</th>
+        <th style="padding:0.3rem">Destination</th>
+        <th style="padding:0.3rem">Statut analyse</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for h in t.get('per_host', [])[:15] %}
+      <tr style="border-bottom:1px solid rgba(0,221,68,0.1)">
+        <td style="padding:0.25rem;font-weight:bold;color:{% if h.grade in ['A+','A'] %}var(--phos-hot){% elif h.grade == 'B' %}var(--phos){% elif h.grade == 'C' %}var(--amber){% else %}var(--red){% endif %}">{{ h.grade }}</td>
+        <td style="padding:0.25rem;font-family:monospace;color:var(--text)">{{ h.host[:60] }}</td>
+        <td style="padding:0.25rem;color:var(--dim);font-size:0.72rem">{{ h.status }} — {{ h.reason[:70] }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+{% endif %}
+
 <p class="refresh">↻ Auto-refresh toutes les 15 secondes</p>
 
 <div class="card">

--- a/packages/secubox-toolbox/conf/report-live.html.j2
+++ b/packages/secubox-toolbox/conf/report-live.html.j2
@@ -411,7 +411,47 @@ li::before{content:"▸ ";color:var(--phos);text-shadow:0 0 4px var(--phos)}
       <div class="k">📜 Patterns whitelist actifs</div>
       <div class="v">{{ t.get('whitelist_stats', {}).get('count', 0) }} (baseline + override)</div>
     {% endif %}
+    {% if t.get('sensitivity') %}
+      <div class="k">🎛 Sensibilité active</div>
+      <div class="v">{{ t.get('sensitivity', {}).get('label', '?') }} — {{ t.get('sensitivity', {}).get('description', '')[:80] }}</div>
+    {% endif %}
   </div>
+
+  {# Phase 3 (#492) : tentatives counters — full transparency #}
+  {% set a = t.get('attempts', {}) %}
+  {% if a.get('total', 0) > 0 %}
+  <div style="margin-top:0.8rem;padding-top:0.6rem;border-top:1px solid var(--dim)">
+    <p style="font-size:0.78rem;color:var(--dim);margin-bottom:0.4rem"><b>📈 Tentatives observées (toutes catégories)</b></p>
+    <div class="kv" style="font-size:0.8rem">
+      <span class="k">Total observé</span><span class="v">{{ a.get('total', 0) }}</span>
+      <span class="k">🔍 Inspecté</span><span class="v">{{ a.get('inspected', 0) }}</span>
+      <span class="k">🛡 Bypass</span><span class="v">{{ a.get('bypassed_whitelist', 0) }}</span>
+      <span class="k">🔒 Cert-pinning</span><span class="v">{{ a.get('pinned_failed', 0) }}</span>
+      <span class="k">🔐 E2E opaque</span><span class="v">{{ a.get('e2e_opaque', 0) }}</span>
+      {% if a.get('blocked', 0) > 0 %}
+      <span class="k">🚫 Bloqué</span><span class="v" style="color:var(--red)">{{ a.get('blocked', 0) }}</span>
+      {% endif %}
+    </div>
+  </div>
+  {% endif %}
+
+  {# Phase 3 (#492) : whitelist hits — accountability per pattern/category #}
+  {% set wh = t.get('whitelist_hits', {}) %}
+  {% if wh.get('total', 0) > 0 %}
+  <div style="margin-top:0.8rem;padding-top:0.6rem;border-top:1px solid var(--dim)">
+    <p style="font-size:0.78rem;color:var(--dim);margin-bottom:0.4rem"><b>📜 Tes bypass whitelist en détail</b> — {{ wh.get('total') }} connexions sciemment non-inspectées</p>
+    <div class="kv" style="font-size:0.78rem">
+      {% for cat, cnt in (wh.get('by_category', {}) | dictsort(by='value', reverse=True))[:8] %}
+      <span class="k">{{ cat }}</span><span class="v">{{ cnt }} hits</span>
+      {% endfor %}
+    </div>
+    <ul style="margin-top:0.4rem">
+      {% for p in wh.get('top_patterns', [])[:8] %}
+      <li style="font-size:0.72rem"><code>{{ p.pattern }}</code> · {{ p.count }} hits</li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
 </div>
 
 {% if t.get('per_host') %}

--- a/packages/secubox-toolbox/conf/report-live.html.j2
+++ b/packages/secubox-toolbox/conf/report-live.html.j2
@@ -121,7 +121,8 @@ li::before{content:"▸ ";color:var(--phos);text-shadow:0 0 4px var(--phos)}
     <span class="k">Sensibilité actuelle</span>
     <span class="v">{{ sens.label|default('—') if sens else '—' }}</span>
     <span class="k">Description</span>
-    <span class="v" style="font-size:0.75rem">{{ sens.description|default('Engine pas chargé')[:90] if sens else 'Engine pas chargé' }}</span>
+    {% set sens_desc = (sens.description if sens and sens.description else 'Engine pas chargé') %}
+    <span class="v" style="font-size:0.75rem">{{ sens_desc[:90] }}</span>
     <span class="k">🔍 Threat-intel feeds</span>
     <span class="v">{{ (threat_intel_matches|default([]))|length }} matches actifs</span>
     <span class="k">🎲 DGA candidates</span>

--- a/packages/secubox-toolbox/conf/report-live.html.j2
+++ b/packages/secubox-toolbox/conf/report-live.html.j2
@@ -42,7 +42,102 @@ li::before{content:"▸ ";color:var(--phos);text-shadow:0 0 4px var(--phos)}
 <h1>📡 GONDWANA TOOLBOX</h1>
 <p class="sub">// Rapport live — Cabine numérique VILLAGE3B</p>
 
-{# Phase 3 (#492) : welcome / switch confirmation banner #}
+{# Phase 3 (#492) : hero widgets — same shape as PDF #}
+{% set m = metrics or {} %}
+{% set sc = risk_score or 0 %}
+{% set rl = risk_label or 'LOW' %}
+<div class="card" style="background:linear-gradient(135deg,rgba(0,221,68,0.08),rgba(110,64,201,0.05));border-color:var(--phos)">
+  <h2 style="display:flex;justify-content:space-between;align-items:center">
+    📊 Ta session VILLAGE3B
+    <span style="font-size:0.75rem;padding:0.3rem 0.8rem;border-radius:99px;
+      background:{% if sc < 30 %}#00cc44{% elif sc < 70 %}#ffb347{% else %}#ff4466{% endif %};
+      color:#0a0a0f;font-weight:bold">
+      {% if sc < 30 %}🟢{% elif sc < 70 %}🟡{% else %}🔴{% endif %} {{ rl }} {{ sc }}/100
+    </span>
+  </h2>
+  <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:0.5rem;margin-top:0.8rem">
+    {% for emoji, val, lbl in [
+      ('🌐', m.connections|default(0), 'connexions'),
+      ('📡', m.unique_hosts|default(0), 'hôtes uniques'),
+      ('✅', m.successful|default(0), 'OK 2xx/3xx'),
+      ('🔒', m.tls_pinned|default(0), 'cert-pinning')
+    ] %}
+    <div style="padding:0.6rem;background:rgba(0,0,0,0.3);border-radius:4px;text-align:center">
+      <div style="font-size:1.2rem">{{ emoji }}</div>
+      <div style="font-size:1.3rem;font-weight:bold;color:var(--phos-hot);text-shadow:0 0 4px var(--phos)">{{ val }}</div>
+      <div style="font-size:0.65rem;color:var(--dim)">{{ lbl }}</div>
+    </div>
+    {% endfor %}
+  </div>
+  <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:0.5rem;margin-top:0.5rem">
+    {% set dpi_cls = dpi_classified or {} %}
+    {% set cookies_p = cookies_providers or [] %}
+    {% set geo_h = geo_top_hosts or [] %}
+    {% set n_apps = (dpi_cls.top_apps|default([])|selectattr('app','ne','?')|list|length) %}
+    {% set n_trackers = (cookies_p|map(attribute='count')|sum) %}
+    {% set countries = geo_h|map(attribute='country')|reject('equalto','')|list %}
+    {% set n_countries = countries|unique|list|length %}
+    <div style="padding:0.6rem;background:rgba(25,25,45,0.5);border-radius:4px;text-align:center">
+      <div style="font-size:1.2rem">📺</div>
+      <div style="font-size:1.3rem;font-weight:bold;color:#9e76ff">{{ n_apps }}</div>
+      <div style="font-size:0.65rem;color:var(--dim)">apps détectées</div>
+    </div>
+    <div style="padding:0.6rem;background:rgba(45,25,35,0.5);border-radius:4px;text-align:center">
+      <div style="font-size:1.2rem">🍪</div>
+      <div style="font-size:1.3rem;font-weight:bold;color:#ff8866">{{ n_trackers }}</div>
+      <div style="font-size:0.65rem;color:var(--dim)">trackers</div>
+    </div>
+    <div style="padding:0.6rem;background:rgba(25,40,35,0.5);border-radius:4px;text-align:center">
+      <div style="font-size:1.2rem">🌍</div>
+      <div style="font-size:1.3rem;font-weight:bold;color:#66bbff">{{ n_countries }}</div>
+      <div style="font-size:0.65rem;color:var(--dim)">pays/ASN</div>
+    </div>
+    <div style="padding:0.6rem;background:rgba(60,50,15,0.5);border-radius:4px;text-align:center">
+      <div style="font-size:1.2rem">{% if sc < 30 %}🟢{% elif sc < 70 %}🟡{% else %}🔴{% endif %}</div>
+      <div style="font-size:1.3rem;font-weight:bold;color:{% if sc < 30 %}var(--phos-hot){% elif sc < 70 %}#ffb347{% else %}#ff4466{% endif %}">{{ sc }}</div>
+      <div style="font-size:0.65rem;color:var(--dim)">risque /100</div>
+    </div>
+  </div>
+  {# Top device + app + ASN line #}
+  {% set avatar = avatar_analysis or {} %}
+  {% set top_dev = avatar.most_common or '?' %}
+  {% set top_dev_emj = avatar.most_common_emoji or '' %}
+  {% set top_app = (dpi_cls.top_apps and dpi_cls.top_apps[0]) or {} %}
+  {% set top_geo = (geo_h and geo_h[0]) or {} %}
+  <p style="font-size:0.78rem;color:var(--dim);margin-top:0.6rem;text-align:center;padding-top:0.5rem;border-top:1px solid var(--dim)">
+    Top device : {{ top_dev_emj }} {{ top_dev }} ·
+    Top app : {{ top_app.emoji|default('') }} {{ top_app.app|default('?') }} ·
+    Top ASN : {{ top_geo.flag|default('') }} {{ top_geo.asn_org|default('?')[:30] }}
+  </p>
+</div>
+
+{# Phase 3 (#492) : filtering compromissions visibility #}
+{% set t = transparency|default({}) %}
+{% set sens = t.get('sensitivity') %}
+<div class="card" style="background:rgba(255,68,102,0.06);border-color:var(--red)">
+  <h2 style="color:var(--red)">🚨 Filtering compromissions actif</h2>
+  <div class="kv" style="font-size:0.82rem">
+    <span class="k">Sensibilité actuelle</span>
+    <span class="v">{{ sens.label|default('—') if sens else '—' }}</span>
+    <span class="k">Description</span>
+    <span class="v" style="font-size:0.75rem">{{ sens.description|default('Engine pas chargé')[:90] if sens else 'Engine pas chargé' }}</span>
+    <span class="k">🔍 Threat-intel feeds</span>
+    <span class="v">{{ (threat_intel_matches|default([]))|length }} matches actifs</span>
+    <span class="k">🎲 DGA candidates</span>
+    <span class="v">{{ (dga_candidates|default([]))|length }} hôtes suspects</span>
+    <span class="k">📡 Beaconing patterns</span>
+    <span class="v">{{ (beaconing_candidates|default([]))|length }} détectés</span>
+    <span class="k">🚫 Connexions bloquées</span>
+    <span class="v">{{ t.get('attempts', {}).get('blocked', 0) }} <span style="font-size:0.7rem;color:var(--dim)">(Phase 4 : observation only)</span></span>
+  </div>
+  <p style="font-size:0.7rem;color:var(--dim);margin-top:0.5rem;font-style:italic">
+    Le moteur détecte mais ne bloque pas encore — passive transparency. La règle engine
+    décidera blocage actif quand R3 / Phase 4 sera wired.
+  </p>
+</div>
+
+{# Phase 3 (#492) : welcome / switch confirmation banner — uses server-side
+   current_level (NOT request_args.level which is stale after refresh). #}
 {% if request_args and (request_args.get('welcome') or request_args.get('switched')) %}
 <div class="card" style="background:rgba(0,221,68,0.08);border-color:var(--phos)">
   <h2 style="color:var(--phos-hot)">
@@ -51,9 +146,8 @@ li::before{content:"▸ ";color:var(--phos);text-shadow:0 0 4px var(--phos)}
   <p style="font-size:0.85rem">
     Tu es maintenant en mode
     <b style="color:var(--phos-hot)">
-      {% set lvl = request_args.get('level', 'r1') %}
-      {% if lvl == 'r0' %}🌐 R0 — Accès simple (aucune analyse)
-      {% elif lvl == 'r2' %}🔍 R2 — Analyse + bandeau Safari
+      {% if current_level == 'r0' %}🌐 R0 — Bypass complet (aucune analyse)
+      {% elif current_level == 'r2' %}🔍 R2 — Analyse + bandeau Safari
       {% else %}🛡 R1 — Analyse passive recommandée{% endif %}
     </b>.
     Tu peux maintenant <a href="http://captive.apple.com/hotspot-detect.html" target="_blank" style="color:var(--phos-hot);text-decoration:underline">surfer normalement</a> — ce rapport se met à jour toutes les 15s.
@@ -61,24 +155,46 @@ li::before{content:"▸ ";color:var(--phos);text-shadow:0 0 4px var(--phos)}
 </div>
 {% endif %}
 
-{# Phase 3 (#492) : level switcher — user can change opt-in level anytime #}
+{# Phase 3 (#492) : level switcher with active highlight from server-side
+   current_level. Disables button if user clicks their own level (no-op). #}
 <div class="card">
   <h2>🔀 Mon niveau d'opt-in</h2>
-  <p style="font-size:0.78rem;color:var(--dim);margin-bottom:0.6rem">
-    Tu peux changer de niveau à tout moment. R2 inspecte plus mais peut casser des apps.
+  <p style="font-size:0.78rem;color:var(--dim);margin-bottom:0.5rem">
+    📍 Tu es actuellement en
+    <b style="color:{% if current_level == 'r0' %}var(--text){% elif current_level == 'r2' %}#ffd6a0{% else %}var(--phos-hot){% endif %}">
+      {% if current_level == 'r0' %}🌐 R0 — Bypass complet
+      {% elif current_level == 'r2' %}🔍 R2 — Analyse + bandeau
+      {% else %}🛡 R1 — Analyse passive{% endif %}
+    </b>
+    · clique sur un autre niveau pour switcher
   </p>
   <form method="POST" action="/change-level" style="display:grid;grid-template-columns:repeat(3,1fr);gap:0.4rem">
     <button type="submit" name="level" value="r0"
-      style="padding:0.5rem;background:transparent;color:var(--text);border:1px solid var(--dim);cursor:pointer;font-family:inherit;font-size:0.85rem">
-      🌐 R0
+      style="padding:0.5rem;cursor:pointer;font-family:inherit;font-size:0.85rem;
+        {% if current_level == 'r0' %}
+          background:rgba(255,255,255,0.08);color:var(--text);border:2px solid var(--text);font-weight:bold;
+        {% else %}
+          background:transparent;color:var(--text);border:1px solid var(--dim);
+        {% endif %}">
+      {% if current_level == 'r0' %}✓ {% endif %}🌐 R0
     </button>
     <button type="submit" name="level" value="r1"
-      style="padding:0.5rem;background:rgba(0,221,68,0.1);color:var(--phos-hot);border:1px solid var(--phos);cursor:pointer;font-family:inherit;font-size:0.85rem;font-weight:bold">
-      🛡 R1
+      style="padding:0.5rem;cursor:pointer;font-family:inherit;font-size:0.85rem;
+        {% if current_level == 'r1' %}
+          background:rgba(0,221,68,0.25);color:var(--phos-hot);border:2px solid var(--phos);font-weight:bold;
+        {% else %}
+          background:transparent;color:var(--phos);border:1px solid var(--dim);
+        {% endif %}">
+      {% if current_level == 'r1' %}✓ {% endif %}🛡 R1
     </button>
     <button type="submit" name="level" value="r2"
-      style="padding:0.5rem;background:transparent;color:#ffd6a0;border:1px solid #ffb347;cursor:pointer;font-family:inherit;font-size:0.85rem">
-      🔍 R2
+      style="padding:0.5rem;cursor:pointer;font-family:inherit;font-size:0.85rem;
+        {% if current_level == 'r2' %}
+          background:rgba(255,179,71,0.25);color:#ffd6a0;border:2px solid #ffb347;font-weight:bold;
+        {% else %}
+          background:transparent;color:#9d7846;border:1px solid var(--dim);
+        {% endif %}">
+      {% if current_level == 'r2' %}✓ {% endif %}🔍 R2
     </button>
   </form>
 </div>

--- a/packages/secubox-toolbox/conf/report-live.html.j2
+++ b/packages/secubox-toolbox/conf/report-live.html.j2
@@ -5,6 +5,11 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta http-equiv="refresh" content="15">
+{# Phase 3 (#492) : PWA tags for iOS Add-to-Home-Screen webclip experience #}
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="ToolBoX Cabine">
+<meta name="theme-color" content="#0a0a0f">
 <title>Mon rapport Gondwana ToolBoX — live</title>
 <style>
 :root{--bg:#0a0a0f;--phos:#00dd44;--phos-hot:#00ff55;--dim:#006622;--text:#e8e6d9;--red:#ff4466;--amber:#ffb347}

--- a/packages/secubox-toolbox/conf/report-live.html.j2
+++ b/packages/secubox-toolbox/conf/report-live.html.j2
@@ -42,6 +42,47 @@ li::before{content:"▸ ";color:var(--phos);text-shadow:0 0 4px var(--phos)}
 <h1>📡 GONDWANA TOOLBOX</h1>
 <p class="sub">// Rapport live — Cabine numérique VILLAGE3B</p>
 
+{# Phase 3 (#492) : welcome / switch confirmation banner #}
+{% if request_args and (request_args.get('welcome') or request_args.get('switched')) %}
+<div class="card" style="background:rgba(0,221,68,0.08);border-color:var(--phos)">
+  <h2 style="color:var(--phos-hot)">
+    {% if request_args.get('switched') %}🔄 Niveau changé{% else %}🎉 Bienvenue !{% endif %}
+  </h2>
+  <p style="font-size:0.85rem">
+    Tu es maintenant en mode
+    <b style="color:var(--phos-hot)">
+      {% set lvl = request_args.get('level', 'r1') %}
+      {% if lvl == 'r0' %}🌐 R0 — Accès simple (aucune analyse)
+      {% elif lvl == 'r2' %}🔍 R2 — Analyse + bandeau Safari
+      {% else %}🛡 R1 — Analyse passive recommandée{% endif %}
+    </b>.
+    Tu peux maintenant <a href="http://captive.apple.com/hotspot-detect.html" target="_blank" style="color:var(--phos-hot);text-decoration:underline">surfer normalement</a> — ce rapport se met à jour toutes les 15s.
+  </p>
+</div>
+{% endif %}
+
+{# Phase 3 (#492) : level switcher — user can change opt-in level anytime #}
+<div class="card">
+  <h2>🔀 Mon niveau d'opt-in</h2>
+  <p style="font-size:0.78rem;color:var(--dim);margin-bottom:0.6rem">
+    Tu peux changer de niveau à tout moment. R2 inspecte plus mais peut casser des apps.
+  </p>
+  <form method="POST" action="/change-level" style="display:grid;grid-template-columns:repeat(3,1fr);gap:0.4rem">
+    <button type="submit" name="level" value="r0"
+      style="padding:0.5rem;background:transparent;color:var(--text);border:1px solid var(--dim);cursor:pointer;font-family:inherit;font-size:0.85rem">
+      🌐 R0
+    </button>
+    <button type="submit" name="level" value="r1"
+      style="padding:0.5rem;background:rgba(0,221,68,0.1);color:var(--phos-hot);border:1px solid var(--phos);cursor:pointer;font-family:inherit;font-size:0.85rem;font-weight:bold">
+      🛡 R1
+    </button>
+    <button type="submit" name="level" value="r2"
+      style="padding:0.5rem;background:transparent;color:#ffd6a0;border:1px solid #ffb347;cursor:pointer;font-family:inherit;font-size:0.85rem">
+      🔍 R2
+    </button>
+  </form>
+</div>
+
 <div class="card">
   <h2>👤 Identifiant anonyme</h2>
   <div class="kv">

--- a/packages/secubox-toolbox/conf/splash.html.j2
+++ b/packages/secubox-toolbox/conf/splash.html.j2
@@ -39,6 +39,54 @@ button.lvl-r2{border-color:var(--amber);color:#ffd6a0}
     {% if mac_hash and mac_hash != '??' %}<br>Ton appareil (anonymisé) : <b>{{ mac_hash }}</b>{% endif %}
   </div>
 
+  {# Phase 3 (#492) : cert chain auto-check. JS probes mitm response to a known
+     HTTPS endpoint. Result mapped to a colored badge. Helps user verify R2
+     readiness BEFORE selecting it. #}
+  <div id="cert-status" class="info" style="margin-top:0.5rem;font-size:0.78rem">
+    <span id="cert-emoji">⏳</span>
+    <span id="cert-text">Vérification certificat racine ToolBoX...</span>
+    <div style="font-size:0.7rem;opacity:0.7;margin-top:0.3rem">
+      Empreinte attendue : <code id="cert-fp"></code>
+    </div>
+  </div>
+  <script>
+  (function(){
+    var fpEl = document.getElementById('cert-fp');
+    var emEl = document.getElementById('cert-emoji');
+    var txEl = document.getElementById('cert-text');
+    var statusEl = document.getElementById('cert-status');
+    // Get the CA fingerprint for display
+    fetch('/ca/fingerprint').then(function(r){return r.json();}).then(function(d){
+      fpEl.textContent = (d.sha1 || d.sha256 || '?').substring(0, 47);
+    }).catch(function(){fpEl.textContent = '?';});
+    // Probe a HTTPS endpoint that the iPhone would reach via mitm if CA installed.
+    // We use a simple image fetch ; onload = success, onerror = TLS failure.
+    var probe = new Image();
+    probe.onload = function(){
+      emEl.textContent = '🟢';
+      txEl.innerHTML = '<b>Certificat installé</b> — R2 prêt à fonctionner.';
+      statusEl.style.borderLeftColor = 'var(--phos)';
+      statusEl.style.background = 'rgba(0,221,68,0.08)';
+    };
+    probe.onerror = function(){
+      emEl.textContent = '🔴';
+      txEl.innerHTML = '<b>Certificat NON installé</b> — <a href="/ca/install-help" style="color:var(--amber)">installer le profil</a> avant de choisir R2.';
+      statusEl.style.borderLeftColor = 'var(--amber)';
+      statusEl.style.background = 'rgba(255,179,71,0.08)';
+    };
+    // Cache-bust + cross-domain (any HTTPS works as a probe — the success
+    // proves CA validates the cert mitmproxy generated for that domain)
+    probe.src = 'https://www.google.com/favicon.ico?t=' + Date.now();
+    // Fallback timeout : if no resolution in 3s, mark unknown
+    setTimeout(function(){
+      if (emEl.textContent === '⏳') {
+        emEl.textContent = '❔';
+        txEl.innerHTML = 'Statut indéterminé — <a href="/ca/install-help" style="color:var(--phos)">vérifier l\'installation du certificat</a>';
+      }
+    }, 3000);
+  })();
+  </script>
+
   <p class="choose-label">👇 Choisis ton niveau d'analyse :</p>
 
   <form method="POST" action="/accept" style="display:flex;flex-direction:column;gap:0.6rem">

--- a/packages/secubox-toolbox/conf/splash.html.j2
+++ b/packages/secubox-toolbox/conf/splash.html.j2
@@ -43,7 +43,7 @@ button:hover{background:rgba(0,221,68,0.1);box-shadow:0 0 12px var(--phos)}
   <form method="POST" action="/accept" style="display:flex;flex-direction:column;gap:0.8rem">
 
     <button type="submit" name="level" value="r0" style="border-color:var(--dim);color:var(--text)">
-      🌐 R0 — Accès simple <span style="opacity:0.7;font-size:0.75rem">· réseau seul, 0 analyse</span>
+      🌐 R0 — Bypass complet <span style="opacity:0.7;font-size:0.75rem">· réseau seul, ZÉRO analyse, comme un AP normal</span>
     </button>
 
     <button type="submit" name="level" value="r1" style="border-color:var(--phos);color:var(--phos-hot)">

--- a/packages/secubox-toolbox/conf/splash.html.j2
+++ b/packages/secubox-toolbox/conf/splash.html.j2
@@ -32,23 +32,36 @@ button:hover{background:rgba(0,221,68,0.1);box-shadow:0 0 12px var(--phos)}
     Ton appareil : <b>{{ mac_hash }}</b> (anonymisé)
   </div>
 
-  {% if r2_enabled %}
-  <div class="r2">
-    <strong>⚠ Inspection volontaire activée :</strong> en cliquant ci-dessous, tu acceptes que ton
-    trafic transitant par cette borne soit déchiffré (TLS-break) le temps de ta session, pour
-    détecter une éventuelle compromission de ton appareil. À la fin, tu pourras récupérer ton
-    rapport personnel anonyme (lien éphémère 24h). Aucune donnée n'est revendue.
-  </div>
-  {% endif %}
-
   <p class="terms">
     Conformité : R2 (CSPN) — consentement explicite ; LCEN — anonymisation par hash quotidien.
     Ce dispositif est défensif (détection seule, pas d'interception de tiers).
-    <a href="/ca/install-help">Installer le certificat (recommandé pour TLS-break)</a>
+    Choisis ton niveau ci-dessous (tu peux changer plus tard depuis le rapport) :
   </p>
 
-  <form method="POST" action="/accept">
-    <button type="submit">✓ Activer mon accès</button>
+  {# Phase 3 (#492) : 3-level explicit opt-in. R0 = net only, R1 = passive
+     analysis (default, no impact on UX), R2 = R1 + visible banner + QUIC drop. #}
+  <form method="POST" action="/accept" style="display:flex;flex-direction:column;gap:0.8rem">
+
+    <button type="submit" name="level" value="r0" style="border-color:var(--dim);color:var(--text)">
+      🌐 R0 — Accès simple <span style="opacity:0.7;font-size:0.75rem">· réseau seul, 0 analyse</span>
+    </button>
+
+    <button type="submit" name="level" value="r1" style="border-color:var(--phos);color:var(--phos-hot)">
+      🛡 R1 — Accès + analyse passive <span style="opacity:0.85;font-size:0.75rem">· rapport sur ta session, pas d'impact, recommandé</span>
+    </button>
+
+    {% if r2_enabled %}
+    <button type="submit" name="level" value="r2" style="border-color:#ffb347;color:#ffd6a0">
+      🔍 R2 — Analyse + bandeau Safari <span style="opacity:0.85;font-size:0.75rem">· peut casser iCloud/Push</span>
+    </button>
+
+    <div class="r2" style="font-size:0.75rem;margin-top:0.3rem">
+      <strong>⚠ R2 active</strong> : déchiffrement TLS (CA à installer) + bandeau visible sur les pages
+      web Safari + redirection forcée TCP (drop QUIC). Apps natives iOS (iCloud sync, FaceTime, Push
+      notifications) peuvent être lentes ou échouer le temps de la session. Tu peux revenir en R1
+      depuis le rapport. <a href="/ca/install-help" style="color:#ffb347">Installer le certificat</a>
+    </div>
+    {% endif %}
   </form>
 
   <p style="margin-top:1rem;font-size:0.78rem;color:var(--dim);text-align:center">

--- a/packages/secubox-toolbox/conf/splash.html.j2
+++ b/packages/secubox-toolbox/conf/splash.html.j2
@@ -39,6 +39,19 @@ button.lvl-r2{border-color:var(--amber);color:#ffd6a0}
     {% if mac_hash and mac_hash != '??' %}<br>Ton appareil (anonymisé) : <b>{{ mac_hash }}</b>{% endif %}
   </div>
 
+  {% if already_validated %}
+  <div class="info" style="margin-top:0.5rem;background:rgba(0,221,68,0.08);border-left-color:var(--phos)">
+    ✅ <b>Tu es déjà validé en mode
+    {% if current_level == 'r0' %}🌐 R0 (bypass complet)
+    {% elif current_level == 'r2' %}🔍 R2 (analyse + bandeau)
+    {% else %}🛡 R1 (analyse passive){% endif %}</b>
+    · <a href="/report/me/html" style="color:var(--phos-hot);text-decoration:underline">📊 Voir mon rapport live</a>
+    <span style="font-size:0.72rem;opacity:0.7;display:block;margin-top:0.3rem">
+      Tu peux installer/réinstaller les composants ci-dessous ou changer de niveau.
+    </span>
+  </div>
+  {% endif %}
+
   {# Phase 3 (#492) : 📦 Composants à installer — quick-up menu emoji #}
   <div class="info" style="margin-top:0.5rem;background:rgba(110,64,201,0.08);border-left-color:#9e76ff">
     <p style="font-size:0.9rem;color:#cbb6ff;margin-bottom:0.6rem;font-weight:bold">

--- a/packages/secubox-toolbox/conf/splash.html.j2
+++ b/packages/secubox-toolbox/conf/splash.html.j2
@@ -39,51 +39,84 @@ button.lvl-r2{border-color:var(--amber);color:#ffd6a0}
     {% if mac_hash and mac_hash != '??' %}<br>Ton appareil (anonymisé) : <b>{{ mac_hash }}</b>{% endif %}
   </div>
 
-  {# Phase 3 (#492) : cert chain auto-check. JS probes mitm response to a known
-     HTTPS endpoint. Result mapped to a colored badge. Helps user verify R2
-     readiness BEFORE selecting it. #}
-  <div id="cert-status" class="info" style="margin-top:0.5rem;font-size:0.78rem">
-    <span id="cert-emoji">⏳</span>
-    <span id="cert-text">Vérification certificat racine ToolBoX...</span>
-    <div style="font-size:0.7rem;opacity:0.7;margin-top:0.3rem">
-      Empreinte attendue : <code id="cert-fp"></code>
+  {# Phase 3 (#492) : cert access + auto-check. Big install button + manual test
+     button + auto-detected status. R1/R2 require the CA to be in trust store. #}
+  <div id="cert-card" class="info" style="margin-top:0.5rem;background:rgba(110,64,201,0.08);border-left-color:#9e76ff">
+    <p style="font-size:0.85rem;color:#cbb6ff;margin-bottom:0.4rem">
+      🔐 <b>Certificat racine ToolBoX</b> — requis pour R1/R2
+    </p>
+    <p style="font-size:0.72rem;opacity:0.85;line-height:1.45;margin-bottom:0.5rem">
+      Sans certificat installé, R1 et R2 cassent tous les HTTPS (TLS handshake fails).
+      R0 fonctionne sans le certificat (mais aucune analyse).
+    </p>
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.4rem;margin-bottom:0.5rem">
+      <a href="/ca/mobileconfig"
+         style="display:block;padding:0.55rem;background:#9e76ff;color:#0a0a0f;text-decoration:none;text-align:center;font-weight:bold;font-size:0.82rem;border-radius:3px">
+        📥 Installer (iPhone)
+      </a>
+      <a href="/ca/android.crt"
+         style="display:block;padding:0.55rem;background:transparent;color:#cbb6ff;text-decoration:none;text-align:center;font-weight:bold;font-size:0.82rem;border:1px solid #9e76ff;border-radius:3px">
+        🤖 Télécharger CRT (Android/PC)
+      </a>
     </div>
+
+    <button type="button" id="test-cert-btn"
+            style="width:100%;padding:0.5rem;background:transparent;color:var(--phos-hot);border:1px solid var(--phos);font-family:inherit;font-size:0.82rem;cursor:pointer;margin-bottom:0.4rem">
+      🧪 Tester le certificat maintenant
+    </button>
+
+    <div id="cert-status" style="font-size:0.78rem;padding:0.5rem;background:rgba(0,0,0,0.3);border-radius:3px;text-align:center">
+      <span id="cert-emoji">⏳</span>
+      <span id="cert-text">Auto-test en cours...</span>
+    </div>
+
+    <p style="font-size:0.65rem;opacity:0.7;margin-top:0.4rem;font-family:monospace;word-break:break-all">
+      Empreinte CA SHA-1 : <code id="cert-fp" style="color:#cbb6ff"></code>
+    </p>
   </div>
   <script>
   (function(){
     var fpEl = document.getElementById('cert-fp');
     var emEl = document.getElementById('cert-emoji');
     var txEl = document.getElementById('cert-text');
+    var btnEl = document.getElementById('test-cert-btn');
     var statusEl = document.getElementById('cert-status');
-    // Get the CA fingerprint for display
+
     fetch('/ca/fingerprint').then(function(r){return r.json();}).then(function(d){
-      fpEl.textContent = (d.sha1 || d.sha256 || '?').substring(0, 47);
+      fpEl.textContent = (d.sha1 || d.sha256 || '?');
     }).catch(function(){fpEl.textContent = '?';});
-    // Probe a HTTPS endpoint that the iPhone would reach via mitm if CA installed.
-    // We use a simple image fetch ; onload = success, onerror = TLS failure.
-    var probe = new Image();
-    probe.onload = function(){
-      emEl.textContent = '🟢';
-      txEl.innerHTML = '<b>Certificat installé</b> — R2 prêt à fonctionner.';
-      statusEl.style.borderLeftColor = 'var(--phos)';
-      statusEl.style.background = 'rgba(0,221,68,0.08)';
-    };
-    probe.onerror = function(){
-      emEl.textContent = '🔴';
-      txEl.innerHTML = '<b>Certificat NON installé</b> — <a href="/ca/install-help" style="color:var(--amber)">installer le profil</a> avant de choisir R2.';
-      statusEl.style.borderLeftColor = 'var(--amber)';
-      statusEl.style.background = 'rgba(255,179,71,0.08)';
-    };
-    // Cache-bust + cross-domain (any HTTPS works as a probe — the success
-    // proves CA validates the cert mitmproxy generated for that domain)
-    probe.src = 'https://www.google.com/favicon.ico?t=' + Date.now();
-    // Fallback timeout : if no resolution in 3s, mark unknown
-    setTimeout(function(){
-      if (emEl.textContent === '⏳') {
+
+    function runProbe() {
+      emEl.textContent = '⏳';
+      txEl.textContent = 'Test en cours...';
+      statusEl.style.background = 'rgba(0,0,0,0.3)';
+      var probe = new Image();
+      var done = false;
+      probe.onload = function(){
+        if (done) return; done = true;
+        emEl.textContent = '🟢';
+        txEl.innerHTML = '<b>Certificat OK — R1/R2 prêt</b>';
+        statusEl.style.background = 'rgba(0,221,68,0.15)';
+      };
+      probe.onerror = function(){
+        if (done) return; done = true;
+        emEl.textContent = '🔴';
+        txEl.innerHTML = '<b>Certificat NON installé</b> — clique 📥 ci-dessus';
+        statusEl.style.background = 'rgba(255,68,102,0.15)';
+      };
+      // Probe a reliable HTTPS endpoint. We try Apple captive (which iOS
+      // already trusts) — if it loads via mitm with our CA, our CA is trusted.
+      probe.src = 'https://captive.apple.com/library/test/success.html?t=' + Date.now();
+      setTimeout(function(){
+        if (done) return; done = true;
         emEl.textContent = '❔';
-        txEl.innerHTML = 'Statut indéterminé — <a href="/ca/install-help" style="color:var(--phos)">vérifier l\'installation du certificat</a>';
-      }
-    }, 3000);
+        txEl.innerHTML = 'Timeout — relance le test';
+        statusEl.style.background = 'rgba(255,179,71,0.15)';
+      }, 4000);
+    }
+    btnEl.addEventListener('click', runProbe);
+    setTimeout(runProbe, 600);
   })();
   </script>
 

--- a/packages/secubox-toolbox/conf/splash.html.j2
+++ b/packages/secubox-toolbox/conf/splash.html.j2
@@ -86,8 +86,22 @@ button.lvl-r2{border-color:var(--amber);color:#ffd6a0}
       <span id="cert-text">Auto-test en cours...</span>
     </div>
 
-    <p style="font-size:0.65rem;opacity:0.7;margin-top:0.4rem;font-family:monospace;word-break:break-all">
-      Empreinte CA SHA-1 : <code id="cert-fp" style="color:#cbb6ff"></code>
+    <p style="font-size:0.7rem;opacity:0.85;margin-top:0.6rem;line-height:1.5">
+      ⚠ L'auto-test est <b>best-effort</b> (probe HTTPS). Pour <b>certifier</b>
+      que le CA est bien installé + activé sur iPhone :
+    </p>
+    <ol style="font-size:0.7rem;padding-left:1.2rem;line-height:1.55;color:#cbb6ff">
+      <li>Réglages → Général → <b>VPN et gestion d'appareils</b></li>
+      <li>Profil <b>Gondwana ToolBoX CA</b> doit apparaître → tap → installer</li>
+      <li>Réglages → Général → Information → <b>Réglages de confiance des certificats</b></li>
+      <li>Activer le toggle pour <b>Gondwana ToolBoX CA</b> 🟢</li>
+    </ol>
+
+    <p style="font-size:0.7rem;opacity:0.9;margin-top:0.5rem;border-top:1px solid rgba(158,118,255,0.3);padding-top:0.4rem">
+      Vérifie cette empreinte dans Réglages :
+    </p>
+    <p style="font-family:monospace;font-size:0.78rem;word-break:break-all;color:#cbb6ff;background:rgba(0,0,0,0.4);padding:0.5rem;border-radius:3px;margin-top:0.3rem">
+      🔑 <code id="cert-fp"></code>
     </p>
   </div>
 
@@ -120,27 +134,36 @@ button.lvl-r2{border-color:var(--amber);color:#ffd6a0}
       emEl.textContent = '⏳';
       txEl.textContent = 'Test en cours...';
       statusEl.style.background = 'rgba(0,0,0,0.3)';
+      // The probe is HEURISTIC : iOS has special handling for many domains
+      // (captive.apple.com cert-pinned, etc.) so auto-test is best-effort.
+      // We probe example.com which is :
+      //  - NOT cert-pinned by iOS
+      //  - simple, low-latency HTTPS
+      //  - if user is in R1/R2 (MITM enabled), mitm generates a leaf cert
+      //    signed by our CA -> success only if our CA is installed.
+      //  - if user is NOT yet in MITM set (pre-validation), the cert chain
+      //    is example.com's real chain -> always succeeds regardless of our CA.
+      // So pre-validation : auto-test ALWAYS passes (informative only).
+      // Post-R1/R2 acceptance : auto-test is reliable.
       var probe = new Image();
       var done = false;
       probe.onload = function(){
         if (done) return; done = true;
         emEl.textContent = '🟢';
-        txEl.innerHTML = '<b>Certificat OK — R1/R2 prêt</b>';
+        txEl.innerHTML = '<b>HTTPS OK</b> — si tu es déjà en R1/R2, ton CA est installé. Vérifie quand même les étapes manuelles ci-dessous.';
         statusEl.style.background = 'rgba(0,221,68,0.15)';
       };
       probe.onerror = function(){
         if (done) return; done = true;
         emEl.textContent = '🔴';
-        txEl.innerHTML = '<b>Certificat NON installé</b> — clique 📥 ci-dessus';
+        txEl.innerHTML = '<b>HTTPS échoue</b> — soit pas de réseau, soit en R1/R2 SANS le CA installé. Suis les étapes manuelles ci-dessous.';
         statusEl.style.background = 'rgba(255,68,102,0.15)';
       };
-      // Probe a reliable HTTPS endpoint. We try Apple captive (which iOS
-      // already trusts) — if it loads via mitm with our CA, our CA is trusted.
-      probe.src = 'https://captive.apple.com/library/test/success.html?t=' + Date.now();
+      probe.src = 'https://example.com/favicon.ico?t=' + Date.now();
       setTimeout(function(){
         if (done) return; done = true;
         emEl.textContent = '❔';
-        txEl.innerHTML = 'Timeout — relance le test';
+        txEl.innerHTML = 'Timeout — relance le test ou vérifie manuellement ci-dessous';
         statusEl.style.background = 'rgba(255,179,71,0.15)';
       }, 4000);
     }

--- a/packages/secubox-toolbox/conf/splash.html.j2
+++ b/packages/secubox-toolbox/conf/splash.html.j2
@@ -189,11 +189,11 @@ button.lvl-r2{border-color:var(--amber);color:#ffd6a0}
     {% if r2_enabled %}
     <button type="submit" name="level" value="r2" class="lvl-btn lvl-r2">
       🔍 <b>R2 — Analyse + bandeau Safari</b>
-      <span class="sub-desc">Déchiffrement TLS + bandeau visible sur les pages Safari. Apps natives iOS peuvent être lentes (iCloud / Push / FaceTime).</span>
+      <span class="sub-desc">Déchiffrement TLS + bandeau visible sur les pages Safari HTML.</span>
     </button>
 
     <div class="r2-warn">
-      <strong>⚠ Si tu choisis R2 :</strong> il te faut <a href="/ca/install-help">installer le certificat racine ToolBoX</a> sur ton iPhone, sinon TLS handshake fails. Tu pourras revenir en R1 depuis le rapport à tout moment.
+      <strong>⚠ Si tu choisis R2 :</strong> il te faut <a href="/ca/install-help">installer le certificat racine ToolBoX</a> sur ton iPhone, sinon les sites HTTPS échouent. Le bandeau n'apparaît que sur les pages HTML servies en TCP (la plupart des apps iPhone utilisent QUIC et ne montreront pas le bandeau). Tu peux revenir en R1 depuis le rapport à tout moment.
     </div>
     {% endif %}
   </form>

--- a/packages/secubox-toolbox/conf/splash.html.j2
+++ b/packages/secubox-toolbox/conf/splash.html.j2
@@ -6,71 +6,72 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>{{ ssid }} — Cabine numérique Gondwana</title>
 <style>
-:root{--bg:#0a0a0f;--phos:#00dd44;--phos-hot:#00ff55;--dim:#006622;--text:#e8e6d9;--red:#ff4466}
+:root{--bg:#0a0a0f;--phos:#00dd44;--phos-hot:#00ff55;--dim:#006622;--text:#e8e6d9;--red:#ff4466;--amber:#ffb347}
 *{box-sizing:border-box;margin:0;padding:0}
-body{font-family:'Courier New',monospace;background:var(--bg);color:var(--text);min-height:100vh;display:flex;align-items:center;justify-content:center;padding:1.5rem}
-.card{max-width:520px;width:100%;border:1px solid var(--dim);padding:2rem;box-shadow:0 0 20px rgba(0,221,68,0.3)}
-h1{font-size:1.8rem;color:var(--phos-hot);text-shadow:0 0 6px var(--phos);margin-bottom:0.5rem;letter-spacing:0.1em}
-.subtitle{color:var(--dim);font-size:0.9rem;margin-bottom:1.5rem;letter-spacing:0.05em}
-.info{background:rgba(0,221,68,0.05);border-left:2px solid var(--phos);padding:0.8rem 1rem;margin-bottom:1rem;font-size:0.9rem;line-height:1.55}
+body{font-family:'Courier New',monospace;background:var(--bg);color:var(--text);min-height:100vh;display:flex;align-items:center;justify-content:center;padding:1.2rem}
+.card{max-width:540px;width:100%;border:1px solid var(--dim);padding:1.5rem;box-shadow:0 0 20px rgba(0,221,68,0.3)}
+h1{font-size:1.6rem;color:var(--phos-hot);text-shadow:0 0 6px var(--phos);margin-bottom:0.3rem;letter-spacing:0.08em}
+.subtitle{color:var(--dim);font-size:0.85rem;margin-bottom:1rem;letter-spacing:0.05em}
+.info{background:rgba(0,221,68,0.05);border-left:2px solid var(--phos);padding:0.7rem 0.9rem;margin-bottom:1rem;font-size:0.82rem;line-height:1.5}
 .info b{color:var(--phos);text-shadow:0 0 4px var(--phos)}
-.r2{background:rgba(255,179,71,0.05);border-left:2px solid #ffb347;padding:0.8rem 1rem;margin-bottom:1rem;font-size:0.85rem;line-height:1.5;color:#ffd6a0}
-.r2 strong{color:#ffb347}
-.terms{font-size:0.78rem;color:var(--dim);margin-bottom:1.5rem;line-height:1.5}
+.choose-label{font-size:0.95rem;color:var(--phos-hot);margin-bottom:0.6rem;text-shadow:0 0 4px var(--phos);text-align:center;letter-spacing:0.05em}
+button.lvl-btn{width:100%;font-family:inherit;text-align:left;padding:0.8rem 0.9rem;background:transparent;border:1px solid;cursor:pointer;font-size:0.95rem;line-height:1.35;transition:all 0.15s;display:block}
+button.lvl-btn:hover{background:rgba(255,255,255,0.04);transform:translateX(2px)}
+button.lvl-r0{border-color:var(--dim);color:var(--text)}
+button.lvl-r1{border-color:var(--phos);color:var(--phos-hot);text-shadow:0 0 4px var(--phos);box-shadow:inset 0 0 12px rgba(0,221,68,0.15)}
+button.lvl-r2{border-color:var(--amber);color:#ffd6a0}
+.badge{display:inline-block;font-size:0.65rem;padding:0.1rem 0.4rem;background:var(--phos);color:#0a0a0f;border-radius:99px;margin-left:0.3rem;font-weight:bold;letter-spacing:0.03em;vertical-align:middle}
+.sub-desc{display:block;font-size:0.72rem;opacity:0.75;margin-top:0.2rem;letter-spacing:0}
+.r2-warn{margin-top:0.8rem;padding:0.7rem 0.9rem;background:rgba(255,179,71,0.08);border-left:2px solid var(--amber);font-size:0.75rem;line-height:1.45;color:#ffd6a0}
+.r2-warn strong{color:var(--amber);text-shadow:0 0 4px var(--amber)}
+.r2-warn a{color:var(--amber);text-decoration:underline}
+.terms{font-size:0.72rem;color:var(--dim);margin-top:1rem;line-height:1.45;border-top:1px solid var(--dim);padding-top:0.7rem}
 .terms a{color:var(--phos);text-decoration:underline}
-button{width:100%;font-family:inherit;font-size:1.05rem;padding:0.9rem;background:transparent;color:var(--phos-hot);border:1px solid var(--phos);cursor:pointer;text-shadow:0 0 6px var(--phos);letter-spacing:0.08em;transition:all 0.2s}
-button:hover{background:rgba(0,221,68,0.1);box-shadow:0 0 12px var(--phos)}
-.footer{text-align:center;margin-top:1.5rem;font-size:0.7rem;color:var(--dim);letter-spacing:0.1em}
+.footer{text-align:center;margin-top:1rem;font-size:0.65rem;color:var(--dim);letter-spacing:0.08em}
 .footer a{color:var(--dim);text-decoration:none}
 </style></head><body>
 <div class="card">
   <h1>📡 {{ ssid }}</h1>
-  <p class="subtitle">// Cabine numérique Gondwana — accès libre + diagnostic compromission</p>
+  <p class="subtitle">// Cabine numérique Gondwana</p>
 
   <div class="info">
-    Tu es connecté au réseau public.<br>
-    Ton appareil : <b>{{ mac_hash }}</b> (anonymisé)
+    🌐 Tu es connecté au réseau de la borne.
+    {% if mac_hash and mac_hash != '??' %}<br>Ton appareil (anonymisé) : <b>{{ mac_hash }}</b>{% endif %}
   </div>
 
-  <p class="terms">
-    Conformité : R2 (CSPN) — consentement explicite ; LCEN — anonymisation par hash quotidien.
-    Ce dispositif est défensif (détection seule, pas d'interception de tiers).
-    Choisis ton niveau ci-dessous (tu peux changer plus tard depuis le rapport) :
-  </p>
+  <p class="choose-label">👇 Choisis ton niveau d'analyse :</p>
 
-  {# Phase 3 (#492) : 3-level explicit opt-in. R0 = net only, R1 = passive
-     analysis (default, no impact on UX), R2 = R1 + visible banner + QUIC drop. #}
-  <form method="POST" action="/accept" style="display:flex;flex-direction:column;gap:0.8rem">
+  <form method="POST" action="/accept" style="display:flex;flex-direction:column;gap:0.6rem">
 
-    <button type="submit" name="level" value="r0" style="border-color:var(--dim);color:var(--text)">
-      🌐 R0 — Bypass complet <span style="opacity:0.7;font-size:0.75rem">· réseau seul, ZÉRO analyse, comme un AP normal</span>
+    <button type="submit" name="level" value="r0" class="lvl-btn lvl-r0">
+      🌐 <b>R0 — Bypass complet</b>
+      <span class="sub-desc">Réseau seul, ZÉRO analyse. La cabine se comporte comme un AP normal.</span>
     </button>
 
-    <button type="submit" name="level" value="r1" style="border-color:var(--phos);color:var(--phos-hot)">
-      🛡 R1 — Accès + analyse passive <span style="opacity:0.85;font-size:0.75rem">· rapport sur ta session, pas d'impact, recommandé</span>
+    <button type="submit" name="level" value="r1" class="lvl-btn lvl-r1">
+      🛡 <b>R1 — Analyse passive</b><span class="badge">✓ DÉFAUT RECOMMANDÉ</span>
+      <span class="sub-desc">Rapport détaillé sur ta session, <b>aucun impact</b> sur ta navigation. Apps natives + iCloud + Push fonctionnent normalement.</span>
     </button>
 
     {% if r2_enabled %}
-    <button type="submit" name="level" value="r2" style="border-color:#ffb347;color:#ffd6a0">
-      🔍 R2 — Analyse + bandeau Safari <span style="opacity:0.85;font-size:0.75rem">· peut casser iCloud/Push</span>
+    <button type="submit" name="level" value="r2" class="lvl-btn lvl-r2">
+      🔍 <b>R2 — Analyse + bandeau Safari</b>
+      <span class="sub-desc">Déchiffrement TLS + bandeau visible sur les pages Safari. Apps natives iOS peuvent être lentes (iCloud / Push / FaceTime).</span>
     </button>
 
-    <div class="r2" style="font-size:0.75rem;margin-top:0.3rem">
-      <strong>⚠ R2 active</strong> : déchiffrement TLS (CA à installer) + bandeau visible sur les pages
-      web Safari + redirection forcée TCP (drop QUIC). Apps natives iOS (iCloud sync, FaceTime, Push
-      notifications) peuvent être lentes ou échouer le temps de la session. Tu peux revenir en R1
-      depuis le rapport. <a href="/ca/install-help" style="color:#ffb347">Installer le certificat</a>
+    <div class="r2-warn">
+      <strong>⚠ Si tu choisis R2 :</strong> il te faut <a href="/ca/install-help">installer le certificat racine ToolBoX</a> sur ton iPhone, sinon TLS handshake fails. Tu pourras revenir en R1 depuis le rapport à tout moment.
     </div>
     {% endif %}
   </form>
 
-  <p style="margin-top:1rem;font-size:0.78rem;color:var(--dim);text-align:center">
-    Après validation, tu pourras <a href="/report/me" style="color:var(--phos);text-decoration:underline">télécharger ton rapport d'analyse PDF</a>
-    à tout moment pendant 24h.
+  <p class="terms">
+    <b>Conformité :</b> CSPN R2 — consentement explicite par MAC ; LCEN — anonymisation par hash quotidien rotatif. Dispositif défensif (rapport sur TON appareil, jamais sur les tiers).
+    Après validation, <a href="/report/me/html">accède à ton rapport live</a> ou <a href="/report/me">télécharge le PDF</a> pendant 24h.
   </p>
 
   <p class="footer">
-    SecuBox-Deb · CyberMind · <a href="https://github.com/CyberMind-FR/secubox-deb">Source (LicenseRef-CMSD-1.0)</a>
+    SecuBox-Deb · CyberMind · <a href="https://github.com/CyberMind-FR/secubox-deb">Source LicenseRef-CMSD-1.0</a>
   </p>
 </div>
 </body></html>

--- a/packages/secubox-toolbox/conf/splash.html.j2
+++ b/packages/secubox-toolbox/conf/splash.html.j2
@@ -39,34 +39,36 @@ button.lvl-r2{border-color:var(--amber);color:#ffd6a0}
     {% if mac_hash and mac_hash != '??' %}<br>Ton appareil (anonymisé) : <b>{{ mac_hash }}</b>{% endif %}
   </div>
 
-  {# Phase 3 (#492) : cert access + auto-check. Big install button + manual test
-     button + auto-detected status. R1/R2 require the CA to be in trust store. #}
-  <div id="cert-card" class="info" style="margin-top:0.5rem;background:rgba(110,64,201,0.08);border-left-color:#9e76ff">
-    <p style="font-size:0.85rem;color:#cbb6ff;margin-bottom:0.4rem">
-      🔐 <b>Certificat racine ToolBoX</b> — requis pour R1/R2
-    </p>
-    <p style="font-size:0.72rem;opacity:0.85;line-height:1.45;margin-bottom:0.5rem">
-      Sans certificat installé, R1 et R2 cassent tous les HTTPS (TLS handshake fails).
-      R0 fonctionne sans le certificat (mais aucune analyse).
+  {# Phase 3 (#492) : 📦 Composants à installer — quick-up menu emoji #}
+  <div class="info" style="margin-top:0.5rem;background:rgba(110,64,201,0.08);border-left-color:#9e76ff">
+    <p style="font-size:0.9rem;color:#cbb6ff;margin-bottom:0.6rem;font-weight:bold">
+      📦 Quick install — composants ToolBoX
     </p>
 
-    <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.4rem;margin-bottom:0.5rem">
-      <a href="/ca/mobileconfig"
-         style="display:block;padding:0.55rem;background:#9e76ff;color:#0a0a0f;text-decoration:none;text-align:center;font-weight:bold;font-size:0.82rem;border-radius:3px">
-        📥 Installer (iPhone)
+    <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:0.5rem;margin-bottom:0.6rem">
+      <a href="/ca/mobileconfig" class="qbtn qbtn-primary">
+        🔐 Certificat iPhone
+        <span class="qbtn-sub">.mobileconfig pour iOS</span>
       </a>
-      <a href="/ca/android.crt"
-         style="display:block;padding:0.55rem;background:transparent;color:#cbb6ff;text-decoration:none;text-align:center;font-weight:bold;font-size:0.82rem;border:1px solid #9e76ff;border-radius:3px">
-        🤖 Télécharger CRT (Android/PC)
+      <a href="/ca/android.crt" class="qbtn qbtn-outline">
+        🤖 Certificat Android/PC
+        <span class="qbtn-sub">.crt à installer manuellement</span>
+      </a>
+      <a href="/ca/webclip-cabine.mobileconfig" class="qbtn qbtn-primary-alt">
+        📱 Icône Home iPhone
+        <span class="qbtn-sub">1-tap accès rapport</span>
+      </a>
+      <a href="/ca/install-help" class="qbtn qbtn-outline">
+        📜 Guide pas-à-pas
+        <span class="qbtn-sub">comment installer</span>
       </a>
     </div>
 
-    <button type="button" id="test-cert-btn"
-            style="width:100%;padding:0.5rem;background:transparent;color:var(--phos-hot);border:1px solid var(--phos);font-family:inherit;font-size:0.82rem;cursor:pointer;margin-bottom:0.4rem">
+    <button type="button" id="test-cert-btn" class="qbtn qbtn-test">
       🧪 Tester le certificat maintenant
     </button>
 
-    <div id="cert-status" style="font-size:0.78rem;padding:0.5rem;background:rgba(0,0,0,0.3);border-radius:3px;text-align:center">
+    <div id="cert-status" style="font-size:0.8rem;padding:0.55rem;background:rgba(0,0,0,0.3);border-radius:3px;text-align:center;margin-top:0.5rem">
       <span id="cert-emoji">⏳</span>
       <span id="cert-text">Auto-test en cours...</span>
     </div>
@@ -75,6 +77,20 @@ button.lvl-r2{border-color:var(--amber);color:#ffd6a0}
       Empreinte CA SHA-1 : <code id="cert-fp" style="color:#cbb6ff"></code>
     </p>
   </div>
+
+  <style>
+  .qbtn{display:block;padding:0.7rem 0.6rem;text-decoration:none;text-align:center;
+        font-family:inherit;font-size:0.82rem;font-weight:bold;border-radius:4px;
+        transition:transform 0.1s,box-shadow 0.1s;line-height:1.25}
+  .qbtn:hover{transform:translateY(-1px);box-shadow:0 2px 6px rgba(0,0,0,0.4)}
+  .qbtn-sub{display:block;font-size:0.65rem;font-weight:normal;opacity:0.75;margin-top:0.2rem}
+  .qbtn-primary{background:#9e76ff;color:#0a0a0f}
+  .qbtn-primary-alt{background:#6e40c9;color:#fff}
+  .qbtn-outline{background:transparent;color:#cbb6ff;border:1px solid #9e76ff}
+  .qbtn-test{width:100%;background:transparent;color:var(--phos-hot);border:1px solid var(--phos);
+             padding:0.55rem;cursor:pointer;font-family:inherit;font-size:0.85rem}
+  .qbtn-test:hover{background:rgba(0,221,68,0.1)}
+  </style>
   <script>
   (function(){
     var fpEl = document.getElementById('cert-fp');

--- a/packages/secubox-toolbox/conf/success.html.j2
+++ b/packages/secubox-toolbox/conf/success.html.j2
@@ -3,25 +3,55 @@
 <html lang="fr"><head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-title" content="ToolBoX Cabine">
 <title>VILLAGE3B — Accès activé</title>
 <style>
-body{font-family:'Courier New',monospace;background:#0a0a0f;color:#00ff55;display:flex;align-items:center;justify-content:center;min-height:100vh;text-align:center;padding:1rem;text-shadow:0 0 6px #00dd44}
-h1{font-size:2rem;margin-bottom:1rem}
-p{color:#006622;margin:0.4rem 0}
-.mac{font-family:monospace;color:#00dd44;text-shadow:0 0 4px #00dd44}
-.actions a{display:inline-block;margin:0.5rem;padding:0.4rem 0.9rem;color:#00ff55;border:1px solid #00dd44;text-decoration:none;font-size:0.85rem}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:'Courier New',monospace;background:#0a0a0f;color:#00ff55;min-height:100vh;padding:1.5rem;text-shadow:0 0 6px #00dd44}
+.card{max-width:560px;margin:auto;border:1px solid #006622;padding:1.5rem;box-shadow:0 0 20px rgba(0,221,68,0.3)}
+h1{font-size:1.8rem;text-align:center;margin-bottom:0.4rem;color:#00ff55;letter-spacing:0.05em}
+.lvl{display:inline-block;padding:0.35rem 1rem;border-radius:99px;font-size:0.85rem;font-weight:bold;margin:0.5rem auto;text-align:center}
+.lvl-r0{background:#222;color:#888;border:1px solid #444}
+.lvl-r1{background:rgba(0,221,68,0.15);color:#00ff55;border:1px solid #00dd44}
+.lvl-r2{background:rgba(255,179,71,0.15);color:#ffd6a0;border:1px solid #ffb347}
+p{color:#a8b6a8;margin:0.5rem 0;text-align:center;font-size:0.9rem}
+.mac{font-family:monospace;color:#00dd44;font-size:0.75rem;text-shadow:none;opacity:0.7}
+.go-surf{display:block;width:100%;text-align:center;padding:1rem;margin:1.2rem 0;background:linear-gradient(90deg,#00dd44 0%,#00aa33 100%);color:#0a0a0f;font-weight:bold;font-size:1.05rem;text-decoration:none;border-radius:4px;letter-spacing:0.05em;box-shadow:0 0 12px rgba(0,221,68,0.5)}
+.go-surf:hover{box-shadow:0 0 20px rgba(0,221,68,0.8)}
+.subtle{font-size:0.78rem;color:#666;text-align:center;margin:0.8rem 0}
+.actions{display:grid;grid-template-columns:1fr;gap:0.5rem;margin-top:1rem}
+.actions a{display:block;padding:0.6rem 1rem;color:#00ff55;border:1px solid #00dd44;text-decoration:none;font-size:0.88rem;text-align:left}
 .actions a:hover{background:rgba(0,221,68,0.1)}
-</style></head>
-<body><div>
-<h1>✓ Accès activé</h1>
-<p>Tu peux maintenant naviguer.</p>
-<p class="mac">{{ mac_hash }}</p>
-{% if r2_enabled %}<p>Inspection R2 en cours pour analyse compromission.</p>{% endif %}
-<div class="actions">
-  <a href="/report/me/html">📊 Mon analyse live (auto-refresh)</a>
-  <a href="/report/me">📄 Télécharger mon rapport (PDF)</a>
-  <a href="/ca/install-help">📜 Installer le certificat</a>
-  <a href="/ca/webclip-cabine.mobileconfig">📱 Ajouter icône iPhone (1-tap)</a>
+.foot{margin-top:1.2rem;font-size:0.7rem;color:#444;text-align:center;border-top:1px solid #222;padding-top:0.7rem}
+</style></head><body>
+<div class="card">
+<h1>✓ ACCÈS ACTIVÉ</h1>
+<div style="text-align:center">
+{% if level == 'r0' %}
+  <span class="lvl lvl-r0">🌐 R0 — Accès simple</span>
+  <p>Tu surfes en mode <b>réseau seul</b>, aucune analyse. Bonne navigation.</p>
+{% elif level == 'r2' %}
+  <span class="lvl lvl-r2">🔍 R2 — Analyse + bandeau</span>
+  <p>Inspection R2 active : <b>bandeau Safari + QUIC drop</b>. Si iCloud/Push lent, repasse en R1.</p>
+{% else %}
+  <span class="lvl lvl-r1">🛡 R1 — Analyse passive</span>
+  <p>Analyse en arrière-plan, <b>aucun impact</b> sur ta navigation. Rapport disponible 24h.</p>
+{% endif %}
 </div>
-<p style="margin-top:1rem;font-size:0.7rem">// VILLAGE3B · Gondwana</p>
+
+<a href="https://duckduckgo.com" class="go-surf">🚀 COMMENCE À SURFER</a>
+
+<p class="subtle">// Hash session : <span class="mac">{{ mac_hash }}</span></p>
+
+<div class="actions">
+  <a href="/report/me/html">📊 Mon analyse live (auto-refresh 15s)</a>
+  <a href="/report/me">📄 Télécharger mon rapport PDF</a>
+  {% if level in ('r1', 'r2') %}
+  <a href="/ca/install-help">📜 Installer le certificat (R2 only)</a>
+  {% endif %}
+  <a href="/ca/webclip-cabine.mobileconfig">📱 Ajouter icône ToolBoX sur écran d'accueil</a>
+</div>
+
+<p class="foot">// VILLAGE3B · Gondwana ToolBoX · CyberMind</p>
 </div></body></html>

--- a/packages/secubox-toolbox/conf/success.html.j2
+++ b/packages/secubox-toolbox/conf/success.html.j2
@@ -21,6 +21,7 @@ p{color:#006622;margin:0.4rem 0}
   <a href="/report/me/html">📊 Mon analyse live (auto-refresh)</a>
   <a href="/report/me">📄 Télécharger mon rapport (PDF)</a>
   <a href="/ca/install-help">📜 Installer le certificat</a>
+  <a href="/ca/webclip-cabine.mobileconfig">📱 Ajouter icône iPhone (1-tap)</a>
 </div>
 <p style="margin-top:1rem;font-size:0.7rem">// VILLAGE3B · Gondwana</p>
 </div></body></html>

--- a/packages/secubox-toolbox/conf/success.html.j2
+++ b/packages/secubox-toolbox/conf/success.html.j2
@@ -40,7 +40,19 @@ p{color:#a8b6a8;margin:0.5rem 0;text-align:center;font-size:0.9rem}
 {% endif %}
 </div>
 
-<a href="https://duckduckgo.com" class="go-surf">🚀 COMMENCE À SURFER</a>
+{# Phase 3 (#492) : iOS captive-sheet aware. Linking directly to
+   https://duckduckgo.com gets intercepted by iOS captive UI which doesn't
+   navigate. Linking to the Apple captive probe lets iOS verify connectivity
+   and CLOSE the captive sheet automatically — user lands in Safari. #}
+<a href="http://captive.apple.com/hotspot-detect.html"
+   target="_blank" rel="noopener"
+   class="go-surf"
+   onclick="setTimeout(function(){window.location.href='https://duckduckgo.com';}, 500);">
+   🚀 COMMENCE À SURFER
+</a>
+<p style="font-size:0.7rem;color:#444;text-align:center;margin-top:-0.5rem">
+  ↑ ferme la page captive et ouvre Safari · ou utilise ton navigateur directement
+</p>
 
 <p class="subtle">// Hash session : <span class="mac">{{ mac_hash }}</span></p>
 

--- a/packages/secubox-toolbox/conf/webclip.mobileconfig.j2
+++ b/packages/secubox-toolbox/conf/webclip.mobileconfig.j2
@@ -1,0 +1,53 @@
+{# SPDX-License-Identifier: LicenseRef-CMSD-1.0 #}
+{# iOS webclip — adds "ToolBoX Cabine" home-screen icon pointing at /report/me/html #}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>PayloadType</key>
+    <string>Configuration</string>
+    <key>PayloadVersion</key>
+    <integer>1</integer>
+    <key>PayloadIdentifier</key>
+    <string>fr.cybermind.gondwana.toolbox.webclip</string>
+    <key>PayloadUUID</key>
+    <string>{{ payload_uuid }}</string>
+    <key>PayloadDisplayName</key>
+    <string>ToolBoX Cabine — icône d'accueil</string>
+    <key>PayloadDescription</key>
+    <string>Ajoute une icône "ToolBoX Cabine" à ton écran d'accueil iPhone pour accéder en 1 tap au rapport live de ta session VILLAGE3B.</string>
+    <key>PayloadOrganization</key>
+    <string>CyberMind / Gondwana</string>
+    <key>PayloadRemovalDisallowed</key>
+    <false/>
+    <key>PayloadContent</key>
+    <array>
+        <dict>
+            <key>PayloadType</key>
+            <string>com.apple.webClip.managed</string>
+            <key>PayloadVersion</key>
+            <integer>1</integer>
+            <key>PayloadIdentifier</key>
+            <string>fr.cybermind.gondwana.toolbox.webclip.icon</string>
+            <key>PayloadUUID</key>
+            <string>{{ webclip_uuid }}</string>
+            <key>PayloadDisplayName</key>
+            <string>ToolBoX Cabine</string>
+            <key>PayloadDescription</key>
+            <string>Rapport live VILLAGE3B</string>
+            <key>URL</key>
+            <string>{{ report_url }}</string>
+            <key>Label</key>
+            <string>📡 ToolBoX</string>
+            <key>FullScreen</key>
+            <true/>
+            <key>IsRemovable</key>
+            <true/>
+            <key>Precomposed</key>
+            <false/>
+            <key>IgnoreManifestScope</key>
+            <true/>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/packages/secubox-toolbox/conf/whitelist-baseline.yaml
+++ b/packages/secubox-toolbox/conf/whitelist-baseline.yaml
@@ -218,6 +218,262 @@ whitelist:
     category: vendor-os
     quality_expected: A
 
+  # ───────────── Banking FR additional (neobanks + extras) ─────────────
+  - pattern: "*.boursorama-banque.com"
+    reason: "Banking neobank FR"
+    category: financial
+    quality_expected: A
+  - pattern: "*.hellobank.fr"
+    reason: "Banking FR"
+    category: financial
+    quality_expected: A
+  - pattern: "*.bforbank.com"
+    reason: "Banking neobank FR"
+    category: financial
+    quality_expected: A
+  - pattern: "*.n26.com"
+    reason: "Banking neobank EU"
+    category: financial
+    quality_expected: A+
+  - pattern: "*.wise.com"
+    reason: "Money transfer service (Wise/Transferwise)"
+    category: financial
+    quality_expected: A+
+  - pattern: "*.monzo.com"
+    reason: "Banking neobank"
+    category: financial
+    quality_expected: A+
+  - pattern: "*.ing.fr"
+    reason: "Banking FR (ING)"
+    category: financial
+    quality_expected: A
+  - pattern: "*.traderepublic.com"
+    reason: "Brokerage EU"
+    category: financial
+    quality_expected: A+
+  - pattern: "*.binance.com"
+    reason: "Crypto exchange (cert-pinned)"
+    category: financial
+    quality_expected: A
+  - pattern: "*.kraken.com"
+    reason: "Crypto exchange (cert-pinned)"
+    category: financial
+    quality_expected: A+
+  - pattern: "*.coinbase.com"
+    reason: "Crypto exchange (cert-pinned)"
+    category: financial
+    quality_expected: A+
+
+  # ───────────── Streaming media (cert-pinned, MITM would break playback) ─────────────
+  - pattern: "*.netflix.com"
+    reason: "Netflix streaming, cert-pinned + DRM"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.nflximg.net"
+    reason: "Netflix CDN"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.nflxvideo.net"
+    reason: "Netflix video CDN"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.disneyplus.com"
+    reason: "Disney+ streaming"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.spotify.com"
+    reason: "Spotify cert-pinned"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.scdn.co"
+    reason: "Spotify CDN"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.deezer.com"
+    reason: "Deezer streaming FR"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.canalplus.com"
+    reason: "Canal+ streaming FR"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.mycanal.fr"
+    reason: "MyCanal streaming FR"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.france.tv"
+    reason: "France Télévisions (public broadcasting)"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.arte.tv"
+    reason: "Arte (public broadcasting FR/DE)"
+    category: streaming-media
+    quality_expected: A+
+  - pattern: "*.youtube.com"
+    reason: "YouTube cert-pinned, DRM video"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.googlevideo.com"
+    reason: "YouTube video CDN"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.ytimg.com"
+    reason: "YouTube static CDN"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.twitch.tv"
+    reason: "Twitch live streaming, cert-pinned"
+    category: streaming-media
+    quality_expected: A
+  - pattern: "*.amazonvideo.com"
+    reason: "Amazon Prime Video"
+    category: streaming-media
+    quality_expected: A
+
+  # ───────────── Productivity / Education FR ─────────────
+  - pattern: "*.pronote.net"
+    reason: "Pronote ENT scolaire FR"
+    category: education
+    quality_expected: A
+  - pattern: "*.index-education.net"
+    reason: "Pronote operator"
+    category: education
+    quality_expected: A
+  - pattern: "*.ecoledirecte.com"
+    reason: "Ecole Directe ENT scolaire FR"
+    category: education
+    quality_expected: A
+  - pattern: "*.ent.unice.fr"
+    reason: "ENT universitaire FR"
+    category: education
+    quality_expected: A
+  - pattern: "*.cned.fr"
+    reason: "CNED enseignement à distance FR"
+    category: education
+    quality_expected: A
+  - pattern: "*.maiia.com"
+    reason: "Telemedicine FR (Cegedim)"
+    category: health
+    quality_expected: A
+  - pattern: "*.livi.fr"
+    reason: "Telemedicine FR (Livi)"
+    category: health
+    quality_expected: A
+
+  # ───────────── Workplace SaaS (cert-pinned) ─────────────
+  - pattern: "*.office.com"
+    reason: "Microsoft Office365"
+    category: workplace
+    quality_expected: A
+  - pattern: "*.live.com"
+    reason: "Microsoft accounts"
+    category: workplace
+    quality_expected: A
+  - pattern: "*.office365.com"
+    reason: "Microsoft Office365"
+    category: workplace
+    quality_expected: A
+  - pattern: "*.sharepoint.com"
+    reason: "Microsoft SharePoint"
+    category: workplace
+    quality_expected: A
+  - pattern: "*.slack.com"
+    reason: "Slack messaging"
+    category: workplace
+    quality_expected: A
+  - pattern: "*.zoom.us"
+    reason: "Zoom videoconference"
+    category: workplace
+    quality_expected: A
+  - pattern: "*.teams.microsoft.com"
+    reason: "Microsoft Teams"
+    category: workplace
+    quality_expected: A
+  - pattern: "*.salesforce.com"
+    reason: "Salesforce CRM"
+    category: workplace
+    quality_expected: A
+  - pattern: "*.atlassian.com"
+    reason: "Atlassian (Jira, Confluence)"
+    category: workplace
+    quality_expected: A
+  - pattern: "*.notion.so"
+    reason: "Notion workspace"
+    category: workplace
+    quality_expected: A
+  - pattern: "*.dropbox.com"
+    reason: "Dropbox cloud sync"
+    category: workplace
+    quality_expected: A
+  - pattern: "*.box.com"
+    reason: "Box.com cloud"
+    category: workplace
+    quality_expected: A
+  - pattern: "*.adobe.com"
+    reason: "Adobe Creative Cloud"
+    category: workplace
+    quality_expected: A
+
+  # ───────────── Gaming (cert-pinned, DRM, online auth) ─────────────
+  - pattern: "*.steamcommunity.com"
+    reason: "Steam community + downloads"
+    category: gaming
+    quality_expected: A
+  - pattern: "*.steampowered.com"
+    reason: "Steam infrastructure"
+    category: gaming
+    quality_expected: A
+  - pattern: "*.epicgames.com"
+    reason: "Epic Games"
+    category: gaming
+    quality_expected: A
+  - pattern: "*.ea.com"
+    reason: "Electronic Arts"
+    category: gaming
+    quality_expected: A
+  - pattern: "*.battle.net"
+    reason: "Blizzard Battle.net"
+    category: gaming
+    quality_expected: A
+  - pattern: "*.playstation.com"
+    reason: "PlayStation Network"
+    category: gaming
+    quality_expected: A
+  - pattern: "*.xbox.com"
+    reason: "Xbox Live"
+    category: gaming
+    quality_expected: A
+  - pattern: "*.xboxlive.com"
+    reason: "Xbox Live infrastructure"
+    category: gaming
+    quality_expected: A
+  - pattern: "*.nintendo.net"
+    reason: "Nintendo online services"
+    category: gaming
+    quality_expected: A
+  - pattern: "*.discord.com"
+    reason: "Discord (gaming chat, cert-pinned)"
+    category: gaming
+    quality_expected: A
+  - pattern: "*.discord.gg"
+    reason: "Discord invite domain"
+    category: gaming
+    quality_expected: A
+
+  # ───────────── DNS-over-HTTPS resolvers ─────────────
+  - pattern: "*.cloudflare-dns.com"
+    reason: "Cloudflare DoH/DoT resolver"
+    category: privacy-tools
+    quality_expected: A+
+  - pattern: "*.dns.google"
+    reason: "Google DoH/DoT resolver"
+    category: privacy-tools
+    quality_expected: A+
+  - pattern: "*.nextdns.io"
+    reason: "NextDNS DoH/DoT resolver"
+    category: privacy-tools
+    quality_expected: A+
+
   # ───────────── Captive portal probes (must reach the portal itself, not internet) ─────────────
   # NOTE : these probes are HANDLED locally by the captive splash, never reach
   # this whitelist. Listed here for documentation.

--- a/packages/secubox-toolbox/conf/whitelist-baseline.yaml
+++ b/packages/secubox-toolbox/conf/whitelist-baseline.yaml
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# CyberMind ToolBoX Whitelist baseline (#492)
+#
+# This file is installed to /usr/share/secubox/toolbox/whitelist-baseline.yaml
+# and reloaded automatically when modified. To override or extend without
+# touching this file, edit /etc/secubox/toolbox/whitelist.yaml (operator-owned,
+# survives upgrades).
+#
+# Each entry causes the matching FQDN to BYPASS mitmproxy inspection. The
+# cabine reports the bypass in the user-facing /report : honesty over
+# magic-numbers. Quality scoring continues passively (TLS version, JA4).
+
+whitelist:
+
+  # ───────────── Apple ecosystem (cert-pinning ubiquitous) ─────────────
+  - pattern: "*.push.apple.com"
+    reason: "Apple Push Notifications cert-pinned, no MITM possible"
+    category: vendor-os
+    quality_expected: A+
+  - pattern: "*.icloud.com"
+    reason: "Apple iCloud cert-pinned"
+    category: vendor-os
+    quality_expected: A+
+  - pattern: "*.apple.com"
+    reason: "Apple infrastructure (incl. itunes, mzstatic, appstore)"
+    category: vendor-os
+    quality_expected: A+
+  - pattern: "*.aaplimg.com"
+    reason: "Apple CDN"
+    category: vendor-os
+    quality_expected: A
+  - pattern: "*.cdn-apple.com"
+    reason: "Apple CDN"
+    category: vendor-os
+    quality_expected: A
+  - pattern: "*.mzstatic.com"
+    reason: "Apple iTunes/Store CDN"
+    category: vendor-os
+    quality_expected: A
+  - pattern: "smoot.apple.com"
+    reason: "Apple Search/Siri"
+    category: vendor-os
+    quality_expected: A+
+  - pattern: "*.apple-cloudkit.com"
+    reason: "Apple CloudKit"
+    category: vendor-os
+    quality_expected: A+
+
+  # ───────────── Google / Android OS ─────────────
+  - pattern: "*.googleapis.com"
+    reason: "Google APIs, cert-pinned for FCM/auth"
+    category: vendor-os
+    quality_expected: A+
+  - pattern: "*.gstatic.com"
+    reason: "Google CDN"
+    category: vendor-os
+    quality_expected: A
+  - pattern: "fcm.googleapis.com"
+    reason: "Firebase Cloud Messaging, cert-pinned"
+    category: vendor-os
+    quality_expected: A+
+  - pattern: "android.googleapis.com"
+    reason: "Android OS services, cert-pinned"
+    category: vendor-os
+    quality_expected: A+
+  - pattern: "play.googleapis.com"
+    reason: "Google Play Services"
+    category: vendor-os
+    quality_expected: A+
+
+  # ───────────── Messaging E2E (transport-only observation OK) ─────────────
+  - pattern: "*.signal.org"
+    reason: "Signal E2E messenger, content opaque by design"
+    category: messaging-e2e
+    quality_expected: A+
+  - pattern: "*.whispersystems.org"
+    reason: "Signal infrastructure"
+    category: messaging-e2e
+    quality_expected: A+
+  - pattern: "*.threema.ch"
+    reason: "Threema E2E"
+    category: messaging-e2e
+    quality_expected: A+
+  - pattern: "*.simplex.chat"
+    reason: "SimpleX E2E"
+    category: messaging-e2e
+    quality_expected: A+
+
+  # ───────────── Banking FR (CSPN policy : ne JAMAIS MITM la banque) ─────────────
+  - pattern: "*.banque-postale.fr"
+    reason: "Banking, MITM forbidden by ToolBoX policy"
+    category: financial
+    quality_expected: A
+  - pattern: "*.societegenerale.fr"
+    reason: "Banking, MITM forbidden by ToolBoX policy"
+    category: financial
+    quality_expected: A
+  - pattern: "*.bnpparibas.com"
+    reason: "Banking, MITM forbidden by ToolBoX policy"
+    category: financial
+    quality_expected: A
+  - pattern: "*.credit-agricole.fr"
+    reason: "Banking, MITM forbidden by ToolBoX policy"
+    category: financial
+    quality_expected: A
+  - pattern: "*.creditmutuel.fr"
+    reason: "Banking, MITM forbidden by ToolBoX policy"
+    category: financial
+    quality_expected: A
+  - pattern: "*.lcl.fr"
+    reason: "Banking, MITM forbidden by ToolBoX policy"
+    category: financial
+    quality_expected: A
+  - pattern: "*.boursorama.com"
+    reason: "Banking, MITM forbidden by ToolBoX policy"
+    category: financial
+    quality_expected: A
+  - pattern: "*.revolut.com"
+    reason: "Banking (neobank), MITM forbidden"
+    category: financial
+    quality_expected: A+
+
+  # ───────────── Government FR (sensitive citizen data) ─────────────
+  - pattern: "*.service-public.fr"
+    reason: "French government services, MITM forbidden"
+    category: government
+    quality_expected: A
+  - pattern: "*.impots.gouv.fr"
+    reason: "French tax service, MITM forbidden"
+    category: government
+    quality_expected: A
+  - pattern: "*.ameli.fr"
+    reason: "French healthcare, MITM forbidden"
+    category: government
+    quality_expected: A
+  - pattern: "*.france-identite.gouv.fr"
+    reason: "French digital identity, MITM forbidden"
+    category: government
+    quality_expected: A+
+  - pattern: "*.francetravail.fr"
+    reason: "French employment service"
+    category: government
+    quality_expected: A
+  - pattern: "*.caf.fr"
+    reason: "French family allowance"
+    category: government
+    quality_expected: A
+
+  # ───────────── Health (medical confidentiality) ─────────────
+  - pattern: "*.doctolib.fr"
+    reason: "Healthcare booking, medical confidentiality"
+    category: health
+    quality_expected: A
+  - pattern: "*.qare.fr"
+    reason: "Telemedicine, MITM forbidden"
+    category: health
+    quality_expected: A
+  - pattern: "monespacesante.fr"
+    reason: "French shared health record"
+    category: health
+    quality_expected: A+
+
+  # ───────────── Privacy-respecting search / DNS / VPN ─────────────
+  - pattern: "*.duckduckgo.com"
+    reason: "Privacy-respecting search"
+    category: privacy-tools
+    quality_expected: A+
+  - pattern: "*.qwant.com"
+    reason: "Privacy-respecting search FR"
+    category: privacy-tools
+    quality_expected: A
+  - pattern: "*.startpage.com"
+    reason: "Privacy-respecting search"
+    category: privacy-tools
+    quality_expected: A+
+  - pattern: "*.proton.me"
+    reason: "Proton (mail/VPN/drive), MITM forbidden"
+    category: privacy-tools
+    quality_expected: A+
+  - pattern: "*.protonmail.com"
+    reason: "Proton Mail legacy domain"
+    category: privacy-tools
+    quality_expected: A+
+  - pattern: "*.tutanota.com"
+    reason: "Tutanota E2E mail"
+    category: privacy-tools
+    quality_expected: A+
+  - pattern: "*.mullvad.net"
+    reason: "Mullvad VPN, MITM forbidden"
+    category: privacy-tools
+    quality_expected: A+
+  - pattern: "*.tailscale.com"
+    reason: "Tailscale mesh, control plane"
+    category: privacy-tools
+    quality_expected: A+
+
+  # ───────────── Tor (opaque by design + MITM impossible) ─────────────
+  - pattern: "*.torproject.org"
+    reason: "Tor Project (downloads + bridges)"
+    category: anon-network
+    quality_expected: A+
+
+  # ───────────── OS critical updates ─────────────
+  - pattern: "*.windowsupdate.com"
+    reason: "Windows Update infrastructure"
+    category: vendor-os
+    quality_expected: A
+  - pattern: "*.microsoft.com"
+    reason: "Microsoft services (Office365/Auth)"
+    category: vendor-os
+    quality_expected: A
+  - pattern: "*.debian.org"
+    reason: "Debian package repositories"
+    category: vendor-os
+    quality_expected: A
+  - pattern: "*.ubuntu.com"
+    reason: "Ubuntu package repositories"
+    category: vendor-os
+    quality_expected: A
+
+  # ───────────── Captive portal probes (must reach the portal itself, not internet) ─────────────
+  # NOTE : these probes are HANDLED locally by the captive splash, never reach
+  # this whitelist. Listed here for documentation.
+  # - pattern: "captive.apple.com"
+  # - pattern: "connectivitycheck.gstatic.com"
+  # - pattern: "www.msftconnecttest.com"

--- a/packages/secubox-toolbox/debian/control
+++ b/packages/secubox-toolbox/debian/control
@@ -28,6 +28,7 @@ Depends: ${misc:Depends}, ${python3:Depends},
  adduser,
  fonts-dejavu-core,
  fonts-symbola,
+ fonts-noto-color-emoji,
  python3-yaml,
  python3-geoip2 | geoipupdate
 Description: SecuBox-DEB ToolBoX — Gondwana Cabine Numérique (captive AP + MITM analyzer)

--- a/packages/secubox-toolbox/debian/control
+++ b/packages/secubox-toolbox/debian/control
@@ -25,7 +25,11 @@ Depends: ${misc:Depends}, ${python3:Depends},
  dnsmasq,
  mitmproxy,
  openssl,
- adduser
+ adduser,
+ fonts-dejavu-core,
+ fonts-symbola,
+ python3-yaml,
+ python3-geoip2 | geoipupdate
 Description: SecuBox-DEB ToolBoX — Gondwana Cabine Numérique (captive AP + MITM analyzer)
  Phase 1 du parent #474 (ToolBoX Pipeline). Productionize le PoC captive
  portal en package dédié : splash + consent R2 + CA distribution iOS

--- a/packages/secubox-toolbox/mitmproxy_addons/inject_banner.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/inject_banner.py
@@ -294,6 +294,31 @@ def _banner_html_dynamic(sha1: str, ctx: dict, csp_strict: bool) -> bytes:
     return b"<script>" + js.encode("ascii") + b"</script>"
 
 
+# Phase 3 (#492) : level check — only inject banner for R2 opt-in clients
+try:
+    import sys as _sys
+    _sys.path.insert(0, "/usr/lib/secubox/toolbox")
+    from secubox_toolbox import store as _store_mod  # type: ignore
+    from _common import mac_hash_of  # type: ignore
+    _HAS_LEVEL = True
+except Exception:
+    _HAS_LEVEL = False
+
+
+def _client_level(flow) -> str:
+    """Returns 'r0' | 'r1' | 'r2'. Defaults 'r1' if lookup fails."""
+    if not _HAS_LEVEL:
+        return "r1"
+    try:
+        ip = flow.client_conn.peername[0] if flow.client_conn.peername else None
+        mh = mac_hash_of(ip)
+        if mh:
+            return _store_mod.get_client_level(mh)
+    except Exception:
+        pass
+    return "r1"
+
+
 class InjectBanner:
     def response(self, flow: http.HTTPFlow) -> None:
         if not flow.response:
@@ -302,6 +327,9 @@ class InjectBanner:
         if "text/html" not in ct.lower():
             return
         if flow.response.status_code < 200 or flow.response.status_code >= 400:
+            return
+        # Phase 3 (#492) : skip if client opted into R0/R1 only
+        if _client_level(flow) != "r2":
             return
         body = flow.response.content
         if body is None or _GUARD in body:

--- a/packages/secubox-toolbox/mitmproxy_addons/inject_banner.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/inject_banner.py
@@ -7,6 +7,11 @@ CSPN R2 requirement (CM-WALL-EGRESS-2026-06 §3) : transparency obligatoire.
 The user being inspected MUST see at all times that R2 inspection is active +
 be able to verify the CA fingerprint against their device trust store.
 
+Phase 3 (#492) : the banner is now data-rich per-site (status + quality grade
++ country flag + ASN + app emoji from secubox_core.classifiers), with CSP-
+aware fallback : strict-CSP sites get a JS-less HTML+style pill, lax sites
+get the interactive version.
+
 Skip non-HTML and non-200 responses. Idempotent (won't double-inject).
 """
 from __future__ import annotations
@@ -22,9 +27,28 @@ log = logging.getLogger("secubox.toolbox.banner")
 
 CA_PEM = Path("/etc/secubox/toolbox/ca/ca.pem")
 PORTAL_URL = "http://10.99.0.1:8088"
+REPORT_URL = "http://10.99.0.1:8088/report/me/html"
 
 _RE_BODY_CLOSE = re.compile(rb"</body\s*>", re.I)
 _GUARD = b"__GONDWANA_MITM_BANNER__"
+
+# Phase 3 classifiers (soft import : ToolBoX runs even if not deployed)
+try:
+    from secubox_core.classifiers import host_app as _host_app
+    from secubox_core.classifiers import security_quality as _sec_quality
+    from secubox_core import whitelist as _whitelist_mod
+    _HAS_CLASSIFIERS = True
+except ImportError:
+    _HAS_CLASSIFIERS = False
+
+# Geo lookup (toolbox-local, falls back gracefully)
+try:
+    import sys as _sys
+    _sys.path.insert(0, "/usr/lib/secubox/toolbox")
+    from secubox_toolbox import geo as _geo_mod  # type: ignore
+    _HAS_GEO = True
+except Exception:
+    _HAS_GEO = False
 
 
 def _ca_sha1() -> str:
@@ -33,7 +57,6 @@ def _ca_sha1() -> str:
             ["openssl", "x509", "-in", str(CA_PEM), "-noout", "-fingerprint", "-sha1"],
             capture_output=True, text=True, timeout=2, check=False,
         ).stdout
-        # Format: "sha1 Fingerprint=XX:YY:..."
         if "=" in out:
             return out.split("=", 1)[1].strip()
     except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -44,42 +67,211 @@ def _ca_sha1() -> str:
 _CA_SHA1 = _ca_sha1()
 
 
-def _banner_html(sha1: str) -> bytes:
-    """Render the injection payload — pure HTML+CSS+JS, no external resources."""
-    # Light/dark friendly amber theme. z-index max. Closable.
-    return (
-        b"<script>(function(){"
-        b"if(window." + _GUARD + b")return;window." + _GUARD + b"=1;"
-        b"function inject(){"
-        b"if(!document.body)return setTimeout(inject,30);"
-        b"var b=document.createElement('div');"
-        b"b.id='gondwana-mitm-banner';"
-        b"b.setAttribute('role','status');"
-        b"b.style.cssText='position:fixed!important;top:0!important;left:0!important;right:0!important;"
-        b"z-index:2147483647!important;background:linear-gradient(90deg,#ffb347,#9A6010)!important;"
-        b"color:#0a0a0f!important;font-family:Menlo,Consolas,monospace!important;"
-        b"padding:6px 12px!important;font-size:11px!important;line-height:1.4!important;"
-        b"border-bottom:2px solid #C04E24!important;box-shadow:0 2px 8px rgba(0,0,0,0.3)!important;"
-        b"text-align:left!important';"
-        b"b.innerHTML='<b style=\"color:#0a0a0f\">\\xf0\\x9f\\x93\\xa1 Gondwana ToolBoX \\xe2\\x80\\x94 R2 inspection ACTIVE</b>"
-        b" \\xc2\\xb7 CA SHA1: <code style=\"background:rgba(0,0,0,0.1);padding:1px 4px;border-radius:2px\">' + "
-        b"'" + sha1.encode() + b"' + '</code>"
-        b" \\xc2\\xb7 <a href=\"" + PORTAL_URL.encode() + b"\" style=\"color:#0a5840;text-decoration:underline;font-weight:bold\">Session info</a>"
-        b" \\xc2\\xb7 <a href=\"javascript:void(0)\" onclick=\"this.parentNode.style.display=\\'none\\'\" "
-        b"style=\"float:right;color:#0a0a0f;text-decoration:none;font-weight:bold\">[\\xc3\\x97]</a>';"
-        b"if(document.body.firstChild){document.body.insertBefore(b,document.body.firstChild);}"
-        b"else{document.body.appendChild(b);}"
-        b"document.body.style.paddingTop='28px';"
-        b"}"
-        b"if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',inject);}"
-        b"else{inject();}"
-        b"})();</script>"
-    )
+def _compute_site_context(flow: http.HTTPFlow) -> dict:
+    """Compute per-site signals for the dynamic right-side of the banner."""
+    host = (flow.request.host or "").lower()
+    ctx = {
+        "host": host[:50],
+        "app_emoji": "❔",
+        "app": host,
+        "grade": "?",
+        "grade_color": "#888",
+        "flag": "",
+        "country": "",
+        "asn": "",
+        "status": "inspected",
+        "status_icon": "🔍",
+    }
+    if not _HAS_CLASSIFIERS:
+        return ctx
+
+    # App classification
+    try:
+        cls = _host_app.classify_host(host)
+        ctx["app_emoji"] = cls.get("emoji", "❔")
+        ctx["app"] = cls.get("app", host) if cls.get("app") != "?" else host
+    except Exception:
+        pass
+
+    # Whitelist / status
+    try:
+        wl = _whitelist_mod.match(host)
+        if wl:
+            ctx["status"] = "bypassed-whitelist"
+            ctx["status_icon"] = "🛡"
+        # E2E pattern check (cheap)
+        elif re.search(r"\.(signal|whispersystems|threema|simplex|matrix|proton|tutanota)\.", host):
+            ctx["status"] = "e2e-opaque"
+            ctx["status_icon"] = "🔐"
+    except Exception:
+        pass
+
+    # Geo (flag + country + ASN)
+    if _HAS_GEO:
+        try:
+            info = _geo_mod.lookup(host) or {}
+            ctx["flag"] = info.get("flag", "")
+            ctx["country"] = info.get("country_iso", "")
+            ctx["asn"] = (info.get("asn_org") or "")[:24]
+        except Exception:
+            pass
+
+    # Quality grade (passive — we only see response headers + transport)
+    try:
+        # Detect TLS version from connection metadata if available
+        tls_v = None
+        if hasattr(flow, "server_conn") and hasattr(flow.server_conn, "tls_version"):
+            v = flow.server_conn.tls_version or ""
+            if "1.3" in v or "13" in v:
+                tls_v = "13"
+            elif "1.2" in v or "12" in v:
+                tls_v = "12"
+        is_e2e = ctx["status"] == "e2e-opaque"
+        if ctx["status"] == "inspected":
+            # Use active grading with response headers
+            cookies_attrs = []
+            for sc in (flow.response.headers.get_all("set-cookie") or [])[:10]:
+                attrs = {"secure": "secure" in sc.lower(),
+                         "httponly": "httponly" in sc.lower(),
+                         "samesite": "strict" if "samesite=strict" in sc.lower()
+                                     else "lax" if "samesite=lax" in sc.lower() else None}
+                cookies_attrs.append(attrs)
+            g = _sec_quality.grade_active(
+                tls_version=tls_v or "13",  # mitm-decrypted ≥ TLS 1.2
+                sni=host,
+                headers=dict(flow.response.headers.items()),
+                cookies_attrs=cookies_attrs,
+            )
+        else:
+            g = _sec_quality.grade_passive(
+                tls_version=tls_v,
+                sni=host,
+                is_e2e_messaging=is_e2e,
+            )
+        ctx["grade"] = g.get("grade", "?")
+        if ctx["grade"] in ("A+", "A"):
+            ctx["grade_color"] = "#00cc44"
+        elif ctx["grade"] == "B":
+            ctx["grade_color"] = "#88cc00"
+        elif ctx["grade"] == "C":
+            ctx["grade_color"] = "#ffaa00"
+        else:
+            ctx["grade_color"] = "#ff4466"
+    except Exception:
+        pass
+
+    return ctx
+
+
+def _detect_csp_strict(flow: http.HTTPFlow) -> bool:
+    """Returns True if the site has a CSP that blocks inline scripts."""
+    csp = flow.response.headers.get("content-security-policy", "")
+    if not csp:
+        return False
+    csp_l = csp.lower()
+    # If CSP defines script-src but doesn't include 'unsafe-inline' or nonce
+    if "script-src" in csp_l or "default-src" in csp_l:
+        if "'unsafe-inline'" not in csp_l and "nonce-" not in csp_l:
+            return True
+    return False
+
+
+def _banner_html_dynamic(sha1: str, ctx: dict, csp_strict: bool) -> bytes:
+    """Render the injection payload.
+
+    Two flavors depending on CSP strictness :
+      - csp_strict=True  : pure HTML+inline-style, NO JS. Non-dismissible.
+      - csp_strict=False : JS-driven, dismissible, dynamic insertion.
+    """
+    # Compose the per-site right-side text
+    right_parts = [f"{ctx['status_icon']} {ctx['status']}"]
+    if ctx["flag"]:
+        right_parts.append(ctx["flag"])
+    if ctx["app_emoji"] and ctx["app"]:
+        right_parts.append(f"{ctx['app_emoji']} {ctx['app']}")
+    if ctx["asn"]:
+        right_parts.append(ctx["asn"])
+    right_text = " · ".join(right_parts)
+    grade = ctx["grade"]
+    grade_color = ctx["grade_color"]
+
+    if csp_strict:
+        # JS-less HTML banner — visible only, no close button, no padding-top hack.
+        # Uses position:fixed with inline styles (style-src 'unsafe-inline' usually allowed
+        # even when script-src is strict). If style-src is also strict, the banner becomes
+        # an unstyled inline block — still visible, just ugly.
+        html = (
+            f"<div id=\"gondwana-mitm-banner\" role=\"status\" "
+            f"style=\"position:fixed;top:0;left:0;right:0;z-index:2147483647;"
+            f"background:linear-gradient(90deg,#ffb347 60%,#0a0a0f 100%);"
+            f"color:#0a0a0f;font-family:Menlo,Consolas,monospace;"
+            f"padding:6px 12px;font-size:11px;line-height:1.4;"
+            f"border-bottom:2px solid #C04E24;text-align:left;"
+            f"display:flex;justify-content:space-between;align-items:center;gap:8px\">"
+            f"<span><b>📡 ToolBoX R2</b> · CA SHA1: "
+            f"<code style=\"background:rgba(0,0,0,0.1);padding:1px 4px;border-radius:2px\">{sha1[:23]}</code>"
+            f" · <span style=\"opacity:0.7;font-size:10px\">CSP-safe mode (no JS)</span></span>"
+            f"<span style=\"color:#e8e6d9;background:rgba(0,0,0,0.4);padding:3px 8px;border-radius:3px\">"
+            f"{right_text}"
+            f" · <b style=\"color:{grade_color};background:#0a0a0f;padding:1px 5px;border-radius:2px\">{grade}</b>"
+            f"</span></div>"
+        )
+        # Mark guard via HTML comment (CSP-safe — no script)
+        return (b"<!-- " + _GUARD + b" -->" + html.encode("utf-8"))
+
+    # Interactive JS version with full features
+    # Pre-encode the dynamic strings to JS-safe form
+    import json as _json
+    right_js = _json.dumps(right_text)
+    grade_js = _json.dumps(grade)
+    grade_col_js = _json.dumps(grade_color)
+    sha1_js = _json.dumps(sha1[:23])
+    report_js = _json.dumps(REPORT_URL)
+
+    js = f"""
+(function(){{
+  if(window.{_GUARD.decode()})return;
+  window.{_GUARD.decode()}=1;
+  function inject(){{
+    if(!document.body)return setTimeout(inject,30);
+    var b=document.createElement('div');
+    b.id='gondwana-mitm-banner';
+    b.setAttribute('role','status');
+    b.style.cssText='position:fixed!important;top:0!important;left:0!important;right:0!important;'+
+      'z-index:2147483647!important;'+
+      'background:linear-gradient(90deg,#ffb347 60%,#0a0a0f 100%)!important;'+
+      'color:#0a0a0f!important;font-family:Menlo,Consolas,monospace!important;'+
+      'padding:6px 12px!important;font-size:11px!important;line-height:1.4!important;'+
+      'border-bottom:2px solid #C04E24!important;box-shadow:0 2px 8px rgba(0,0,0,0.3)!important;'+
+      'text-align:left!important;display:flex!important;'+
+      'justify-content:space-between!important;align-items:center!important;gap:8px!important';
+    var rightText={right_js};
+    var grade={grade_js};
+    var gradeCol={grade_col_js};
+    var sha1={sha1_js};
+    var reportUrl={report_js};
+    b.innerHTML='<span><b>📡 ToolBoX R2</b> · CA SHA1: '+
+      '<code style=\"background:rgba(0,0,0,0.1);padding:1px 4px;border-radius:2px\">'+sha1+'</code>'+
+      ' · <a href=\"'+reportUrl+'\" style=\"color:#0a5840;text-decoration:underline;font-weight:bold\">Mon rapport</a></span>'+
+      '<span style=\"display:flex;align-items:center;gap:8px\">'+
+        '<span style=\"color:#e8e6d9;background:rgba(0,0,0,0.4);padding:3px 8px;border-radius:3px\">'+
+          rightText+' · <b style=\"color:'+gradeCol+';background:#0a0a0f;padding:1px 5px;border-radius:2px\">'+grade+'</b>'+
+        '</span>'+
+        '<a href=\"javascript:void(0)\" onclick=\"document.getElementById(\\'gondwana-mitm-banner\\').style.display=\\'none\\';document.body.style.paddingTop=0\" style=\"color:#0a0a0f;text-decoration:none;font-weight:bold;cursor:pointer\">[×]</a>'+
+      '</span>';
+    if(document.body.firstChild){{document.body.insertBefore(b,document.body.firstChild)}}
+    else{{document.body.appendChild(b)}}
+    document.body.style.paddingTop='32px';
+  }}
+  if(document.readyState==='loading'){{document.addEventListener('DOMContentLoaded',inject)}}
+  else{{inject()}}
+}})();
+""".strip()
+    return b"<script>" + js.encode("utf-8") + b"</script>"
 
 
 class InjectBanner:
     def response(self, flow: http.HTTPFlow) -> None:
-        # Guard rails
         if not flow.response:
             return
         ct = flow.response.headers.get("content-type", "")
@@ -87,18 +279,23 @@ class InjectBanner:
             return
         if flow.response.status_code < 200 or flow.response.status_code >= 400:
             return
-        # Skip if already injected (idempotent)
         body = flow.response.content
         if body is None or _GUARD in body:
             return
-        # Inject before </body>
         m = _RE_BODY_CLOSE.search(body)
         if not m:
             return
-        snippet = _banner_html(_CA_SHA1)
+        # Phase 3 : compute per-site context + CSP awareness
+        try:
+            ctx = _compute_site_context(flow)
+            csp_strict = _detect_csp_strict(flow)
+            snippet = _banner_html_dynamic(_CA_SHA1, ctx, csp_strict)
+        except Exception as e:
+            log.warning("banner compute failed for %s: %s", flow.request.host, e)
+            # Fail-open : skip injection rather than break the page
+            return
         new_body = body[: m.start()] + snippet + body[m.start():]
         flow.response.content = new_body
-        # Adjust Content-Length implicitly (mitmproxy handles it).
 
 
 addons = [InjectBanner()]

--- a/packages/secubox-toolbox/mitmproxy_addons/inject_banner.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/inject_banner.py
@@ -32,6 +32,25 @@ REPORT_URL = "http://10.99.0.1:8088/report/me/html"
 _RE_BODY_CLOSE = re.compile(rb"</body\s*>", re.I)
 _GUARD = b"__GONDWANA_MITM_BANNER__"
 
+
+def _ncr(s: str) -> str:
+    """Encode any non-ASCII char as HTML numeric character reference.
+
+    Why: pages with non-UTF-8 declared charset (legacy iso-8859-1) reinterpret
+    our injected raw UTF-8 emoji bytes as garbage. NCRs (&#xXXXX;) are
+    charset-agnostic — the browser decodes them after charset translation.
+
+    Use for HTML content (both CSP-strict HTML body and JS innerHTML).
+    """
+    out = []
+    for ch in s:
+        cp = ord(ch)
+        if cp < 0x80:
+            out.append(ch)
+        else:
+            out.append(f"&#x{cp:X};")
+    return "".join(out)
+
 # Phase 3 classifiers (soft import : ToolBoX runs even if not deployed)
 try:
     from secubox_core.classifiers import host_app as _host_app
@@ -183,23 +202,25 @@ def _banner_html_dynamic(sha1: str, ctx: dict, csp_strict: bool) -> bytes:
       - csp_strict=True  : pure HTML+inline-style, NO JS. Non-dismissible.
       - csp_strict=False : JS-driven, dismissible, dynamic insertion.
     """
-    # Compose the per-site right-side text
-    right_parts = [f"{ctx['status_icon']} {ctx['status']}"]
+    # Compose per-site right-side text. NCR-encode all emojis so the banner
+    # renders correctly regardless of page charset (some legacy pages declare
+    # iso-8859-1 which would mangle our raw UTF-8 emoji bytes).
+    right_parts = [f"{_ncr(ctx['status_icon'])} {ctx['status']}"]
     if ctx["flag"]:
-        right_parts.append(ctx["flag"])
+        right_parts.append(_ncr(ctx["flag"]))
     if ctx["app_emoji"] and ctx["app"]:
-        right_parts.append(f"{ctx['app_emoji']} {ctx['app']}")
+        right_parts.append(f"{_ncr(ctx['app_emoji'])} {_ncr(ctx['app'])}")
     if ctx["asn"]:
-        right_parts.append(ctx["asn"])
-    right_text = " · ".join(right_parts)
+        right_parts.append(_ncr(ctx["asn"]))
+    right_text = " &#xB7; ".join(right_parts)  # middle dot · = &#xB7;
     grade = ctx["grade"]
     grade_color = ctx["grade_color"]
+    # Static emojis used in the left-side text
+    SAT_EMOJI = "&#x1F4E1;"  # 📡 satellite dish
 
     if csp_strict:
         # JS-less HTML banner — visible only, no close button, no padding-top hack.
-        # Uses position:fixed with inline styles (style-src 'unsafe-inline' usually allowed
-        # even when script-src is strict). If style-src is also strict, the banner becomes
-        # an unstyled inline block — still visible, just ugly.
+        # NCRs work even when page charset is iso-8859-1.
         html = (
             f"<div id=\"gondwana-mitm-banner\" role=\"status\" "
             f"style=\"position:fixed;top:0;left:0;right:0;z-index:2147483647;"
@@ -208,25 +229,26 @@ def _banner_html_dynamic(sha1: str, ctx: dict, csp_strict: bool) -> bytes:
             f"padding:6px 12px;font-size:11px;line-height:1.4;"
             f"border-bottom:2px solid #C04E24;text-align:left;"
             f"display:flex;justify-content:space-between;align-items:center;gap:8px\">"
-            f"<span><b>📡 ToolBoX R2</b> · CA SHA1: "
+            f"<span><b>{SAT_EMOJI} ToolBoX R2</b> &#xB7; CA SHA1: "
             f"<code style=\"background:rgba(0,0,0,0.1);padding:1px 4px;border-radius:2px\">{sha1[:23]}</code>"
-            f" · <span style=\"opacity:0.7;font-size:10px\">CSP-safe mode (no JS)</span></span>"
+            f" &#xB7; <span style=\"opacity:0.7;font-size:10px\">CSP-safe mode (no JS)</span></span>"
             f"<span style=\"color:#e8e6d9;background:rgba(0,0,0,0.4);padding:3px 8px;border-radius:3px\">"
             f"{right_text}"
-            f" · <b style=\"color:{grade_color};background:#0a0a0f;padding:1px 5px;border-radius:2px\">{grade}</b>"
+            f" &#xB7; <b style=\"color:{grade_color};background:#0a0a0f;padding:1px 5px;border-radius:2px\">{grade}</b>"
             f"</span></div>"
         )
-        # Mark guard via HTML comment (CSP-safe — no script)
-        return (b"<!-- " + _GUARD + b" -->" + html.encode("utf-8"))
+        return (b"<!-- " + _GUARD + b" -->" + html.encode("ascii"))
 
-    # Interactive JS version with full features
-    # Pre-encode the dynamic strings to JS-safe form
+    # Interactive JS version. We assemble innerHTML with NCRs already in place
+    # so the resulting DOM text is charset-agnostic.
     import json as _json
-    right_js = _json.dumps(right_text)
+    right_js = _json.dumps(right_text)             # already NCR-encoded
     grade_js = _json.dumps(grade)
     grade_col_js = _json.dumps(grade_color)
     sha1_js = _json.dumps(sha1[:23])
     report_js = _json.dumps(REPORT_URL)
+    sat_js = _json.dumps(SAT_EMOJI)
+    mid_js = _json.dumps(" &#xB7; ")
 
     js = f"""
 (function(){{
@@ -250,14 +272,16 @@ def _banner_html_dynamic(sha1: str, ctx: dict, csp_strict: bool) -> bytes:
     var gradeCol={grade_col_js};
     var sha1={sha1_js};
     var reportUrl={report_js};
-    b.innerHTML='<span><b>📡 ToolBoX R2</b> · CA SHA1: '+
+    var SAT={sat_js};
+    var MID={mid_js};
+    b.innerHTML='<span><b>'+SAT+' ToolBoX R2</b>'+MID+'CA SHA1: '+
       '<code style=\"background:rgba(0,0,0,0.1);padding:1px 4px;border-radius:2px\">'+sha1+'</code>'+
-      ' · <a href=\"'+reportUrl+'\" style=\"color:#0a5840;text-decoration:underline;font-weight:bold\">Mon rapport</a></span>'+
+      MID+'<a href=\"'+reportUrl+'\" style=\"color:#0a5840;text-decoration:underline;font-weight:bold\">Mon rapport</a></span>'+
       '<span style=\"display:flex;align-items:center;gap:8px\">'+
         '<span style=\"color:#e8e6d9;background:rgba(0,0,0,0.4);padding:3px 8px;border-radius:3px\">'+
-          rightText+' · <b style=\"color:'+gradeCol+';background:#0a0a0f;padding:1px 5px;border-radius:2px\">'+grade+'</b>'+
+          rightText+MID+'<b style=\"color:'+gradeCol+';background:#0a0a0f;padding:1px 5px;border-radius:2px\">'+grade+'</b>'+
         '</span>'+
-        '<a href=\"javascript:void(0)\" onclick=\"document.getElementById(\\'gondwana-mitm-banner\\').style.display=\\'none\\';document.body.style.paddingTop=0\" style=\"color:#0a0a0f;text-decoration:none;font-weight:bold;cursor:pointer\">[×]</a>'+
+        '<a href=\"javascript:void(0)\" onclick=\"document.getElementById(\\'gondwana-mitm-banner\\').style.display=\\'none\\';document.body.style.paddingTop=0\" style=\"color:#0a0a0f;text-decoration:none;font-weight:bold;cursor:pointer\">[&#xD7;]</a>'+
       '</span>';
     if(document.body.firstChild){{document.body.insertBefore(b,document.body.firstChild)}}
     else{{document.body.appendChild(b)}}
@@ -267,7 +291,7 @@ def _banner_html_dynamic(sha1: str, ctx: dict, csp_strict: bool) -> bytes:
   else{{inject()}}
 }})();
 """.strip()
-    return b"<script>" + js.encode("utf-8") + b"</script>"
+    return b"<script>" + js.encode("ascii") + b"</script>"
 
 
 class InjectBanner:

--- a/packages/secubox-toolbox/mitmproxy_addons/local_store.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/local_store.py
@@ -33,6 +33,41 @@ SALT_FILE = Path("/etc/secubox/secrets/toolbox-mac-salt")
 _RE_MAC = re.compile(r"lladdr\s+([0-9a-f:]{17})", re.I)
 _SALT_CACHE: str | None = None
 
+# Phase 3 (#492) : analysis_status tagging on every event
+# Soft import : whitelist may not be installed yet (older boards)
+try:
+    from secubox_core import whitelist as _whitelist
+except Exception:
+    _whitelist = None
+
+# Known E2E SNI suffixes — content opaque by design
+_E2E_SNI_PATTERNS = re.compile(
+    r"(\.signal\.org|\.whispersystems\.org|\.threema\.|\.simplex\.|"
+    r"\.matrix\.org|\.proton\.me|\.protonmail\.|\.tutanota\.)$",
+    re.I,
+)
+
+
+def _analysis_status(host: str | None, sni: str | None, decrypted: bool) -> tuple[str, str]:
+    """Return (status, reason) for an observed flow.
+
+    Order :
+      1. decrypted -> inspected
+      2. whitelist match -> bypassed-whitelist + reason from yaml
+      3. E2E SNI pattern -> e2e-opaque
+      4. fallback -> pinned-failed-mitm
+    """
+    if decrypted:
+        return ("inspected", "MITM decryption succeeded via ToolBoX CA")
+    target = (sni or host or "").lower()
+    if _whitelist is not None and target:
+        m = _whitelist.match(target)
+        if m:
+            return ("bypassed-whitelist", m.get("reason", "whitelisted"))
+    if target and _E2E_SNI_PATTERNS.search(target):
+        return ("e2e-opaque", "E2E messenger : content opaque by design")
+    return ("pinned-failed-mitm", "TLS handshake failed (cert-pinning detected)")
+
 
 def _salt() -> str:
     global _SALT_CACHE
@@ -103,6 +138,9 @@ class LocalStore:
         if not mac_hash:
             return
         host = flow.request.host
+        sni = getattr(flow.client_conn, "sni", None)
+        # If we got here with a parsed request, decryption succeeded.
+        status, reason = _analysis_status(host, sni, decrypted=True)
         _insert(mac_hash, "dpi", {
             "client_ip": ip,
             "host": host,
@@ -110,6 +148,8 @@ class LocalStore:
             "method": flow.request.method,
             "path": flow.request.path[:200],
             "user_agent": flow.request.headers.get("user-agent"),
+            "analysis_status": status,
+            "analysis_reason": reason,
         })
 
     def response(self, flow: http.HTTPFlow) -> None:
@@ -159,6 +199,27 @@ class LocalStore:
                 "kind": "suspicious_host_pattern",
                 "weight": 15,
             })
+
+    def tls_failed_clienthello(self, data) -> None:
+        """Phase 3 (#492) : record cert-pinning / whitelisted bypasses.
+
+        Fires when TLS handshake fails (cert-pinning) OR when we deliberately
+        skipped MITM (whitelist). We log the SNI + status so the report can
+        be honest about what we didn't inspect.
+        """
+        ip = data.context.client.peername[0] if data.context.client.peername else None
+        mac_hash = _hash_mac(_mac_of(ip))
+        if not mac_hash:
+            return
+        sni = getattr(data.client_hello, "sni", None) if hasattr(data, "client_hello") else None
+        status, reason = _analysis_status(host=None, sni=sni, decrypted=False)
+        _insert(mac_hash, "dpi", {
+            "client_ip": ip,
+            "host": sni or "?",
+            "sni": sni,
+            "analysis_status": status,
+            "analysis_reason": reason,
+        })
 
     def tls_clienthello(self, data) -> None:
         ip = data.context.client.peername[0] if data.context.client.peername else None

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -97,17 +97,16 @@ async def splash(request: Request):
         "Pragma": "no-cache",
     }
 
-    # Phase 3 (#492) : if already validated, send user to the dashboard which
-    # has the level switcher + cert card + transparency metrics. The previous
-    # 'success.html.j2 fallback' was a stale dead-end that did NOT show the
-    # new cert card auto-check.
-    validated = bool(mac and nft.is_validated(mac))
-    if validated:
-        from fastapi.responses import RedirectResponse
-        return RedirectResponse(url="/report/me/html", status_code=303,
-                                 headers=no_cache_headers)
+    # Phase 3 (#492) : ALWAYS render splash on GET /. Even validated users
+    # benefit from seeing the cert install buttons + level switcher + dashboard
+    # link. Auto-redirect was hiding the cert links from users who already
+    # validated — they had no path back to the install buttons.
     html = _env.get_template("splash.html.j2").render(
-        mac_hash=mac_hash or "??", ssid=cfg.ap.ssid, r2_enabled=cfg.r2.enabled,
+        mac_hash=mac_hash or "??",
+        ssid=cfg.ap.ssid,
+        r2_enabled=cfg.r2.enabled,
+        already_validated=bool(mac and nft.is_validated(mac)),
+        current_level=store.get_client_level(mac_hash) if mac_hash else None,
     )
     return HTMLResponse(html, headers=no_cache_headers)
 

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -104,6 +104,15 @@ async def splash(request: Request) -> HTMLResponse:
 
 @router.post("/accept", response_model=AcceptResp)
 async def accept(request: Request) -> AcceptResp:
+    """Phase 3 (#492) : 3-level explicit opt-in.
+
+    Form field 'level' = 'r0' | 'r1' | 'r2' (default 'r1' for backward compat
+    with bare-button submission). Each level adds the MAC to incremental nft
+    sets and persists the level in the clients table.
+      r0 = validated only (net access, no inspection)
+      r1 = r0 + consented_r2_macs (MITM enabled, passive analysis only)
+      r2 = r1 + r2_banner_macs (banner injection + QUIC drop)
+    """
     ip, mac = _resolve(request)
     if not ip or not mac:
         raise HTTPException(400, "client mac unknown")
@@ -111,16 +120,33 @@ async def accept(request: Request) -> AcceptResp:
     salt = _get_salt()
     mac_hash = macmod.hash_mac(mac, salt)
 
+    # Parse level from POST body — accept form-urlencoded or fallback to r1
+    try:
+        form = await request.form()
+        level = (form.get("level") or "r1").lower()
+    except Exception:
+        level = "r1"
+    if level not in ("r0", "r1", "r2"):
+        level = "r1"
+    # R2 only allowed if config enables it
+    if level == "r2" and not cfg.r2.enabled:
+        level = "r1"
+
+    # All levels get validated (net access)
     if not nft.add_validated(mac, ttl="24h"):
         raise HTTPException(500, "nft add validated failed")
+
     r2_ok = False
-    if cfg.r2.enabled and nft.add_consented(mac, ttl="24h"):
+    if level in ("r1", "r2") and nft.add_consented(mac, ttl="24h"):
         r2_ok = True
+    # R2-only : QUIC drop + banner injection (separate nft set)
+    if level == "r2":
+        nft.add_r2_banner(mac, ttl="24h")
 
     ua = request.headers.get("user-agent", "")
     store.record_consent(mac_hash, ip, ua, ttl_seconds=86400)
-    store.upsert_client(mac_hash, ip)
-    log.info("consent recorded mac_hash=%s r2=%s", mac_hash, r2_ok)
+    store.upsert_client(mac_hash, ip, level=level)
+    log.info("consent recorded mac_hash=%s level=%s r2=%s", mac_hash, level, r2_ok)
     return AcceptResp(ok=True, mac_hash=mac_hash, r2=r2_ok)
 
 

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -102,8 +102,8 @@ async def splash(request: Request) -> HTMLResponse:
     ))
 
 
-@router.post("/accept", response_model=AcceptResp)
-async def accept(request: Request) -> AcceptResp:
+@router.post("/accept")
+async def accept(request: Request):
     """Phase 3 (#492) : 3-level explicit opt-in.
 
     Form field 'level' = 'r0' | 'r1' | 'r2' (default 'r1' for backward compat
@@ -147,7 +147,15 @@ async def accept(request: Request) -> AcceptResp:
     store.record_consent(mac_hash, ip, ua, ttl_seconds=86400)
     store.upsert_client(mac_hash, ip, level=level)
     log.info("consent recorded mac_hash=%s level=%s r2=%s", mac_hash, level, r2_ok)
-    return AcceptResp(ok=True, mac_hash=mac_hash, r2=r2_ok)
+    # Phase 3 (#492) : detect whether the call came from a browser form (HTML
+    # response = render success page) vs from a programmatic API client (JSON).
+    accept_hdr = request.headers.get("accept", "")
+    wants_json = "application/json" in accept_hdr and "text/html" not in accept_hdr
+    if wants_json:
+        return AcceptResp(ok=True, mac_hash=mac_hash, r2=r2_ok)
+    return HTMLResponse(_env.get_template("success.html.j2").render(
+        mac_hash=mac_hash, r2_enabled=cfg.r2.enabled, level=level,
+    ))
 
 
 @router.get("/status", response_model=StatusResp)

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -147,15 +147,66 @@ async def accept(request: Request):
     store.record_consent(mac_hash, ip, ua, ttl_seconds=86400)
     store.upsert_client(mac_hash, ip, level=level)
     log.info("consent recorded mac_hash=%s level=%s r2=%s", mac_hash, level, r2_ok)
-    # Phase 3 (#492) : detect whether the call came from a browser form (HTML
-    # response = render success page) vs from a programmatic API client (JSON).
+    # Phase 3 (#492) : detect form-vs-API.
+    # Browser : 303 redirect straight to the dashboard with welcome state.
+    # API     : JSON AcceptResp for programmatic clients.
     accept_hdr = request.headers.get("accept", "")
     wants_json = "application/json" in accept_hdr and "text/html" not in accept_hdr
     if wants_json:
         return AcceptResp(ok=True, mac_hash=mac_hash, r2=r2_ok)
-    return HTMLResponse(_env.get_template("success.html.j2").render(
-        mac_hash=mac_hash, r2_enabled=cfg.r2.enabled, level=level,
-    ))
+    from fastapi.responses import RedirectResponse
+    return RedirectResponse(url=f"/report/me/html?welcome=1&level={level}",
+                             status_code=303)
+
+
+@router.post("/change-level")
+async def change_level(request: Request):
+    """Phase 3 (#492) : change opt-in level from the dashboard.
+
+    Adds/removes the MAC from the appropriate nft sets and updates the
+    persisted level. Redirects back to /report/me/html.
+    """
+    ip, mac = _resolve(request)
+    if not ip or not mac:
+        raise HTTPException(400, "client mac unknown")
+    cfg = _get_cfg()
+    salt = _get_salt()
+    mac_hash = macmod.hash_mac(mac, salt)
+
+    try:
+        form = await request.form()
+        level = (form.get("level") or "r1").lower()
+    except Exception:
+        level = "r1"
+    if level not in ("r0", "r1", "r2"):
+        level = "r1"
+    if level == "r2" and not cfg.r2.enabled:
+        level = "r1"
+
+    # Re-validate (idempotent extend)
+    nft.add_validated(mac, ttl="24h")
+    # Membership in consented_r2_macs : add for r1/r2, remove for r0
+    if level in ("r1", "r2"):
+        nft.add_consented(mac, ttl="24h")
+    else:
+        try:
+            nft.del_validated  # name-check
+            from . import nft as _nft
+            _nft._run(_nft.NFT, "delete", "element", "inet", "toolbox",
+                      "consented_r2_macs", "{ " + mac + " }")
+        except Exception:
+            pass
+    # Membership in r2_banner_macs : add for r2, remove otherwise
+    if level == "r2":
+        nft.add_r2_banner(mac, ttl="24h")
+    else:
+        nft.del_r2_banner(mac)
+
+    store.upsert_client(mac_hash, ip, level=level)
+    log.info("level switched mac_hash=%s -> %s", mac_hash, level)
+    from fastapi.responses import RedirectResponse
+    return RedirectResponse(url=f"/report/me/html?switched=1&level={level}",
+                             status_code=303)
 
 
 @router.get("/status", response_model=StatusResp)
@@ -700,8 +751,12 @@ async def report_me_html(request: Request) -> HTMLResponse:
     salt = _get_salt()
     mac_hash = macmod.hash_mac(mac, salt)
     session = _aggregate_session(mac_hash)
+    # Phase 3 (#492) : pass query args for welcome/switched banner
     return HTMLResponse(_env.get_template("report-live.html.j2").render(
-        mac_hash=mac_hash, ip=ip, **session,
+        mac_hash=mac_hash, ip=ip,
+        request_args=dict(request.query_params),
+        current_level=store.get_client_level(mac_hash) if mac_hash else "r1",
+        **session,
     ))
 
 

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -159,6 +159,25 @@ async def ca_android_crt() -> Response:
     )
 
 
+@router.get("/ca/webclip-cabine.mobileconfig")
+async def webclip_cabine() -> Response:
+    """Phase 3 (#492) : iOS Add-to-Home-Screen profile that drops a 'ToolBoX
+    Cabine' icon pointing at /report/me/html. User can then check the live
+    session report in 1 tap, surviving Safari cache misses + native-app gaps."""
+    import uuid as _uuid
+    cfg = _get_cfg()
+    body = _env.get_template("webclip.mobileconfig.j2").render(
+        payload_uuid=str(_uuid.uuid4()),
+        webclip_uuid=str(_uuid.uuid4()),
+        report_url=f"http://{cfg.dhcp.gateway}/report/me/html",
+    )
+    return Response(
+        content=body,
+        media_type="application/x-apple-aspen-config",
+        headers={"Content-Disposition": "attachment; filename=toolbox-cabine-icon.mobileconfig"},
+    )
+
+
 @router.get("/ca/install-help", response_class=HTMLResponse)
 async def ca_install_help() -> HTMLResponse:
     return HTMLResponse(_env.get_template("ca-help.html.j2").render())

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -86,20 +86,30 @@ def _resolve(request: Request) -> tuple[str | None, str | None]:
 @router.get("/hotspot-detect.html", response_class=HTMLResponse)
 @router.get("/generate_204", response_class=HTMLResponse)
 @router.get("/connecttest.txt", response_class=HTMLResponse)
-async def splash(request: Request) -> HTMLResponse:
+async def splash(request: Request):
     ip, mac = _resolve(request)
     cfg = _get_cfg()
     salt = _get_salt()
     mac_hash = macmod.hash_mac(mac, salt) if mac else None
 
+    no_cache_headers = {
+        "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+        "Pragma": "no-cache",
+    }
+
+    # Phase 3 (#492) : if already validated, send user to the dashboard which
+    # has the level switcher + cert card + transparency metrics. The previous
+    # 'success.html.j2 fallback' was a stale dead-end that did NOT show the
+    # new cert card auto-check.
     validated = bool(mac and nft.is_validated(mac))
     if validated:
-        return HTMLResponse(_env.get_template("success.html.j2").render(
-            mac_hash=mac_hash, r2_enabled=cfg.r2.enabled,
-        ))
-    return HTMLResponse(_env.get_template("splash.html.j2").render(
+        from fastapi.responses import RedirectResponse
+        return RedirectResponse(url="/report/me/html", status_code=303,
+                                 headers=no_cache_headers)
+    html = _env.get_template("splash.html.j2").render(
         mac_hash=mac_hash or "??", ssid=cfg.ap.ssid, r2_enabled=cfg.r2.enabled,
-    ))
+    )
+    return HTMLResponse(html, headers=no_cache_headers)
 
 
 @router.post("/accept")
@@ -796,13 +806,18 @@ async def report_me_html(request: Request) -> HTMLResponse:
     salt = _get_salt()
     mac_hash = macmod.hash_mac(mac, salt)
     session = _aggregate_session(mac_hash)
-    # Phase 3 (#492) : pass query args for welcome/switched banner
-    return HTMLResponse(_env.get_template("report-live.html.j2").render(
+    # Phase 3 (#492) : pass query args + force no-cache so iPhone Safari
+    # actually fetches the new template.
+    html = _env.get_template("report-live.html.j2").render(
         mac_hash=mac_hash, ip=ip,
         request_args=dict(request.query_params),
         current_level=store.get_client_level(mac_hash) if mac_hash else "r1",
         **session,
-    ))
+    )
+    return HTMLResponse(html, headers={
+        "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+        "Pragma": "no-cache",
+    })
 
 
 @router.get("/report/me")

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -184,26 +184,21 @@ async def change_level(request: Request):
         level = "r1"
 
     # Re-validate (idempotent extend)
-    nft.add_validated(mac, ttl="24h")
+    v_ok = nft.add_validated(mac, ttl="24h")
     # Membership in consented_r2_macs : add for r1/r2, remove for r0
     if level in ("r1", "r2"):
-        nft.add_consented(mac, ttl="24h")
+        c_ok = nft.add_consented(mac, ttl="24h")
     else:
-        try:
-            nft.del_validated  # name-check
-            from . import nft as _nft
-            _nft._run(_nft.NFT, "delete", "element", "inet", "toolbox",
-                      "consented_r2_macs", "{ " + mac + " }")
-        except Exception:
-            pass
+        c_ok = nft.del_consented(mac)
     # Membership in r2_banner_macs : add for r2, remove otherwise
     if level == "r2":
-        nft.add_r2_banner(mac, ttl="24h")
+        b_ok = nft.add_r2_banner(mac, ttl="24h")
     else:
-        nft.del_r2_banner(mac)
+        b_ok = nft.del_r2_banner(mac)
 
     store.upsert_client(mac_hash, ip, level=level)
-    log.info("level switched mac_hash=%s -> %s", mac_hash, level)
+    log.info("level switched mac_hash=%s -> %s (nft: validated=%s consented=%s banner=%s)",
+             mac_hash, level, v_ok, c_ok, b_ok)
     from fastapi.responses import RedirectResponse
     return RedirectResponse(url=f"/report/me/html?switched=1&level={level}",
                              status_code=303)

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -552,7 +552,7 @@ def _build_transparency(
     host_analysis: dict[str, dict],
     dpi_hosts: dict[str, int],
     ja4_snis: set,
-) -> dict:
+) -> dict:  # noqa: C901
     """Phase 3 (#492) : pack the inspection breakdown + per-host quality table.
 
     The breakdown shows what % of traffic was inspected / bypassed / pinned /
@@ -605,6 +605,45 @@ def _build_transparency(
     # Whitelist sanity stats
     wl_stats = _whitelist_mod.stats() if _HAS_TRANSPARENCY else {"count": 0}
 
+    # Phase 3 (#492) : count whitelist hits per pattern + per category.
+    # iPhone usage stores IPs in dpi_hosts (cert-pinning bypasses) but SNIs
+    # in ja4_snis (TLS clienthello visible). Iterate BOTH so apple.com etc.
+    # actually match patterns like *.apple.com.
+    wl_hits_by_pattern: dict[str, int] = {}
+    wl_hits_by_category: dict[str, int] = {}
+    wl_hits_total = 0
+    if _HAS_TRANSPARENCY:
+        # Merge dpi_hosts (IP-tagged counts) and ja4_snis (FQDN tags with count 1)
+        all_hosts: dict[str, int] = dict(dpi_hosts)
+        for sni in ja4_snis:
+            all_hosts[sni] = all_hosts.get(sni, 0) + 1
+        for h, count in all_hosts.items():
+            entry = _whitelist_mod.match(h)
+            if entry:
+                pat = entry.get("pattern", h)
+                cat = entry.get("category", "other")
+                wl_hits_by_pattern[pat] = wl_hits_by_pattern.get(pat, 0) + count
+                wl_hits_by_category[cat] = wl_hits_by_category.get(cat, 0) + count
+                wl_hits_total += count
+
+    # Phase 3 (#492) : attempt counters — full transparency including failures
+    attempts = {
+        "total": sum(breakdown.values()),
+        "inspected": breakdown.get("inspected", 0),
+        "bypassed_whitelist": breakdown.get("bypassed-whitelist", 0),
+        "pinned_failed": breakdown.get("pinned-failed-mitm", 0),
+        "e2e_opaque": breakdown.get("e2e-opaque", 0),
+        "blocked": breakdown.get("blocked", 0),  # Phase 4 placeholder
+    }
+
+    # Sensitivity profile info (rule engine)
+    sensitivity = None
+    try:
+        from secubox_core import rule_engine as _re
+        sensitivity = _re.get_sensitivity()
+    except Exception:
+        pass
+
     return {
         "breakdown": breakdown,
         "breakdown_pct": pct,
@@ -612,6 +651,17 @@ def _build_transparency(
         "per_host": per_host[:50],
         "whitelist_stats": wl_stats,
         "has_transparency": _HAS_TRANSPARENCY,
+        # Phase 3 metrics for richer reporting
+        "attempts": attempts,
+        "whitelist_hits": {
+            "total": wl_hits_total,
+            "top_patterns": sorted(
+                [{"pattern": k, "count": v} for k, v in wl_hits_by_pattern.items()],
+                key=lambda x: -x["count"],
+            )[:15],
+            "by_category": wl_hits_by_category,
+        },
+        "sensitivity": sensitivity,
     }
 
 

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -27,6 +27,13 @@ from . import (
     store,
     threat_intel,
 )
+# Phase 3 (#492) : transparency layer
+try:
+    from secubox_core import whitelist as _whitelist_mod
+    from secubox_core.classifiers import security_quality as _sec_quality
+    _HAS_TRANSPARENCY = True
+except ImportError:
+    _HAS_TRANSPARENCY = False
 from .config import load_config, resolve_secret
 from .models import AcceptResp, ClientRow, Config, StatusResp
 
@@ -258,6 +265,9 @@ def _aggregate_session(mac_hash: str) -> dict:
     soc_indicators: list[dict] = []
     ja4_snis: set[str] = set()
     ja4_alpns: set[str] = set()
+    # Phase 3 (#492) : transparency layer state
+    analysis_breakdown: dict[str, int] = {}
+    host_analysis: dict[str, dict] = {}
     try:
         with _sq3.connect("/var/lib/secubox/toolbox/toolbox.db", timeout=2) as c:
             cur = c.execute(
@@ -279,6 +289,15 @@ def _aggregate_session(mac_hash: str) -> dict:
                     ua = p.get("user_agent")
                     if ua:
                         user_agents.add(ua[:80])
+                    # Phase 3 (#492) : analysis_status breakdown
+                    status = p.get("analysis_status")
+                    if status:
+                        analysis_breakdown[status] = analysis_breakdown.get(status, 0) + 1
+                        # Keep a per-host status for the quality table
+                        host_analysis[host] = {
+                            "status": status,
+                            "reason": p.get("analysis_reason", ""),
+                        }
                 elif source == "cookies":
                     cookies_total_set += p.get("set_cookie_count", 0)
                     cookies_total_sent += p.get("cookie_count", 0)
@@ -417,6 +436,78 @@ def _aggregate_session(mac_hash: str) -> dict:
         "cookies_providers": cookie_analysis.top_providers(cookies_urls, limit=10),
         # ── Phase 2b (#488) : pull events from receiving modules ──
         "mitm_modules": _pull_mitm_module_events(mac_hash),
+        # ── Phase 3 (#492) : transparency layer ──
+        "transparency": _build_transparency(
+            analysis_breakdown, host_analysis, dpi_hosts, ja4_snis,
+        ),
+    }
+
+
+def _build_transparency(
+    breakdown: dict[str, int],
+    host_analysis: dict[str, dict],
+    dpi_hosts: dict[str, int],
+    ja4_snis: set,
+) -> dict:
+    """Phase 3 (#492) : pack the inspection breakdown + per-host quality table.
+
+    The breakdown shows what % of traffic was inspected / bypassed / pinned /
+    e2e. The per-host quality table grades each destination via passive or
+    active signals (currently passive, since header capture is not yet wired).
+    """
+    total = sum(breakdown.values()) or 1
+    pct = {k: round(100 * v / total, 1) for k, v in breakdown.items()}
+
+    # Backfill any host without explicit analysis_status (legacy events)
+    for h in dpi_hosts:
+        if h not in host_analysis:
+            # Best-effort post-hoc tag : whitelist match → bypass, else inspected
+            target = h.lower()
+            if _HAS_TRANSPARENCY and _whitelist_mod.is_whitelisted(target):
+                host_analysis[h] = {
+                    "status": "bypassed-whitelist",
+                    "reason": (_whitelist_mod.match(target) or {}).get("reason", ""),
+                }
+            else:
+                host_analysis[h] = {
+                    "status": "inspected",
+                    "reason": "MITM decryption (post-hoc tag)",
+                }
+
+    # Build per-host quality (passive grading from what we have)
+    per_host: list[dict] = []
+    if _HAS_TRANSPARENCY:
+        for h, info in host_analysis.items():
+            status = info.get("status", "inspected")
+            is_e2e = status == "e2e-opaque"
+            # We don't know tls_version per host without further capture ; assume
+            # 13 for whitelisted (cert-pinned apps use modern TLS) and unknown otherwise
+            tls_v = "13" if status in ("bypassed-whitelist", "pinned-failed-mitm", "e2e-opaque") else None
+            g = _sec_quality.grade_passive(
+                tls_version=tls_v,
+                sni=h if h in ja4_snis else None,
+                is_e2e_messaging=is_e2e,
+            )
+            per_host.append({
+                "host": h,
+                "grade": g["grade"],
+                "score": g["score"],
+                "status": status,
+                "reason": info.get("reason", ""),
+            })
+        # Sort : worst quality first (catches user attention)
+        per_host.sort(key=lambda x: (x["score"], x["host"]))
+
+    # Whitelist sanity stats
+    wl_stats = _whitelist_mod.stats() if _HAS_TRANSPARENCY else {"count": 0}
+
+    return {
+        "breakdown": breakdown,
+        "breakdown_pct": pct,
+        "total_events": total,
+        "per_host": per_host[:50],
+        "whitelist_stats": wl_stats,
+        "has_transparency": _HAS_TRANSPARENCY,
     }
 
 

--- a/packages/secubox-toolbox/secubox_toolbox/nft.py
+++ b/packages/secubox-toolbox/secubox_toolbox/nft.py
@@ -76,6 +76,13 @@ def del_r2_banner(mac: str) -> bool:
     return rc == 0
 
 
+def del_consented(mac: str) -> bool:
+    """Remove MAC from consented_r2_macs (used for R0 downgrade)."""
+    rc, _, _ = _run(NFT, "delete", "element", "inet", "toolbox",
+                    "consented_r2_macs", "{ " + mac + " }")
+    return rc == 0
+
+
 def is_r2_banner(mac: str) -> bool:
     rc, out, _ = _run(NFT, "list", "set", "inet", "toolbox", "r2_banner_macs")
     return rc == 0 and mac.lower() in out.lower()

--- a/packages/secubox-toolbox/secubox_toolbox/nft.py
+++ b/packages/secubox-toolbox/secubox_toolbox/nft.py
@@ -59,3 +59,23 @@ def is_validated(mac: str) -> bool:
 def is_consented(mac: str) -> bool:
     rc, out, _ = _run(NFT, "list", "set", "inet", "toolbox", "consented_r2_macs")
     return rc == 0 and mac.lower() in out.lower()
+
+
+def add_r2_banner(mac: str, ttl: str = "24h") -> bool:
+    """Phase 3 (#492) : R2 explicit opt-in subset (banner inject + QUIC drop)."""
+    rc, _, err = _run(NFT, "add", "element", "inet", "toolbox",
+                      "r2_banner_macs", "{ " + mac + " timeout " + ttl + " }")
+    if rc:
+        log.error("nft add r2_banner_macs %s failed: %s", mac, err)
+    return rc == 0
+
+
+def del_r2_banner(mac: str) -> bool:
+    rc, _, _ = _run(NFT, "delete", "element", "inet", "toolbox",
+                    "r2_banner_macs", "{ " + mac + " }")
+    return rc == 0
+
+
+def is_r2_banner(mac: str) -> bool:
+    rc, out, _ = _run(NFT, "list", "set", "inet", "toolbox", "r2_banner_macs")
+    return rc == 0 and mac.lower() in out.lower()

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -142,8 +142,6 @@ def render_pdf(report: dict) -> bytes:
 
     # Compromise analysis (the hero shows the risk badge ; details below)
     _section(pdf, "🚨 ANALYSE COMPROMISSION")
-    score = report.get("risk_score", 0)
-    risk_label = report.get("risk_label") or ("LOW" if score < 30 else "MEDIUM" if score < 70 else "HIGH")
     pdf.set_text_color(0)
     pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "", 10)
     pdf.ln(1)
@@ -421,94 +419,134 @@ _EMOJI_REPLACEMENTS = {
 }
 
 
-def _dashboard_hero(pdf, family: str, report: dict) -> None:
-    """Phase 3 (#492) : visual hero with big global numbers + risk score badge.
+def _widget(pdf, family: str, x: float, y: float, w: float, h: float,
+            emoji: str, value: str, label: str,
+            bg: tuple, fg: tuple = (10, 10, 15)) -> None:
+    """Render a single rounded widget tile : big emoji, value, label."""
+    pdf.set_fill_color(*bg)
+    pdf.set_draw_color(*bg)
+    pdf.set_line_width(0.3)
+    # Rounded rect (fpdf2 2.7+ supports round_corners + corner_radius)
+    try:
+        pdf.rect(x, y, w, h, style="DF", round_corners=True, corner_radius=3)
+    except TypeError:
+        pdf.rect(x, y, w, h, style="DF")  # older fpdf2 fallback
+    # Emoji at top-center
+    pdf.set_xy(x, y + 1.5)
+    pdf.set_font(family, "B", 14)
+    pdf.set_text_color(*fg)
+    pdf.cell(w, 6, _safe(emoji), ln=False, align="C")
+    # Value (big number)
+    pdf.set_xy(x, y + 7.5)
+    pdf.set_font(family, "B", 13)
+    pdf.cell(w, 6, _safe(value), ln=False, align="C")
+    # Label (small)
+    pdf.set_xy(x, y + 13.5)
+    pdf.set_font(family, "", 6)
+    pdf.cell(w, 3, _safe(label), ln=False, align="C")
 
-    Layout :
-      ┌──────────────────────────────────────────────────────────────────┐
-      │  📊 TA SESSION VILLAGE3B                  Risk : LOW  [score]    │
-      │                                                                  │
-      │  [N connexions]  [N hosts]  [N inspectés]  [N cert-pinning]      │
-      │                                                                  │
-      │  Top app : 📺 YouTube · Top device : 📱 iPhone iOS 17.4         │
-      │  Top country : 🇺🇸 United States (Amazon, Google, Apple)        │
-      └──────────────────────────────────────────────────────────────────┘
+
+def _dashboard_hero(pdf, family: str, report: dict) -> None:
+    """Phase 3 (#492) : 3-row widget dashboard, banner-style, with aggregations.
+
+    Row 1 (4 widgets) : raw global counters
+       🌐 conn   📡 hosts   ✅ OK 2xx   🔒 pinned
+
+    Row 2 (4 widgets) : aggregated insights
+       📺 apps detected   🍪 trackers   🌍 countries   🎯 risk score
+
+    Row 3 (single banner) : verbal summary
+       'Top device 📱 iPhone · Top app 📺 YouTube · Top ASN 🇺🇸 Amazon · Risque: LOW'
     """
     m = report.get("metrics") or {}
     avatar = report.get("avatar_analysis") or {}
     dpi_cls = report.get("dpi_classified") or {}
     geo_hosts = report.get("geo_top_hosts") or []
+    cookies_p = report.get("cookies_providers") or []
     score = report.get("risk_score", 0)
     label = report.get("risk_label") or ("LOW" if score < 30 else "MEDIUM" if score < 70 else "HIGH")
 
-    # Hero card background
-    pdf.set_fill_color(20, 30, 25)  # dark green-tinted
-    pdf.set_draw_color(0, 90, 64)
-    pdf.set_line_width(0.5)
-    hero_y = pdf.get_y()
-    pdf.rect(pdf.l_margin, hero_y, _page_w(pdf), 42, "DF")
-
-    # Title left + Risk badge right
-    pdf.set_xy(pdf.l_margin + 4, hero_y + 3)
-    pdf.set_font(family, "B", 13)
+    # Title with sat dish + session label
+    pdf.set_font(family, "B", 12)
     pdf.set_text_color(0, 221, 68)
-    pdf.cell(_page_w(pdf) - 60, 6, "📊 TA SESSION VILLAGE3B", ln=False)
-    # Risk badge
-    if score < 30:
-        badge_r, badge_g, badge_b = 0, 200, 100
-    elif score < 70:
-        badge_r, badge_g, badge_b = 255, 179, 71
-    else:
-        badge_r, badge_g, badge_b = 255, 68, 102
-    pdf.set_fill_color(badge_r, badge_g, badge_b)
-    pdf.set_text_color(10, 10, 15)
-    pdf.set_x(pdf.l_margin + _page_w(pdf) - 55)
-    pdf.set_font(family, "B", 11)
-    pdf.cell(50, 6, _safe(f"Risque: {label} ({score}/100)"), align="C", fill=True)
-    pdf.ln(8)
+    pdf.cell(0, 6, _safe("📊 TA SESSION VILLAGE3B"), ln=True)
+    pdf.ln(1)
 
-    # Big numbers row (4 KPI cells)
-    pdf.set_text_color(0, 221, 68)
-    pdf.set_font(family, "B", 18)
-    box_w = (_page_w(pdf) - 8) / 4
-    y_kpi = pdf.get_y() + 2
-    kpis = [
-        (str(m.get("connections", 0)), "connexions"),
-        (str(m.get("unique_hosts", 0)), "hôtes"),
-        (str(m.get("successful", 0)), "OK 2xx/3xx"),
-        (str(m.get("tls_pinned", 0)), "cert-pinning"),
+    # ── Row 1 : raw counters ──
+    y = pdf.get_y()
+    box_w = (_page_w(pdf) - 6) / 4
+    box_h = 17
+    row_kpis = [
+        ("🌐", str(m.get("connections", 0)), "connexions", (15, 35, 30)),
+        ("📡", str(m.get("unique_hosts", 0)), "hôtes uniques", (15, 30, 40)),
+        ("✅", str(m.get("successful", 0)), "OK 2xx/3xx", (15, 40, 25)),
+        ("🔒", str(m.get("tls_pinned", 0)), "cert-pinning", (40, 30, 15)),
     ]
-    for i, (n, lbl) in enumerate(kpis):
-        x = pdf.l_margin + 4 + i * box_w
-        pdf.set_xy(x, y_kpi)
-        pdf.set_font(family, "B", 16)
-        pdf.set_text_color(0, 255, 85)
-        pdf.cell(box_w, 7, n, ln=False, align="C")
-        pdf.set_xy(x, y_kpi + 7)
-        pdf.set_font(family, "", 8)
-        pdf.set_text_color(150, 150, 150)
-        pdf.cell(box_w, 4, _safe(lbl), ln=False, align="C")
+    for i, (emoji, val, lbl, bg) in enumerate(row_kpis):
+        x = pdf.l_margin + i * (box_w + 2)
+        _widget(pdf, family, x, y, box_w, box_h, emoji, val, lbl, bg, fg=(0, 255, 100))
+    pdf.set_y(y + box_h + 2)
 
-    # Top device + top app + top country lines
-    pdf.set_xy(pdf.l_margin + 4, hero_y + 30)
-    pdf.set_font(family, "", 9)
-    pdf.set_text_color(220, 220, 200)
+    # ── Row 2 : aggregations ──
+    # Count distinct apps detected (top_apps)
+    n_apps = len([a for a in dpi_cls.get("top_apps", []) if a.get("app") and a.get("app") != "?"])
+    # Trackers detected (cookies providers)
+    n_trackers = sum(p.get("count", 0) for p in cookies_p) if cookies_p else 0
+    # Countries seen (distinct country codes in geo_top_hosts)
+    countries = {h.get("country") for h in geo_hosts if h.get("country")}
+    n_countries = len(countries)
+    # Risk score widget
+    risk_emoji = "🟢" if score < 30 else "🟡" if score < 70 else "🔴"
+    risk_bg = (15, 50, 20) if score < 30 else (60, 50, 15) if score < 70 else (60, 20, 20)
+
+    y = pdf.get_y()
+    row_agg = [
+        ("📺", str(n_apps), "apps détectées", (25, 25, 45)),
+        ("🍪", str(n_trackers), "trackers", (45, 25, 35)),
+        ("🌍", str(n_countries), "pays/ASN", (25, 40, 35)),
+        (risk_emoji, f"{score}/100", f"risque {label}", risk_bg),
+    ]
+    for i, (emoji, val, lbl, bg) in enumerate(row_agg):
+        x = pdf.l_margin + i * (box_w + 2)
+        _widget(pdf, family, x, y, box_w, box_h, emoji, val, lbl, bg, fg=(0, 230, 220))
+    pdf.set_y(y + box_h + 2)
+
+    # ── Row 3 : verbal summary banner ──
     top_device = avatar.get("most_common") or "?"
     top_device_emoji = avatar.get("most_common_emoji") or ""
     top_app = "?"
     if dpi_cls.get("top_apps"):
         ta = dpi_cls["top_apps"][0]
-        top_app = f"{ta.get('emoji', '')} {ta.get('app', '?')}"
+        if ta.get("app") and ta["app"] != "?":
+            top_app = f"{ta.get('emoji', '')} {ta.get('app')}"
     top_country = "?"
     if geo_hosts:
         gh = geo_hosts[0]
-        if gh.get("flag") or gh.get("country"):
+        if gh.get("flag") or gh.get("country") or gh.get("asn_org"):
             top_country = f"{gh.get('flag', '')} {gh.get('asn_org', '?')[:30]}"
-    pdf.cell(0, 4, _safe(f"Top device : {top_device_emoji} {top_device}  ·  Top app : {top_app}  ·  Top ASN : {top_country}"), ln=True)
 
-    # Reset cursor + colors below the hero
-    pdf.set_y(hero_y + 44)
+    y = pdf.get_y()
+    # Banner with gradient-like background
+    pdf.set_fill_color(20, 25, 35)
+    pdf.set_draw_color(0, 90, 64)
+    try:
+        pdf.rect(pdf.l_margin, y, _page_w(pdf), 9, style="DF", round_corners=True, corner_radius=2)
+    except TypeError:
+        pdf.rect(pdf.l_margin, y, _page_w(pdf), 9, style="DF")
+    pdf.set_xy(pdf.l_margin + 3, y + 2)
+    pdf.set_font(family, "", 9)
+    pdf.set_text_color(220, 220, 200)
+    summary = (
+        f"Top device : {top_device_emoji} {top_device}    ·    "
+        f"Top app : {top_app}    ·    "
+        f"Top ASN : {top_country}"
+    )
+    pdf.cell(_page_w(pdf) - 6, 5, _safe(summary[:140]), ln=False)
+    pdf.set_y(y + 11)
+
+    # Reset
     pdf.set_text_color(0, 0, 0)
+    pdf.set_font(family, "", 10)
     pdf.ln(2)
 
 

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -249,6 +249,36 @@ def render_pdf(report: dict) -> bytes:
         _bullet(pdf, rec)
     pdf.ln(2)
 
+    # Phase 3 (#492) : Transparency — inspection breakdown + per-host quality
+    t = report.get("transparency") or {}
+    if t.get("total_events"):
+        _section(pdf, "INSPECTION : CE QUI A ETE REGARDE (et pas regarde)")
+        b = t.get("breakdown_pct") or {}
+        if b.get("inspected"):
+            _bullet(pdf, f"Inspecte (MITM via notre CA) : {b['inspected']}% - contenu visible")
+        if b.get("bypassed-whitelist"):
+            _bullet(pdf, f"Bypass whitelist : {b['bypassed-whitelist']}% - decision policy (vendor cert-pinning)")
+        if b.get("pinned-failed-mitm"):
+            _bullet(pdf, f"Cert-pinning : {b['pinned-failed-mitm']}% - app refuse notre CA, normal+bon signe")
+        if b.get("e2e-opaque"):
+            _bullet(pdf, f"E2E messaging : {b['e2e-opaque']}% - opaque par design, ton chiffrement marche")
+        _bullet(pdf, f"Total events analyses : {t.get('total_events', 0)}")
+        wl = (t.get("whitelist_stats") or {}).get("count", 0)
+        if wl:
+            _bullet(pdf, f"Patterns whitelist actifs : {wl} (baseline + override operateur)")
+        pdf.ln(2)
+
+        # Per-host quality table — worst first, capped 10
+        per_host = t.get("per_host") or []
+        if per_host:
+            _section(pdf, "QUALITE SECURITE PAR DESTINATION (worst-first)")
+            for h in per_host[:10]:
+                grade = h.get("grade", "?")
+                host = h.get("host", "?")[:50]
+                status = h.get("status", "?")
+                _bullet(pdf, f"[{grade}] {host} - {status}", font_size=8)
+            pdf.ln(2)
+
     # Retention
     _section(pdf, "RETENTION DES DONNEES")
     _bullet(pdf, "Hash MAC anonyme : 24h (sel rotatif quotidien)")

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -23,6 +23,10 @@ DEJAVU_OBLIQUE_PATH = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Oblique.ttf"
 # Symbola : broad monochrome emoji + symbol coverage (📱📡🔍🔒🎯🎵🐙📊🍪…)
 # Apt package : fonts-symbola
 SYMBOLA_PATH = "/usr/share/fonts/truetype/ancient-scripts/Symbola_hint.ttf"
+# Noto Color Emoji : CBDT/CBLC color bitmap font covering ALL emojis incl.
+# flags (regional indicator pairs 🇫🇷🇺🇸🇩🇪) which Symbola lacks.
+# fpdf2 >= 2.7 supports color emoji rendering — package fonts-noto-color-emoji
+NOTO_COLOR_EMOJI_PATH = "/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf"
 
 
 def mint_token(mac_hash: str, salt: str, ttl_seconds: int = 86400) -> ReportToken:
@@ -79,9 +83,22 @@ def _setup_fonts(pdf) -> str:
             if Path(DEJAVU_OBLIQUE_PATH).exists():
                 pdf.add_font("DejaVu", style="I", fname=DEJAVU_OBLIQUE_PATH)
             family = "DejaVu"
-            # Fallback chain : Symbola covers 📱📡🔍🔒🎯🎵🐙📊🍪 + most emoji
-            # not present in DejaVu.
+            # Fallback chain :
+            #   NotoColorEmoji  : COLOR CBDT/CBLC, covers ALL emojis including
+            #                     flags as composite glyphs (🇫🇷 = single bitmap)
+            #                     and modern 2020+ emojis Symbola lacks
+            #   Symbola         : monochrome vector fallback for chars not in Noto
+            # Order matters : Noto FIRST. Symbola has regional indicator letters
+            # but renders them as separate boxed letters, not composite flags.
+            # By trying Noto first, flag emojis render as proper single glyphs.
             fallback = []
+            if Path(NOTO_COLOR_EMOJI_PATH).exists():
+                try:
+                    pdf.add_font("NotoColorEmoji", style="", fname=NOTO_COLOR_EMOJI_PATH)
+                    fallback.append("NotoColorEmoji")
+                    log.info("NotoColorEmoji loaded — color emoji + flags enabled")
+                except Exception as e:
+                    log.warning("NotoColorEmoji font load failed: %s", e)
             if Path(SYMBOLA_PATH).exists():
                 try:
                     pdf.add_font("Symbola", style="", fname=SYMBOLA_PATH)
@@ -90,11 +107,8 @@ def _setup_fonts(pdf) -> str:
                     log.warning("Symbola font load failed: %s", e)
             if fallback:
                 try:
-                    # exact_match=False so Bold/Italic text also falls back to
-                    # regular Symbola (it has no Bold variant).
                     pdf.set_fallback_fonts(fallback, exact_match=False)
                 except TypeError:
-                    # Older fpdf2 without exact_match param
                     pdf.set_fallback_fonts(fallback)
                 except Exception as e:
                     log.warning("set_fallback_fonts failed: %s", e)
@@ -399,23 +413,14 @@ def _page_w(pdf) -> float:
 # Phase 3 (#492) : with DejaVu Sans + Noto fallback, most emojis render as
 # real glyphs (monochrome). For chars not in either font (e.g. some flags,
 # very recent emoji), we fall back to a small ASCII replacement table.
-_EMOJI_REPLACEMENTS = {
-    # Common emojis NOT in DejaVu Sans + Symbola fallback — replaced gracefully
-    # Flag emojis (regional indicator pairs, not in monochrome fonts)
-    "🇫🇷": "[FR]", "🇺🇸": "[US]", "🇩🇪": "[DE]", "🇨🇳": "[CN]",
-    "🇬🇧": "[GB]", "🇯🇵": "[JP]", "🇨🇦": "[CA]", "🇮🇪": "[IE]",
-    "🇮🇹": "[IT]", "🇪🇸": "[ES]", "🇧🇪": "[BE]", "🇨🇭": "[CH]",
-    "🇳🇱": "[NL]", "🇸🇪": "[SE]", "🇮🇱": "[IL]", "🇧🇷": "[BR]",
-    "🇷🇺": "[RU]", "🇮🇳": "[IN]", "🇰🇷": "[KR]", "🇦🇺": "[AU]",
-    "🏳": "[??]",
-    # Recent emoji (2020+) not in Symbola
-    "🟢": "[OK]",  # green circle
-    "🟡": "[WARN]",  # yellow circle
-    "🔴": "[KO]",  # red circle (also used for Opera but contextual)
-    "🟦": "[BOX]",  # blue square
-    "🦋": "[BSKY]",  # butterfly
-    "🦊": "[FF]",  # fox face
-    "🪟": "[EDGE]",  # window
+# With NotoColorEmoji fallback enabled, ALL emojis (incl flags + recent
+# 2020+ glyphs) render natively. The replacements table is now empty —
+# kept for backward compat (e.g. if NotoColorEmoji absent on a board,
+# we still want graceful degradation, but the user should install
+# fonts-noto-color-emoji per debian/control deps).
+_EMOJI_REPLACEMENTS: dict[str, str] = {
+    # Only catch the white-flag fallback (🏳 alone, no country) — explicit "unknown"
+    "🏳": "🏳",  # keep as-is (NotoColorEmoji has it)
 }
 
 

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -121,49 +121,29 @@ def render_pdf(report: dict) -> bytes:
     pdf._secubox_family = family
 
     # Header
-    pdf.set_font(family, "B", 18)
+    pdf.set_font(family, "B", 20)
     pdf.set_text_color(0, 90, 64)  # P31 dim green
     pdf.cell(0, 12, "📡 GONDWANA TOOLBOX", ln=True, align="C")
-    pdf.set_font(family, "", 11)
+    pdf.set_font(family, "", 10)
     pdf.set_text_color(110, 64, 201)
-    pdf.cell(0, 6, "Rapport d'analyse de session — Cabine numérique VILLAGE3B", ln=True, align="C")
-    pdf.ln(4)
+    pdf.cell(0, 5, "Rapport d'analyse de session — Cabine numérique VILLAGE3B", ln=True, align="C")
+    pdf.ln(3)
+
+    # ── HERO DASHBOARD : big global numbers ──
+    _dashboard_hero(pdf, family, report)
 
     # Anonymous ID
-    _section(pdf, "IDENTIFIANT ANONYME")
+    _section(pdf, "🔑 IDENTIFIANT ANONYME")
     _kv(pdf, "Hash session", report.get("mac_hash", "?"))
     _kv(pdf, "Type appareil", report.get("device_type", "?"))
     _kv(pdf, "Date analyse", report.get("generated_at", "?"))
-    _kv(pdf, "Sandbox subnet", "10.99.0.0/24 (reseau isole VILLAGE3B)")
+    _kv(pdf, "Sandbox subnet", "10.99.0.0/24 (réseau isolé VILLAGE3B)")
     pdf.ln(2)
 
-    # Metrics
-    _section(pdf, "METRIQUES SESSION")
-    m = report.get("metrics", {})
-    _kv(pdf, "Connexions totales", str(m.get("connections", 0)))
-    _kv(pdf, "Hosts uniques", str(m.get("unique_hosts", 0)))
-    _kv(pdf, "Reussies (200/3xx)", str(m.get("successful", 0)))
-    _kv(pdf, "Cert-pin blocks", str(m.get("tls_pinned", 0)))
-    pdf.ln(2)
-
-    # Apps detected
-    _section(pdf, "APPS DETECTEES")
-    for line in report.get("apps_detected", []):
-        _bullet(pdf, line)
-    pdf.ln(2)
-
-    # Compromise analysis
-    _section(pdf, "ANALYSE COMPROMISSION")
+    # Compromise analysis (the hero shows the risk badge ; details below)
+    _section(pdf, "🚨 ANALYSE COMPROMISSION")
     score = report.get("risk_score", 0)
     risk_label = report.get("risk_label") or ("LOW" if score < 30 else "MEDIUM" if score < 70 else "HIGH")
-    pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "B", 13)
-    if score < 30:
-        pdf.set_text_color(0, 221, 68)
-    elif score < 70:
-        pdf.set_text_color(255, 179, 71)
-    else:
-        pdf.set_text_color(255, 68, 102)
-    pdf.cell(0, 8, _ascii_safe(f"Score risque : {score}/100 ({risk_label})"), ln=True)
     pdf.set_text_color(0)
     pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "", 10)
     pdf.ln(1)
@@ -439,6 +419,97 @@ _EMOJI_REPLACEMENTS = {
     "🦊": "[FF]",  # fox face
     "🪟": "[EDGE]",  # window
 }
+
+
+def _dashboard_hero(pdf, family: str, report: dict) -> None:
+    """Phase 3 (#492) : visual hero with big global numbers + risk score badge.
+
+    Layout :
+      ┌──────────────────────────────────────────────────────────────────┐
+      │  📊 TA SESSION VILLAGE3B                  Risk : LOW  [score]    │
+      │                                                                  │
+      │  [N connexions]  [N hosts]  [N inspectés]  [N cert-pinning]      │
+      │                                                                  │
+      │  Top app : 📺 YouTube · Top device : 📱 iPhone iOS 17.4         │
+      │  Top country : 🇺🇸 United States (Amazon, Google, Apple)        │
+      └──────────────────────────────────────────────────────────────────┘
+    """
+    m = report.get("metrics") or {}
+    avatar = report.get("avatar_analysis") or {}
+    dpi_cls = report.get("dpi_classified") or {}
+    geo_hosts = report.get("geo_top_hosts") or []
+    score = report.get("risk_score", 0)
+    label = report.get("risk_label") or ("LOW" if score < 30 else "MEDIUM" if score < 70 else "HIGH")
+
+    # Hero card background
+    pdf.set_fill_color(20, 30, 25)  # dark green-tinted
+    pdf.set_draw_color(0, 90, 64)
+    pdf.set_line_width(0.5)
+    hero_y = pdf.get_y()
+    pdf.rect(pdf.l_margin, hero_y, _page_w(pdf), 42, "DF")
+
+    # Title left + Risk badge right
+    pdf.set_xy(pdf.l_margin + 4, hero_y + 3)
+    pdf.set_font(family, "B", 13)
+    pdf.set_text_color(0, 221, 68)
+    pdf.cell(_page_w(pdf) - 60, 6, "📊 TA SESSION VILLAGE3B", ln=False)
+    # Risk badge
+    if score < 30:
+        badge_r, badge_g, badge_b = 0, 200, 100
+    elif score < 70:
+        badge_r, badge_g, badge_b = 255, 179, 71
+    else:
+        badge_r, badge_g, badge_b = 255, 68, 102
+    pdf.set_fill_color(badge_r, badge_g, badge_b)
+    pdf.set_text_color(10, 10, 15)
+    pdf.set_x(pdf.l_margin + _page_w(pdf) - 55)
+    pdf.set_font(family, "B", 11)
+    pdf.cell(50, 6, _safe(f"Risque: {label} ({score}/100)"), align="C", fill=True)
+    pdf.ln(8)
+
+    # Big numbers row (4 KPI cells)
+    pdf.set_text_color(0, 221, 68)
+    pdf.set_font(family, "B", 18)
+    box_w = (_page_w(pdf) - 8) / 4
+    y_kpi = pdf.get_y() + 2
+    kpis = [
+        (str(m.get("connections", 0)), "connexions"),
+        (str(m.get("unique_hosts", 0)), "hôtes"),
+        (str(m.get("successful", 0)), "OK 2xx/3xx"),
+        (str(m.get("tls_pinned", 0)), "cert-pinning"),
+    ]
+    for i, (n, lbl) in enumerate(kpis):
+        x = pdf.l_margin + 4 + i * box_w
+        pdf.set_xy(x, y_kpi)
+        pdf.set_font(family, "B", 16)
+        pdf.set_text_color(0, 255, 85)
+        pdf.cell(box_w, 7, n, ln=False, align="C")
+        pdf.set_xy(x, y_kpi + 7)
+        pdf.set_font(family, "", 8)
+        pdf.set_text_color(150, 150, 150)
+        pdf.cell(box_w, 4, _safe(lbl), ln=False, align="C")
+
+    # Top device + top app + top country lines
+    pdf.set_xy(pdf.l_margin + 4, hero_y + 30)
+    pdf.set_font(family, "", 9)
+    pdf.set_text_color(220, 220, 200)
+    top_device = avatar.get("most_common") or "?"
+    top_device_emoji = avatar.get("most_common_emoji") or ""
+    top_app = "?"
+    if dpi_cls.get("top_apps"):
+        ta = dpi_cls["top_apps"][0]
+        top_app = f"{ta.get('emoji', '')} {ta.get('app', '?')}"
+    top_country = "?"
+    if geo_hosts:
+        gh = geo_hosts[0]
+        if gh.get("flag") or gh.get("country"):
+            top_country = f"{gh.get('flag', '')} {gh.get('asn_org', '?')[:30]}"
+    pdf.cell(0, 4, _safe(f"Top device : {top_device_emoji} {top_device}  ·  Top app : {top_app}  ·  Top ASN : {top_country}"), ln=True)
+
+    # Reset cursor + colors below the hero
+    pdf.set_y(hero_y + 44)
+    pdf.set_text_color(0, 0, 0)
+    pdf.ln(2)
 
 
 def _safe(text: str) -> str:

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -6,11 +6,23 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import logging
 import secrets
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 
 from .models import ReportToken
+
+log = logging.getLogger("secubox.toolbox.reports")
+
+# Phase 3 (#492) : Unicode fonts for real emoji rendering in PDF
+DEJAVU_PATH = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+DEJAVU_BOLD_PATH = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+DEJAVU_OBLIQUE_PATH = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Oblique.ttf"
+# Symbola : broad monochrome emoji + symbol coverage (📱📡🔍🔒🎯🎵🐙📊🍪…)
+# Apt package : fonts-symbola
+SYMBOLA_PATH = "/usr/share/fonts/truetype/ancient-scripts/Symbola_hint.ttf"
 
 
 def mint_token(mac_hash: str, salt: str, ttl_seconds: int = 86400) -> ReportToken:
@@ -51,6 +63,46 @@ def build_report_data(mac_hash: str, session_data: dict) -> dict:
     }
 
 
+def _setup_fonts(pdf) -> str:
+    """Load DejaVu Sans (broad Unicode) + Symbola (emoji) for the PDF.
+
+    Falls back to Helvetica (latin-1 only) if fonts are absent.
+
+    Returns the font family name to use for set_font() calls.
+    """
+    family = "Helvetica"
+    if Path(DEJAVU_PATH).exists():
+        try:
+            pdf.add_font("DejaVu", style="", fname=DEJAVU_PATH)
+            if Path(DEJAVU_BOLD_PATH).exists():
+                pdf.add_font("DejaVu", style="B", fname=DEJAVU_BOLD_PATH)
+            if Path(DEJAVU_OBLIQUE_PATH).exists():
+                pdf.add_font("DejaVu", style="I", fname=DEJAVU_OBLIQUE_PATH)
+            family = "DejaVu"
+            # Fallback chain : Symbola covers 📱📡🔍🔒🎯🎵🐙📊🍪 + most emoji
+            # not present in DejaVu.
+            fallback = []
+            if Path(SYMBOLA_PATH).exists():
+                try:
+                    pdf.add_font("Symbola", style="", fname=SYMBOLA_PATH)
+                    fallback.append("Symbola")
+                except Exception as e:
+                    log.warning("Symbola font load failed: %s", e)
+            if fallback:
+                try:
+                    # exact_match=False so Bold/Italic text also falls back to
+                    # regular Symbola (it has no Bold variant).
+                    pdf.set_fallback_fonts(fallback, exact_match=False)
+                except TypeError:
+                    # Older fpdf2 without exact_match param
+                    pdf.set_fallback_fonts(fallback)
+                except Exception as e:
+                    log.warning("set_fallback_fonts failed: %s", e)
+        except Exception as e:
+            log.warning("DejaVu font load failed (%s), falling back to Helvetica", e)
+    return family
+
+
 def render_pdf(report: dict) -> bytes:
     """Render the analysis report as PDF (fpdf2). Returns the binary blob."""
     try:
@@ -63,13 +115,18 @@ def render_pdf(report: dict) -> bytes:
     pdf.add_page()
     pdf.set_auto_page_break(auto=True, margin=15)
 
+    # Phase 3 (#492) : Unicode font for emoji rendering
+    family = _setup_fonts(pdf)
+    # Stash for the helper functions to use
+    pdf._secubox_family = family
+
     # Header
-    pdf.set_font("Helvetica", "B", 18)
+    pdf.set_font(family, "B", 18)
     pdf.set_text_color(0, 90, 64)  # P31 dim green
-    pdf.cell(0, 12, "GONDWANA TOOLBOX", ln=True, align="C")
-    pdf.set_font("Helvetica", "", 11)
+    pdf.cell(0, 12, "📡 GONDWANA TOOLBOX", ln=True, align="C")
+    pdf.set_font(family, "", 11)
     pdf.set_text_color(110, 64, 201)
-    pdf.cell(0, 6, "Rapport d'analyse de session - Cabine numerique VILLAGE3B", ln=True, align="C")
+    pdf.cell(0, 6, "Rapport d'analyse de session — Cabine numérique VILLAGE3B", ln=True, align="C")
     pdf.ln(4)
 
     # Anonymous ID
@@ -99,7 +156,7 @@ def render_pdf(report: dict) -> bytes:
     _section(pdf, "ANALYSE COMPROMISSION")
     score = report.get("risk_score", 0)
     risk_label = report.get("risk_label") or ("LOW" if score < 30 else "MEDIUM" if score < 70 else "HIGH")
-    pdf.set_font("Helvetica", "B", 13)
+    pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "B", 13)
     if score < 30:
         pdf.set_text_color(0, 221, 68)
     elif score < 70:
@@ -108,7 +165,7 @@ def render_pdf(report: dict) -> bytes:
         pdf.set_text_color(255, 68, 102)
     pdf.cell(0, 8, _ascii_safe(f"Score risque : {score}/100 ({risk_label})"), ln=True)
     pdf.set_text_color(0)
-    pdf.set_font("Helvetica", "", 10)
+    pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "", 10)
     pdf.ln(1)
     explanation = report.get("risk_explanation", "")
     if explanation:
@@ -124,9 +181,9 @@ def render_pdf(report: dict) -> bytes:
     if breakdown:
         _section(pdf, "BREAKDOWN DU SCORE")
         for b in breakdown:
-            pdf.set_font("Helvetica", "B", 9)
+            pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "B", 9)
             pdf.cell(0, 5, f"{b.get('category', '?').upper()} : poids {b.get('weight_subtotal', 0)} (sur {b.get('raw_signal_count', 0)} signal)", ln=True)
-            pdf.set_font("Helvetica", "", 8)
+            pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "", 8)
             for ex in (b.get("examples") or [])[:3]:
                 _bullet(pdf, ex, font_size=8)
         pdf.ln(2)
@@ -271,16 +328,66 @@ def render_pdf(report: dict) -> bytes:
         # Per-host quality table — worst first, capped 10
         per_host = t.get("per_host") or []
         if per_host:
-            _section(pdf, "QUALITE SECURITE PAR DESTINATION (worst-first)")
+            _section(pdf, "🎯 QUALITÉ SÉCURITÉ PAR DESTINATION (worst-first)")
             for h in per_host[:10]:
                 grade = h.get("grade", "?")
                 host = h.get("host", "?")[:50]
                 status = h.get("status", "?")
-                _bullet(pdf, f"[{grade}] {host} - {status}", font_size=8)
+                _bullet(pdf, f"[{grade}] {host} — {status}", font_size=8)
             pdf.ln(2)
 
+    # Phase 2b/2c (#488/#490) : per-module mitm-ingest aggregate metrics
+    mm = report.get("mitm_modules") or {}
+    if mm and any(v.get("count", 0) > 0 for v in mm.values() if isinstance(v, dict)):
+        _section(pdf, "🛰 INGESTION PAR MODULE (Phase 2b/2c)")
+        for kind, data in mm.items():
+            if not isinstance(data, dict):
+                continue
+            cnt = data.get("count", 0)
+            if cnt == 0:
+                continue
+            emoji = {"dpi": "🌐", "cookies": "🍪", "avatar": "👤",
+                     "soc": "🛡", "threat-analyst": "🕵"}.get(kind, "📡")
+            _bullet(pdf, f"{emoji} secubox-{kind} : {cnt} events ingérés (24h)", font_size=9)
+            es = data.get("enriched_summary") or {}
+            # Per-module top items
+            if kind == "dpi" and es.get("top_apps"):
+                apps_str = " · ".join(f"{a.get('emoji','?')} {a.get('app','?')}×{a.get('count',0)}"
+                                       for a in es["top_apps"][:5])
+                _bullet(pdf, f"   Top apps : {apps_str[:200]}", font_size=8)
+            elif kind == "cookies" and es.get("top_providers"):
+                provs = " · ".join(f"{p.get('emoji','?')} {p.get('provider','?')}×{p.get('count',0)}"
+                                    for p in es["top_providers"][:5])
+                _bullet(pdf, f"   Top trackers : {provs[:200]}", font_size=8)
+                _bullet(pdf, f"   Total tracker hits : {es.get('tracker_total', 0)}", font_size=8)
+            elif kind == "avatar":
+                devs = es.get("devices") or {}
+                if devs:
+                    dev_str = " · ".join(f"{v.get('emoji','?')} {k}×{v.get('count',0)}"
+                                          for k, v in list(devs.items())[:5])
+                    _bullet(pdf, f"   Devices : {dev_str[:200]}", font_size=8)
+                brws = es.get("browsers") or {}
+                if brws:
+                    brw_str = " · ".join(f"{v.get('emoji','?')} {k}×{v.get('count',0)}"
+                                          for k, v in list(brws.items())[:5])
+                    _bullet(pdf, f"   Browsers : {brw_str[:200]}", font_size=8)
+            elif kind == "soc":
+                _bullet(pdf, f"   Score total : {es.get('total_weight', 0)} · "
+                             f"Band : {es.get('max_band', 'low')}", font_size=8)
+                kinds = es.get("indicator_kinds") or {}
+                if kinds:
+                    k_str = " · ".join(f"{k}×{v}" for k, v in list(kinds.items())[:5])
+                    _bullet(pdf, f"   Indicateurs : {k_str[:180]}", font_size=8)
+            elif kind == "threat-analyst" and es.get("top_fingerprints"):
+                fps = ", ".join(f.get("fingerprint", "?")[:12]
+                                 for f in es["top_fingerprints"][:5])
+                _bullet(pdf, f"   JA4 fingerprints uniques : {es.get('unique_count', 0)}",
+                        font_size=8)
+                _bullet(pdf, f"   Top : {fps[:180]}", font_size=8)
+        pdf.ln(2)
+
     # Retention
-    _section(pdf, "RETENTION DES DONNEES")
+    _section(pdf, "🔒 RÉTENTION DES DONNÉES")
     _bullet(pdf, "Hash MAC anonyme : 24h (sel rotatif quotidien)")
     _bullet(pdf, "Events detailles : 24h")
     _bullet(pdf, "Rapport ephemere : 24h (lien HMAC scelle)")
@@ -298,7 +405,7 @@ def render_pdf(report: dict) -> bytes:
     pdf.ln(4)
 
     # Footer
-    pdf.set_font("Helvetica", "I", 8)
+    pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "I", 8)
     pdf.set_text_color(110, 64, 201)
     pdf.cell(0, 4, "Gondwana ToolBoX  -  LicenseRef-CMSD-1.0 (Source-Disclosed License)", ln=True, align="C")
     pdf.cell(0, 4, "Source : github.com/CyberMind-FR/secubox-deb (issues #474 #475 #477)", ln=True, align="C")
@@ -311,50 +418,64 @@ def _page_w(pdf) -> float:
     return pdf.w - pdf.l_margin - pdf.r_margin
 
 
-# Helvetica is latin-1 only ; PDF report uses ASCII replacements for emoji
-# (HTML live report keeps the real emoji glyphs).
+# Phase 3 (#492) : with DejaVu Sans + Noto fallback, most emojis render as
+# real glyphs (monochrome). For chars not in either font (e.g. some flags,
+# very recent emoji), we fall back to a small ASCII replacement table.
 _EMOJI_REPLACEMENTS = {
-    "📺": "[TV]", "🎬": "[FILM]", "🎵": "[MUSIC]", "👥": "[SOCIAL]",
-    "📷": "[PHOTO]", "🐦": "[X]", "👾": "[REDDIT]", "💼": "[WORK]",
-    "📌": "[PIN]", "🐘": "[MASTO]", "🦋": "[BSKY]", "🔒": "[E2E]",
-    "💬": "[CHAT]", "✈": "[TG]", "🟢": "[OK]", "🔍": "[SEARCH]",
-    "🦆": "[DDG]", "📦": "[BOX]", "☁": "[CLOUD]", "🐙": "[GH]",
-    "🦊": "[FF]", "📚": "[DOC]", "🏦": "[BANK]", "📧": "[MAIL]",
-    "🍎": "[APPLE]", "🧅": "[TOR]", "🔐": "[VPN]", "❔": "[?]",
-    "📱": "[PHONE]", "💻": "[PC]", "🐧": "[LINUX]", "🎮": "[GAME]",
-    "📟": "[BOT]", "🛠": "[TOOL]", "🪟": "[EDGE]", "🧭": "[SAFARI]",
-    "🔴": "[OPERA]", "🇫🇷": "[FR]", "🇺🇸": "[US]", "🏳": "[??]",
-    "📊": "[STATS]", "🎯": "[ADS]", "🟦": "[BLOCK]", "—": "-",
-    "·": "-", "…": "...", "✅": "[OK]", "⚠": "[WARN]", "❌": "[KO]",
+    # Common emojis NOT in DejaVu Sans + Symbola fallback — replaced gracefully
+    # Flag emojis (regional indicator pairs, not in monochrome fonts)
+    "🇫🇷": "[FR]", "🇺🇸": "[US]", "🇩🇪": "[DE]", "🇨🇳": "[CN]",
+    "🇬🇧": "[GB]", "🇯🇵": "[JP]", "🇨🇦": "[CA]", "🇮🇪": "[IE]",
+    "🇮🇹": "[IT]", "🇪🇸": "[ES]", "🇧🇪": "[BE]", "🇨🇭": "[CH]",
+    "🇳🇱": "[NL]", "🇸🇪": "[SE]", "🇮🇱": "[IL]", "🇧🇷": "[BR]",
+    "🇷🇺": "[RU]", "🇮🇳": "[IN]", "🇰🇷": "[KR]", "🇦🇺": "[AU]",
+    "🏳": "[??]",
+    # Recent emoji (2020+) not in Symbola
+    "🟢": "[OK]",  # green circle
+    "🟡": "[WARN]",  # yellow circle
+    "🔴": "[KO]",  # red circle (also used for Opera but contextual)
+    "🟦": "[BOX]",  # blue square
+    "🦋": "[BSKY]",  # butterfly
+    "🦊": "[FF]",  # fox face
+    "🪟": "[EDGE]",  # window
 }
 
 
-def _ascii_safe(text: str) -> str:
-    """Strip / replace characters outside Helvetica's latin-1 coverage."""
+def _safe(text: str) -> str:
+    """Replace chars not in DejaVu+NotoSymbols fonts (mostly flag emojis).
+
+    Most emoji render directly via DejaVu Sans + fallback. Flag emojis use
+    regional indicator pairs that aren't in DejaVu, so we substitute them
+    with their ISO country code in brackets.
+    """
     if not text:
         return ""
     s = str(text)
     for emoji, repl in _EMOJI_REPLACEMENTS.items():
         if emoji in s:
             s = s.replace(emoji, repl)
-    # Final fallback : encode to latin-1 ignoring unknown chars
-    return s.encode("latin-1", errors="replace").decode("latin-1")
+    return s
+
+
+def _ascii_safe(text: str) -> str:
+    """Backward-compat alias (other code paths still call this name)."""
+    return _safe(text)
 
 
 def _section(pdf, title: str) -> None:
     pdf.set_x(pdf.l_margin)
-    pdf.set_font("Helvetica", "B", 12)
+    pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "B", 12)
     pdf.set_text_color(0, 221, 68)
     pdf.multi_cell(_page_w(pdf), 7, _ascii_safe(title)[:80])
-    pdf.set_font("Helvetica", "", 10)
+    pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "", 10)
     pdf.set_text_color(0)
 
 
 def _kv(pdf, key: str, value: str) -> None:
     pdf.set_x(pdf.l_margin)
-    pdf.set_font("Helvetica", "B", 9)
+    pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "B", 9)
     pdf.cell(45, 5, _ascii_safe(key)[:30], ln=False)
-    pdf.set_font("Helvetica", "", 9)
+    pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "", 9)
     pdf.cell(_page_w(pdf) - 45, 5, _ascii_safe(value)[:100], ln=True)
 
 
@@ -362,7 +483,7 @@ def _bullet(pdf, text: str, font_size: int = 9) -> None:
     """Render a bullet line. multi_cell with hard truncation to avoid fpdf
     'Not enough horizontal space' errors on long tokens/URLs."""
     pdf.set_x(pdf.l_margin)
-    pdf.set_font("Helvetica", "", font_size)
+    pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "", font_size)
     safe = _ascii_safe(text)[:160]
     # Break unreasonably long single tokens (URLs over ~60 chars)
     parts = []

--- a/packages/secubox-toolbox/secubox_toolbox/store.py
+++ b/packages/secubox-toolbox/secubox_toolbox/store.py
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS clients (
     ip TEXT,
     state TEXT NOT NULL DEFAULT 'validated',
     score INTEGER NOT NULL DEFAULT 0,
+    level TEXT NOT NULL DEFAULT 'r1',
     first_seen INTEGER NOT NULL,
     last_seen INTEGER NOT NULL
 );
@@ -64,14 +65,36 @@ def record_consent(mac_hash: str, ip: str, ua: str | None, ttl_seconds: int) -> 
         )
 
 
-def upsert_client(mac_hash: str, ip: str) -> None:
+def upsert_client(mac_hash: str, ip: str, level: str = "r1") -> None:
+    """Phase 3 (#492) : level = 'r0' | 'r1' | 'r2' opt-in tier."""
     now = int(time.time())
     with _conn() as c:
+        # Idempotent add of level column (for upgrades from pre-#492 DB)
+        try:
+            c.execute("ALTER TABLE clients ADD COLUMN level TEXT NOT NULL DEFAULT 'r1'")
+        except sqlite3.OperationalError:
+            pass  # column already exists
         c.execute(
-            "INSERT INTO clients(mac_hash, ip, first_seen, last_seen) VALUES (?,?,?,?) "
-            "ON CONFLICT(mac_hash) DO UPDATE SET ip=excluded.ip, last_seen=excluded.last_seen",
-            (mac_hash, ip, now, now),
+            "INSERT INTO clients(mac_hash, ip, level, first_seen, last_seen) "
+            "VALUES (?,?,?,?,?) "
+            "ON CONFLICT(mac_hash) DO UPDATE SET ip=excluded.ip, "
+            "level=excluded.level, last_seen=excluded.last_seen",
+            (mac_hash, ip, level, now, now),
         )
+
+
+def get_client_level(mac_hash: str) -> str:
+    """Returns 'r0' | 'r1' | 'r2'. Default 'r1' if not found."""
+    try:
+        with _conn() as c:
+            row = c.execute(
+                "SELECT level FROM clients WHERE mac_hash=?", (mac_hash,)
+            ).fetchone()
+            if row:
+                return row["level"] or "r1"
+    except Exception:
+        pass
+    return "r1"
 
 
 def add_event(mac_hash: str, source: str, payload: dict) -> None:


### PR DESCRIPTION
Closes #492

## TL;DR

Foundation for the **Reverse-WAF Honesty Layer** : the cabine tells the user not just what it inspected, but what it DELIBERATELY BYPASSED and WHY. Quality grade A+/A/B/C/D/F per destination. Zero blocking (Phase 4 will add that on top).

## Deliverables

### 1. Whitelist with auto-direction + reasons
- `common/secubox_core/whitelist.py` : YAML loader, fnmatch globs, hot-reload
- `conf/whitelist-baseline.yaml` : 47 curated patterns shipped to `/usr/share/secubox/toolbox/`
- Operator override : `/etc/secubox/toolbox/whitelist.yaml` (survives upgrades)
- Categories : `vendor-os` / `messaging-e2e` / `financial` / `government` / `health` / `privacy-tools` / `anon-network`

### 2. Analysis-status tagging
- Every DPI event now carries `analysis_status` + `analysis_reason` :
  - `inspected` — MITM decryption succeeded via ToolBoX CA
  - `bypassed-whitelist` — policy decision, reason from YAML
  - `e2e-opaque` — Signal/Threema/etc, opaque by design
  - `pinned-failed-mitm` — cert-pinning, app refused our CA
- New `tls_failed_clienthello` hook captures SNI of failed handshakes

### 3. Security quality scorer
- `common/secubox_core/classifiers/security_quality.py`
- Passive mode : TLS version + JA4 + SNI + ALPN + is_e2e_messaging
- Active mode : adds HSTS + CSP + cookies attrs + mixed-content
- Returns A+/A/B/C/D/F + per-criterion breakdown

### 4. Reports

User-facing : `http://village3b/report/me/html` now shows :

```
🔎 INSPECTION : CE QU'ON A REGARDÉ (et ce qu'on n'a PAS regardé)
  🔍 Inspecté (HTTPS via notre CA)     57% — contenu visible
  🛡 Bypass whitelist                  23% — décision policy (cert-pinning vendor)
  🔒 Cert-pinning détecté              15% — l'app refuse notre CA, normal+bon signe
  🔐 E2E messaging                      5% — opaque par design, ton chiffrement marche

🎯 QUALITÉ SÉCURITÉ PAR DESTINATION (worst-first)
  D  api.dgaXXX.tk          inspected — TLS 1.2 only, no HSTS
  C  starwalk.space         inspected — TLS 1.3 but cookies non-Secure
  A+ assets.revolut.com     bypassed-whitelist — Banking, MITM forbidden by policy
  A+ push.apple.com         bypassed-whitelist — APN cert-pinned, no MITM possible
```

PDF download : mirrors the same sections, ASCII-safe.

## E2E verified (gk2 2026-06-05)

- `whitelist_stats: count=47, baseline_loaded=True`
- aggregator returns `transparency.has_transparency=True`
- per_host populated with quality grades
- PDF still generates clean (4kB)

## Architecture-ready for #493 (full reverse-WAF)

- `whitelist.match()` already returns the full entry dict — Phase 4 will add `action: block/redirect/strip` fields next to `reason/category`
- `analysis_status` enum is extensible (`blocked-by-rule` will join the values)
- `security_quality.grade_active()` already takes headers + cookies — Phase 4 will populate them via mitmproxy response capture

## License

LicenseRef-CMSD-1.0 strict.

## Test plan

- [ ] iPhone : VILLAGE3B → splash → accept → surf 5min
- [ ] `http://village3b/report/me/html` → vérifier les 2 nouvelles cards
- [ ] PDF `http://village3b/report/me` → vérifier sections INSPECTION + QUALITE
- [ ] Confirmer breakdown_pct reflète des % réalistes (>0% sur bypass-whitelist + pinned + inspected)
- [ ] Confirmer Apple/banking/Signal apparaissent en bypass-whitelist (pas en "other")