### PR TITLE
Phase 13.C — DHCP/WG per-device attribution + quarantine (#524)

### DIFF
--- a/packages/secubox-toolbox/debian/changelog
+++ b/packages/secubox-toolbox/debian/changelog
@@ -1,3 +1,27 @@
+secubox-toolbox (2.6.10-1~bookworm1) bookworm; urgency=medium
+
+  * Phase 13.C (#524, parent #519) — DHCP/WG per-device attribution +
+    quarantine.
+      - secubox-blacklist.nft : quarantine_v4/v6 sets + a quarantine-first
+        rule in the enforce chain (a quarantined device's saddr is fully
+        dropped). Rate-limited log prefixes SBX-BL-DROP (enforce drops)
+        and SBX-DOH (DoH watch, ct state new) for attribution.
+      - secubox_toolbox/device_blocks.py : device resolver (R3 WG peer
+        hash / dnsmasq-lease MAC hash with rotating salt / IP fallback)
+        + device_blocks SQLite aggregate + retention.
+      - sbin/secubox-blacklist-attrib : journald kernel-log tailer
+        (cursor-based) that buckets SBX-BL-DROP / SBX-DOH by source IP,
+        maps to an anonymous device, upserts device_blocks. 2-min timer.
+      - api.py : GET /admin/device-blocks (per-device aggregate),
+        POST /admin/quarantine/{ip} + /admin/unquarantine/{ip}.
+      - app.py : device_blocks 7-day retention in the purge loop.
+      - index.html operator tab : per-device blocked-attempts card with
+        a one-click quarantine action.
+    Anonymous attribution (rotating mac_hash). Auto-quarantine NOT wired
+    (operator-manual only this pass ; threshold policy is #519 Q2).
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 11 Jun 2026 10:00:00 +0200
+
 secubox-toolbox (2.6.9-1~bookworm1) bookworm; urgency=medium
 
   * Phase 13.B (#522, parent #519) — DNS-guard : resolve blocklisted

--- a/packages/secubox-toolbox/debian/postinst
+++ b/packages/secubox-toolbox/debian/postinst
@@ -168,6 +168,9 @@ fi
         systemctl start secubox-blacklist-sync.timer 2>/dev/null || true
         # Kick an immediate first sync (best-effort).
         systemctl start secubox-blacklist-sync.service 2>/dev/null || true
+        # Phase 13.C (#524) : per-device attribution tailer timer.
+        systemctl enable secubox-blacklist-attrib.timer 2>/dev/null || true
+        systemctl start secubox-blacklist-attrib.timer 2>/dev/null || true
       fi
     fi
 

--- a/packages/secubox-toolbox/debian/rules
+++ b/packages/secubox-toolbox/debian/rules
@@ -88,6 +88,13 @@ execute_after_dh_auto_install:
 	  debian/secubox-toolbox/lib/systemd/system/
 	install -m 0644 systemd/secubox-blacklist-sync.timer \
 	  debian/secubox-toolbox/lib/systemd/system/
+	# Phase 13.C (#524) : per-device attribution tailer + timer.
+	install -m 0755 sbin/secubox-blacklist-attrib \
+	  debian/secubox-toolbox/usr/sbin/
+	install -m 0644 systemd/secubox-blacklist-attrib.service \
+	  debian/secubox-toolbox/lib/systemd/system/
+	install -m 0644 systemd/secubox-blacklist-attrib.timer \
+	  debian/secubox-toolbox/lib/systemd/system/
 	install -m 0755 sbin/secubox-toolbox-wg-restore \
 	  debian/secubox-toolbox/usr/sbin/
 	install -m 0644 systemd/secubox-toolbox-wg-restore.service \

--- a/packages/secubox-toolbox/nftables.d/secubox-blacklist.nft
+++ b/packages/secubox-toolbox/nftables.d/secubox-blacklist.nft
@@ -39,11 +39,31 @@ table inet secubox_blacklist {
         flags interval, timeout
     }
 
+    # Phase 13.C (#524) — per-device quarantine. An operator (or the
+    # auto-quarantine policy, default off) adds a device's source IP here ;
+    # ALL its forward traffic is dropped until the entry expires / is
+    # removed. Separate from the C2 blacklist so un-quarantine is a single
+    # set op and the device dashboard can show quarantine state distinctly.
+    set quarantine_v4 {
+        type ipv4_addr
+        flags interval, timeout
+    }
+    set quarantine_v6 {
+        type ipv6_addr
+        flags interval, timeout
+    }
+
     chain enforce {
         type filter hook forward priority -10; policy accept;
-        ip  daddr @blacklist_v4 counter drop
+        # Quarantine first : a quarantined device is fully cut off.
+        ip  saddr @quarantine_v4 counter drop
+        ip6 saddr @quarantine_v6 counter drop
+        # C2 blacklist (13.A). Phase 13.C : rate-limited log so the
+        # attribution tailer can bucket drops per source device without
+        # flooding the kernel log.
+        ip  daddr @blacklist_v4 limit rate 20/second log prefix "SBX-BL-DROP " counter drop
         ip  saddr @blacklist_v4 counter drop
-        ip6 daddr @blacklist_v6 counter drop
+        ip6 daddr @blacklist_v6 limit rate 20/second log prefix "SBX-BL-DROP " counter drop
         ip6 saddr @blacklist_v6 counter drop
     }
 
@@ -64,7 +84,9 @@ table inet secubox_blacklist {
     }
     chain doh_watch {
         type filter hook forward priority -11; policy accept;
-        ip  daddr @doh_detect_v4 tcp dport { 443, 853 } counter
-        ip6 daddr @doh_detect_v6 tcp dport { 443, 853 } counter
+        # Phase 13.C : rate-limited log (new connections only) so the
+        # attribution tailer can bucket DoH attempts per device.
+        ip  daddr @doh_detect_v4 tcp dport { 443, 853 } ct state new limit rate 5/second log prefix "SBX-DOH " counter
+        ip6 daddr @doh_detect_v6 tcp dport { 443, 853 } ct state new limit rate 5/second log prefix "SBX-DOH " counter
     }
 }

--- a/packages/secubox-toolbox/sbin/secubox-blacklist-attrib
+++ b/packages/secubox-toolbox/sbin/secubox-blacklist-attrib
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+#
+# SecuBox-Deb :: secubox-blacklist-attrib (Phase 13.C #524)
+#
+# Reads the kernel log for the nft drop/DoH log prefixes (SBX-BL-DROP /
+# SBX-DOH), extracts SRC=/DST=, maps SRC to an anonymous device hash, and
+# records per-device block events into device_blocks.  Runs on a timer ;
+# uses a cursor file so each run only consumes new journal lines.
+set -euo pipefail
+readonly MODULE="secubox-blacklist-attrib"
+
+CURSOR=/run/secubox/blacklist-attrib.cursor
+PYHELPER=/usr/lib/secubox/toolbox
+mkdir -p /run/secubox 2>/dev/null || true
+
+log() { logger -t "$MODULE" -- "$*" 2>/dev/null || echo "[$MODULE] $*" >&2; }
+
+# Pull new kernel-log lines since the saved cursor (journald), kernel
+# facility only, matching our prefixes. --after-cursor needs a stored
+# cursor ; first run uses --since to bound the backlog.
+JARGS=(-k -o export --no-pager)
+if [ -r "$CURSOR" ] && [ -s "$CURSOR" ]; then
+    JARGS+=(--after-cursor "$(cat "$CURSOR")")
+else
+    JARGS+=(--since "-5min")
+fi
+
+# Collect SRC/DST per prefix into a temp, then hand to python for the
+# device mapping + DB upsert (one process, not per-line).
+TMP=$(mktemp); trap 'rm -f "$TMP"' EXIT
+
+# journalctl -o export emits field=value blocks ; we grep MESSAGE lines.
+# Save the last cursor seen so the next run resumes cleanly.
+LASTCUR=""
+while IFS= read -r line; do
+    case "$line" in
+        __CURSOR=*) LASTCUR="${line#__CURSOR=}" ;;
+        MESSAGE=*SBX-BL-DROP*)
+            src=$(printf '%s\n' "$line" | sed -n 's/.*SRC=\([0-9a-fA-F:.]*\).*/\1/p')
+            dst=$(printf '%s\n' "$line" | sed -n 's/.*DST=\([0-9a-fA-F:.]*\).*/\1/p')
+            [ -n "$src" ] && printf 'blacklist-drop\t%s\t%s\n' "$src" "$dst" >> "$TMP"
+            ;;
+        MESSAGE=*SBX-DOH*)
+            src=$(printf '%s\n' "$line" | sed -n 's/.*SRC=\([0-9a-fA-F:.]*\).*/\1/p')
+            dst=$(printf '%s\n' "$line" | sed -n 's/.*DST=\([0-9a-fA-F:.]*\).*/\1/p')
+            [ -n "$src" ] && printf 'doh-attempt\t%s\t%s\n' "$src" "$dst" >> "$TMP"
+            ;;
+    esac
+done < <(journalctl "${JARGS[@]}" 2>/dev/null | grep -aE '^(__CURSOR=|MESSAGE=.*SBX-(BL-DROP|DOH))')
+
+# Persist the cursor for the next run.
+[ -n "$LASTCUR" ] && printf '%s' "$LASTCUR" > "$CURSOR" 2>/dev/null || true
+
+count=$(wc -l < "$TMP" 2>/dev/null || echo 0)
+if [ "$count" -gt 0 ]; then
+    PYTHONPATH="$PYHELPER" python3 - "$TMP" <<'PYEOF'
+import sys
+from secubox_toolbox import device_blocks as db
+n = 0
+with open(sys.argv[1]) as f:
+    for ln in f:
+        parts = ln.rstrip("\n").split("\t")
+        if len(parts) != 3:
+            continue
+        kind, src, dst = parts
+        mac = db.resolve_device(src)
+        db.record_block(mac, src, kind, dst or "?")
+        n += 1
+print(n)
+PYEOF
+fi
+log "attributed ${count} block events"
+exit 0

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -2153,6 +2153,54 @@ async def admin_blacklist() -> dict:
     return out
 
 
+@router.get("/admin/device-blocks")
+async def admin_device_blocks(hours: int = 24) -> dict:
+    """Phase 13.C (#524) — per-device blocked-attempts attribution :
+    which anonymous device hit blacklisted IPs / DoH endpoints, how often.
+    """
+    from . import device_blocks as _db
+    return _db.aggregate(hours=hours)
+
+
+def _quarantine_ip(ip: str, add: bool, ttl: str = "6h") -> dict:
+    """Add/remove a device source IP to the nft quarantine set."""
+    import ipaddress as _ip
+    import subprocess as _sp
+    try:
+        addr = _ip.ip_address(ip)
+    except ValueError:
+        raise HTTPException(400, f"invalid IP {ip!r}")
+    setname = "quarantine_v6" if addr.version == 6 else "quarantine_v4"
+    op = "add" if add else "delete"
+    elem = f"{ip} timeout {ttl}" if add else ip
+    try:
+        r = _sp.run(
+            ["/usr/sbin/nft", op, "element", "inet", "secubox_blacklist",
+             setname, "{ " + elem + " }"],
+            capture_output=True, text=True, timeout=5,
+        )
+        ok = r.returncode == 0
+        if not ok and not add and "No such file" in (r.stderr or ""):
+            ok = True  # already absent → treat as success
+        log.info("quarantine %s %s -> %s", op, ip, "ok" if ok else r.stderr.strip())
+        return {"ok": ok, "ip": ip, "action": op, "set": setname,
+                "error": None if ok else (r.stderr or "").strip()}
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(500, f"nft {op} failed: {e}")
+
+
+@router.post("/admin/quarantine/{ip}")
+async def admin_quarantine_add(ip: str, ttl: str = "6h") -> dict:
+    """Quarantine a device : drop ALL its forward traffic for `ttl`."""
+    return _quarantine_ip(ip, add=True, ttl=ttl)
+
+
+@router.post("/admin/unquarantine/{ip}")
+async def admin_quarantine_remove(ip: str) -> dict:
+    """Lift a device's quarantine."""
+    return _quarantine_ip(ip, add=False)
+
+
 @router.get("/social/report/{token}.pdf")
 async def social_report_pdf(token: str) -> Response:
     """Phase 11.C (#508) — bilingual FR/EN evidence PDF for a peer.

--- a/packages/secubox-toolbox/secubox_toolbox/app.py
+++ b/packages/secubox-toolbox/secubox_toolbox/app.py
@@ -65,6 +65,12 @@ async def _startup() -> None:
         while True:
             try:
                 social.purge_older_than(days=7)
+                # Phase 13.C (#524) — device-blocks retention.
+                try:
+                    from . import device_blocks as _db
+                    _db.purge_older_than(days=7)
+                except Exception:
+                    pass
             except Exception as e:
                 _log.error("social.purge_older_than failed: %s", e)
             await asyncio.sleep(3600)

--- a/packages/secubox-toolbox/secubox_toolbox/device_blocks.py
+++ b/packages/secubox-toolbox/secubox_toolbox/device_blocks.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""
+SecuBox-Deb :: ToolBoX device-blocks attribution (Phase 13.C #524)
+
+Attributes blacklist drops + DoH-bypass attempts to the DEVICE that made
+them, by mapping the packet source IP to a device identity :
+
+  - R3 WG peers (10.99.1.x)  → sha256(wg_pubkey)[:16]  (same hash as the
+    social-mapping model — anonymous, rotating-salt-equivalent via the
+    pubkey).
+  - captive subnet (10.99.0.x / br-lxc 10.100.0.x) → dnsmasq lease MAC
+    hashed with the rotating MAC salt.
+
+Storage : `device_blocks` aggregate (one row per device × kind × dst).
+Read by the /admin/device-blocks endpoint + the SOC tile.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+log = logging.getLogger("secubox.toolbox.device_blocks")
+
+DB_PATH = Path("/var/lib/secubox/toolbox/toolbox.db")
+_WG_PEERS_DB = Path("/var/lib/secubox/toolbox/wg-peers.json")
+_SALT_FILE = Path("/etc/secubox/secrets/toolbox-mac-salt")
+# Common dnsmasq lease locations.
+_LEASE_FILES = (
+    Path("/var/lib/misc/dnsmasq.leases"),
+    Path("/var/lib/dnsmasq/dnsmasq.leases"),
+    Path("/run/secubox/toolbox-dnsmasq.leases"),
+)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS device_blocks (
+    mac_hash  TEXT NOT NULL,
+    ip        TEXT NOT NULL,
+    kind      TEXT NOT NULL,        -- 'blacklist-drop' | 'doh-attempt'
+    dst       TEXT NOT NULL,
+    hits      INTEGER NOT NULL DEFAULT 0,
+    first_seen INTEGER NOT NULL,
+    last_seen  INTEGER NOT NULL,
+    PRIMARY KEY (mac_hash, kind, dst)
+);
+CREATE INDEX IF NOT EXISTS idx_devblk_ts ON device_blocks(last_seen);
+CREATE INDEX IF NOT EXISTS idx_devblk_mac ON device_blocks(mac_hash, last_seen);
+"""
+
+
+def _conn() -> sqlite3.Connection:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    c = sqlite3.connect(str(DB_PATH), timeout=5.0, isolation_level=None)
+    c.row_factory = sqlite3.Row
+    c.executescript(_SCHEMA)
+    return c
+
+
+# ── device resolver ──
+_wg_cache: Dict[str, str] = {}
+_wg_mtime: float = 0.0
+
+
+def _wg_hash(ip: str) -> Optional[str]:
+    global _wg_mtime
+    try:
+        if not _WG_PEERS_DB.exists():
+            return None
+        mt = _WG_PEERS_DB.stat().st_mtime
+        if mt != _wg_mtime or not _wg_cache:
+            _wg_cache.clear()
+            data = json.loads(_WG_PEERS_DB.read_text()).get("peers", {})
+            for pubkey, meta in data.items():
+                pip = meta.get("ip")
+                if pip:
+                    _wg_cache[pip] = hashlib.sha256(pubkey.encode()).hexdigest()[:16]
+            _wg_mtime = mt
+        return _wg_cache.get(ip)
+    except Exception:
+        return None
+
+
+def _salt() -> str:
+    try:
+        return _SALT_FILE.read_text().strip()
+    except Exception:
+        return ""
+
+
+def _lease_mac(ip: str) -> Optional[str]:
+    for lf in _LEASE_FILES:
+        try:
+            if not lf.exists():
+                continue
+            for line in lf.read_text().splitlines():
+                # dnsmasq lease : <expiry> <mac> <ip> <host> <clientid>
+                parts = line.split()
+                if len(parts) >= 3 and parts[2] == ip:
+                    return parts[1].lower()
+        except Exception:
+            continue
+    return None
+
+
+def resolve_device(ip: str) -> str:
+    """Map a source IP to an anonymous device hash.
+
+    R3 WG → wg pubkey hash ; captive/br-lxc → hashed lease MAC ; unknown
+    → a stable hash of the IP itself (so unattributed drops still bucket).
+    """
+    if not ip:
+        return "unknown"
+    if ip.startswith("10.99.1."):
+        h = _wg_hash(ip)
+        if h:
+            return h
+    mac = _lease_mac(ip)
+    if mac:
+        salt = _salt()
+        if salt:
+            key = (salt + ":" + time.strftime("%Y-%m-%d")).encode()
+            import hmac
+            return hmac.new(key, mac.encode(), hashlib.sha256).hexdigest()[:16]
+        return hashlib.sha256(mac.encode()).hexdigest()[:16]
+    # Fall back to an IP-derived bucket (still anonymous, last-octet kept
+    # for the operator to eyeball which subnet).
+    return "ip:" + ip
+
+
+def record_block(mac_hash: str, ip: str, kind: str, dst: str) -> None:
+    """Upsert a device block event (called by the attribution tailer)."""
+    if not (mac_hash and kind and dst):
+        return
+    now = int(time.time())
+    try:
+        with _conn() as c:
+            c.execute(
+                "INSERT INTO device_blocks(mac_hash, ip, kind, dst, hits, "
+                "first_seen, last_seen) VALUES (?, ?, ?, ?, 1, ?, ?) "
+                "ON CONFLICT(mac_hash, kind, dst) DO UPDATE SET "
+                "hits = hits + 1, ip = excluded.ip, last_seen = excluded.last_seen",
+                (mac_hash, ip, kind, dst, now, now),
+            )
+    except Exception as e:  # pragma: no cover
+        log.warning("record_block failed: %s", e)
+
+
+def recent(hours: int = 24, limit: int = 500) -> List[Dict]:
+    since = int(time.time()) - max(hours, 1) * 3600
+    try:
+        with _conn() as c:
+            return [dict(r) for r in c.execute(
+                "SELECT mac_hash, ip, kind, dst, hits, first_seen, last_seen "
+                "FROM device_blocks WHERE last_seen >= ? "
+                "ORDER BY last_seen DESC LIMIT ?",
+                (since, limit),
+            ).fetchall()]
+    except Exception as e:  # pragma: no cover
+        log.warning("recent failed: %s", e)
+        return []
+
+
+def aggregate(hours: int = 24) -> Dict:
+    since = int(time.time()) - max(hours, 1) * 3600
+    out: Dict = {"window_hours": hours, "devices": 0, "total_hits": 0,
+                 "by_device": [], "by_kind": []}
+    try:
+        with _conn() as c:
+            out["devices"] = c.execute(
+                "SELECT COUNT(DISTINCT mac_hash) FROM device_blocks WHERE last_seen >= ?",
+                (since,),
+            ).fetchone()[0]
+            out["total_hits"] = c.execute(
+                "SELECT COALESCE(SUM(hits),0) FROM device_blocks WHERE last_seen >= ?",
+                (since,),
+            ).fetchone()[0]
+            out["by_device"] = [dict(r) for r in c.execute(
+                "SELECT mac_hash, ip, "
+                "SUM(CASE WHEN kind='blacklist-drop' THEN hits ELSE 0 END) AS blacklist, "
+                "SUM(CASE WHEN kind='doh-attempt' THEN hits ELSE 0 END) AS doh, "
+                "SUM(hits) AS total, MAX(last_seen) AS last_seen "
+                "FROM device_blocks WHERE last_seen >= ? "
+                "GROUP BY mac_hash ORDER BY total DESC LIMIT 100",
+                (since,),
+            ).fetchall()]
+            out["by_kind"] = [dict(r) for r in c.execute(
+                "SELECT kind, SUM(hits) AS hits, COUNT(DISTINCT mac_hash) AS devices "
+                "FROM device_blocks WHERE last_seen >= ? GROUP BY kind",
+                (since,),
+            ).fetchall()]
+    except Exception as e:  # pragma: no cover
+        log.warning("aggregate failed: %s", e)
+    return out
+
+
+def purge_older_than(days: int = 7) -> int:
+    cutoff = int(time.time()) - max(days, 1) * 86400
+    try:
+        with _conn() as c:
+            return c.execute(
+                "DELETE FROM device_blocks WHERE last_seen < ?", (cutoff,)
+            ).rowcount or 0
+    except Exception:
+        return 0

--- a/packages/secubox-toolbox/systemd/secubox-blacklist-attrib.service
+++ b/packages/secubox-toolbox/systemd/secubox-blacklist-attrib.service
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Phase 13.C (#524) — attribute nft drops/DoH attempts to devices.
+[Unit]
+Description=SecuBox blacklist per-device attribution (kernel-log tailer)
+Documentation=https://github.com/CyberMind-FR/secubox-deb/issues/524
+After=secubox-toolbox.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/secubox-blacklist-attrib
+User=root
+Nice=15
+IOSchedulingClass=idle
+TimeoutStartSec=60
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/secubox-toolbox/systemd/secubox-blacklist-attrib.timer
+++ b/packages/secubox-toolbox/systemd/secubox-blacklist-attrib.timer
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Phase 13.C (#524) — per-device attribution every 2 min.
+[Unit]
+Description=SecuBox blacklist attribution timer (every 2 min)
+
+[Timer]
+OnBootSec=120s
+OnUnitActiveSec=2min
+AccuracySec=20s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/packages/secubox-toolbox/www/toolbox/index.html
+++ b/packages/secubox-toolbox/www/toolbox/index.html
@@ -149,6 +149,10 @@
                 <div id="social-opgrade"><div class="empty">loading…</div></div>
             </div>
             <div class="card" style="grid-column:1/-1">
+                <h2>🛡️ Blocages par appareil (13.C)</h2>
+                <div id="social-devblocks"><div class="empty">loading…</div></div>
+            </div>
+            <div class="card" style="grid-column:1/-1">
                 <h2>🎯 Top tracker domains</h2>
                 <div id="social-trackers"><div class="empty">loading…</div></div>
             </div>
@@ -277,6 +281,17 @@ async function resetClient(macHash) {
         alert(`RAZ effectuée : ${j.rows_deleted || 0} enregistrements supprimés.`);
         loadClients();
     } catch (e) { alert('Échec RAZ : ' + e.message); }
+}
+
+async function quarantine(ip) {
+    if (!ip) return;
+    if (!confirm(`Mettre en quarantaine l'appareil ${ip} ? Tout son trafic sera coupé 6h.`)) return;
+    try {
+        const r = await fetch(`${API}/admin/quarantine/${encodeURIComponent(ip)}`, { method: 'POST', credentials: 'same-origin' });
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        alert('Appareil en quarantaine (6h).');
+        loadSocial();
+    } catch (e) { alert('Échec quarantaine : ' + e.message); }
 }
 
 async function loadMetrics() {
@@ -408,6 +423,17 @@ async function loadSocial() {
               ba.map(r => `<tr><td>🤖 ${r.antibot_vendor}</td><td>${r.sites}</td><td>${r.clients}</td><td>${r.challenges}</td></tr>`).join('') +
               '</tbody></table>'
             : '<div class="empty">aucun anti-bot détecté</div>';
+    }
+    const dbk = document.getElementById('social-devblocks');
+    if (dbk) {
+        const db = await J('/admin/device-blocks?hours=24');
+        const bd = (db && db.by_device) || [];
+        dbk.innerHTML = bd.length
+            ? `<p style="font-size:0.8rem;color:var(--p31-dim);margin-bottom:0.5rem">${db.devices||0} appareil(s) · ${db.total_hits||0} blocages 24h</p>` +
+              '<table><thead><tr><th>Appareil (hash)</th><th>IP</th><th>blacklist</th><th>DoH</th><th>total</th><th>Quarantaine</th></tr></thead><tbody>' +
+              bd.map(r => `<tr><td><code>${(r.mac_hash||'').slice(0,16)}</code></td><td>${r.ip||'—'}</td><td>${r.blacklist||0}</td><td>${r.doh||0}</td><td>${r.total||0}</td><td><a class="link" href="javascript:void(0)" onclick="quarantine('${r.ip||''}')" style="color:var(--red);font-size:0.78rem">⛔ Quarantaine</a></td></tr>`).join('') +
+              '</tbody></table>'
+            : '<div class="empty">aucun blocage attribué (24h)</div>';
     }
     const og = document.getElementById('social-opgrade');
     if (og) {


### PR DESCRIPTION
Closes #524. Parent #519. Live + verified on gk2 (secubox-toolbox 2.6.10).

- Per-device attribution: rate-limited SBX-BL-DROP/SBX-DOH nft logs → cursor-based journald tailer (secubox-blacklist-attrib, 2min timer) → device_blocks SQLite. Device resolver: R3 WG peer hash / dnsmasq-lease MAC hash / IP fallback (anonymous, social mac_hash model).
- Quarantine: quarantine_v4/v6 sets + quarantine-first enforce rule; POST /admin/quarantine/{ip} + unquarantine. One-click in the operator social tab.
- GET /admin/device-blocks aggregate; 7-day retention.

Verified: resolver maps 10.99.1.60 → 9433ceb90895a075, quarantine add/remove via API, record+aggregate green. Auto-quarantine left operator-manual (#519 Q2).