### PR TITLE
fix: /var/log/secubox traversal — converge postinsts to 0755 (#511)

### DIFF
--- a/packages/secubox-admin/debian/postinst
+++ b/packages/secubox-admin/debian/postinst
@@ -8,7 +8,7 @@ case "$1" in
     install -d -o secubox -g secubox -m 750 /run/secubox
     install -d -o secubox -g secubox -m 750 /var/lib/secubox
     install -d -o secubox -g secubox -m 750 /var/lib/secubox/admin
-    install -d -o root -g secubox -m 750 /var/log/secubox
+    install -d -o root -g secubox -m 0755 /var/log/secubox
     systemctl daemon-reload
     systemctl enable secubox-admin.service
     systemctl start  secubox-admin.service || true

--- a/packages/secubox-mesh/debian/postinst
+++ b/packages/secubox-mesh/debian/postinst
@@ -20,7 +20,7 @@ case "$1" in
     # NE PAS le toucher ici — l'écraser bloque la traversée nginx (www-data) et
     # casse tous les /api/v1/<module>/* en 502 (cf. #471). Si besoin d'un
     # sous-dossier privé, utiliser /run/secubox/mesh/ (et non le parent).
-    install -d -m 0750 -o secubox-mesh -g secubox-mesh /var/log/secubox
+    install -d -m 0755 -o secubox-mesh -g secubox-mesh /var/log/secubox
 
     # 4. Verrou régulatoire FR (idempotent ; ne pas planter si iw absent)
     if command -v iw >/dev/null 2>&1; then

--- a/packages/secubox-toolbox/debian/postinst
+++ b/packages/secubox-toolbox/debian/postinst
@@ -44,7 +44,13 @@ case "$1" in
 
     # 4. Storage dir (SQLite + future PDF reports)
     install -d -m 0750 -o secubox-toolbox -g secubox-toolbox /var/lib/secubox/toolbox
-    install -d -m 0750 -o secubox-toolbox -g secubox-toolbox /var/log/secubox
+    # /var/log/secubox is a SHARED parent traversed by many service users
+    # (the aggregator runs as `secubox` and reads waf-threats.log under
+    # here).  It MUST be 0755 — a 0750 owned by secubox-toolbox silently
+    # breaks WAF + SOC dashboards for the `secubox` user (#511, regressed
+    # the /waf/ + /soc/ pages on gk2 2026-06-10).  Per-module log files +
+    # subdirs inside keep their own restricted perms.
+    install -d -m 0755 -o secubox-toolbox -g secubox-toolbox /var/log/secubox
 
     # 4b. GeoLite2 databases (Phase 2a+ : flag emojis + ASN org)
     # ASN DB from geoipupdate or Debian package geoip-database


### PR DESCRIPTION
Closes #511.

Shared-directory ownership race broke /waf/ + /soc/ on gk2 (2026-06-10). secubox-toolbox + secubox-mesh created /var/log/secubox at 0750 with their own module owner; secubox-admin at 750; ~10 others correctly use 0755 secubox:secubox. Last postinst wins — when toolbox/mesh won, the aggregator (user secubox) lost traversal.

- secubox-toolbox/debian/postinst:47  0750 → 0755 (+ guard comment)
- secubox-mesh/debian/postinst:23     0750 → 0755
- secubox-admin/debian/postinst:11    750  → 0755

Already chmod'd live during triage; this survives reflash. Same class as #507 www chmod + /etc/secubox traversal.