### PR TITLE
Phase 13.D — detection→enforcement feedback loop (#527)

### DIFF
--- a/packages/secubox-toolbox/debian/changelog
+++ b/packages/secubox-toolbox/debian/changelog
@@ -1,3 +1,28 @@
+secubox-toolbox (2.6.11-1~bookworm1) bookworm; urgency=medium
+
+  * Phase 13.D (#527, parent #519) — feedback loop : detections escalate
+    to enforcement. ALL SOURCES DEFAULT OFF.
+      - secubox_toolbox/escalate.py : evaluator reads the social-mapping
+        (by_opgrade / by_antibot) + device-blocks aggregates, applies
+        operator-tunable thresholds, and escalates :
+          * operator-grade / state-adjacent data-broker hosts over
+            threshold → resolve IPs → blacklist_v4/v6 (+ optional cscli
+            decision for audit + TTL),
+          * anti-bot vendors over threshold → flag only (legit infra ;
+            no auto-ban),
+          * devices over the DoH-attempt threshold → 13.C quarantine.
+        Every action append-logged to /var/log/secubox/audit.log (CSPN)
+        and reversible (nft/cscli TTL + operator unban).
+      - sbin/secubox-escalate + systemd .service/.timer (every 10 min) ;
+        sources opted in per SECUBOX_ESCALATE_* env in a drop-in.
+      - api.py GET /admin/escalate : policy flags + last-cycle summary.
+    Phase 13 (protection enforcement plane) complete : A spine + B
+    DNS-guard + C per-device attribution/quarantine + D feedback loop.
+    Detection stays factual ; escalation is a separate, logged,
+    reversible, opt-in policy decision (#519 doctrine).
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 11 Jun 2026 10:30:00 +0200
+
 secubox-toolbox (2.6.10-1~bookworm1) bookworm; urgency=medium
 
   * Phase 13.C (#524, parent #519) — DHCP/WG per-device attribution +

--- a/packages/secubox-toolbox/debian/postinst
+++ b/packages/secubox-toolbox/debian/postinst
@@ -171,6 +171,11 @@ fi
         # Phase 13.C (#524) : per-device attribution tailer timer.
         systemctl enable secubox-blacklist-attrib.timer 2>/dev/null || true
         systemctl start secubox-blacklist-attrib.timer 2>/dev/null || true
+        # Phase 13.D (#527) : escalation evaluator timer. The TIMER runs,
+        # but every escalation SOURCE is default OFF — nothing escalates
+        # until the operator opts in via a SECUBOX_ESCALATE_* drop-in.
+        systemctl enable secubox-escalate.timer 2>/dev/null || true
+        systemctl start secubox-escalate.timer 2>/dev/null || true
       fi
     fi
 

--- a/packages/secubox-toolbox/debian/rules
+++ b/packages/secubox-toolbox/debian/rules
@@ -95,6 +95,13 @@ execute_after_dh_auto_install:
 	  debian/secubox-toolbox/lib/systemd/system/
 	install -m 0644 systemd/secubox-blacklist-attrib.timer \
 	  debian/secubox-toolbox/lib/systemd/system/
+	# Phase 13.D (#527) : escalation evaluator (all sources default OFF).
+	install -m 0755 sbin/secubox-escalate \
+	  debian/secubox-toolbox/usr/sbin/
+	install -m 0644 systemd/secubox-escalate.service \
+	  debian/secubox-toolbox/lib/systemd/system/
+	install -m 0644 systemd/secubox-escalate.timer \
+	  debian/secubox-toolbox/lib/systemd/system/
 	install -m 0755 sbin/secubox-toolbox-wg-restore \
 	  debian/secubox-toolbox/usr/sbin/
 	install -m 0644 systemd/secubox-toolbox-wg-restore.service \

--- a/packages/secubox-toolbox/sbin/secubox-escalate
+++ b/packages/secubox-toolbox/sbin/secubox-escalate
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# SecuBox-Deb :: secubox-escalate (Phase 13.D #527)
+# Thin wrapper : run one escalation cycle. All sources DEFAULT OFF —
+# nothing escalates until an operator opts in via SECUBOX_ESCALATE_* env
+# (set in a /etc/systemd/system/secubox-escalate.service.d/ drop-in).
+set -euo pipefail
+PYHELPER=/usr/lib/secubox/toolbox
+STATE=/run/secubox/escalate.json
+mkdir -p /run/secubox 2>/dev/null || true
+PYTHONPATH="$PYHELPER" python3 - <<'PYEOF' > "$STATE" 2>/dev/null || true
+import json
+from secubox_toolbox import escalate
+print(json.dumps(escalate.evaluate_and_apply()))
+PYEOF
+logger -t secubox-escalate -- "cycle done ($(cat "$STATE" 2>/dev/null | head -c 200))" 2>/dev/null || true
+exit 0

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -2201,6 +2201,25 @@ async def admin_quarantine_remove(ip: str) -> dict:
     return _quarantine_ip(ip, add=False)
 
 
+@router.get("/admin/escalate")
+async def admin_escalate() -> dict:
+    """Phase 13.D (#527) — escalation policy + last cycle summary.
+    Read-only : the policy flags (all default OFF) come from the
+    evaluator's env, the last-run summary from its state file.
+    """
+    import json as _json
+    from pathlib import Path as _P
+    from . import escalate as _esc
+    out: dict = {"policy": _esc.load_policy(), "last_run": None}
+    try:
+        st = _P("/run/secubox/escalate.json")
+        if st.exists():
+            out["last_run"] = _json.loads(st.read_text())
+    except Exception:
+        pass
+    return out
+
+
 @router.get("/social/report/{token}.pdf")
 async def social_report_pdf(token: str) -> Response:
     """Phase 11.C (#508) — bilingual FR/EN evidence PDF for a peer.

--- a/packages/secubox-toolbox/secubox_toolbox/escalate.py
+++ b/packages/secubox-toolbox/secubox_toolbox/escalate.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+
+"""
+SecuBox-Deb :: ToolBoX escalation evaluator (Phase 13.D #527)
+
+Closes the detection → enforcement loop : reads the social-mapping
+(operator-grade / anti-bot) + device-blocks aggregates, applies
+operator-tunable thresholds, and escalates high-confidence repeat
+offenders to the enforcement plane :
+
+  - escalate a tracker/operator-grade HOST → resolve its IPs and add
+    them to the 13.A blacklist set (+ optionally a CrowdSec decision for
+    audit + TTL),
+  - escalate a DEVICE over the DoH/bypass threshold → 13.C quarantine.
+
+**Everything is DEFAULT OFF.** Each source is enabled independently via
+env flags (mirrors the SECUBOX_DOH_BLOCK pattern). Every action is
+logged to the append-only CSPN audit log and is reversible (nft/cscli
+timeouts + operator unban). This module decides + records ; the thin
+`secubox-escalate` wrapper invokes it on a timer.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Dict, List
+
+log = logging.getLogger("secubox.toolbox.escalate")
+
+NFT = "/usr/sbin/nft"
+TABLE = "inet secubox_blacklist"
+AUDIT_LOG = Path("/var/log/secubox/audit.log")
+ESCALATE_TTL = os.environ.get("SECUBOX_ESCALATE_TTL", "4h")
+
+
+def _flag(name: str, default: str = "0") -> bool:
+    return os.environ.get(name, default).strip() in ("1", "true", "yes", "on")
+
+
+def load_policy() -> Dict:
+    """Operator policy from env (all default OFF). The systemd unit /
+    a drop-in sets these ; nothing escalates until an operator opts in."""
+    return {
+        "opgrade_enabled": _flag("SECUBOX_ESCALATE_OPGRADE"),
+        "opgrade_min_clients": int(os.environ.get("SECUBOX_ESCALATE_OPGRADE_MIN_CLIENTS", "2")),
+        "opgrade_min_events": int(os.environ.get("SECUBOX_ESCALATE_OPGRADE_MIN_EVENTS", "20")),
+        "antibot_enabled": _flag("SECUBOX_ESCALATE_ANTIBOT"),
+        "antibot_min_challenges": int(os.environ.get("SECUBOX_ESCALATE_ANTIBOT_MIN", "50")),
+        "device_doh_enabled": _flag("SECUBOX_ESCALATE_DEVICE_DOH"),
+        "device_doh_threshold": int(os.environ.get("SECUBOX_ESCALATE_DEVICE_DOH_THRESHOLD", "200")),
+        "use_crowdsec": _flag("SECUBOX_ESCALATE_CROWDSEC"),
+        "window_hours": int(os.environ.get("SECUBOX_ESCALATE_WINDOW_H", "24")),
+    }
+
+
+def _audit(msg: str) -> None:
+    try:
+        AUDIT_LOG.parent.mkdir(parents=True, exist_ok=True)
+        ts = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+        with AUDIT_LOG.open("a") as f:
+            f.write(f"{ts} secubox-escalate {msg}\n")
+    except Exception as e:  # pragma: no cover
+        log.warning("audit write failed: %s", e)
+
+
+def _resolve_ips(host: str, timeout: float = 2.0) -> List[str]:
+    out: List[str] = []
+    try:
+        socket.setdefaulttimeout(timeout)
+        for fam, *_rest, sockaddr in socket.getaddrinfo(host, None):
+            ip = sockaddr[0]
+            if ip and ip not in out:
+                out.append(ip)
+    except Exception:
+        pass
+    finally:
+        socket.setdefaulttimeout(None)
+    return out
+
+
+def _nft_add_blacklist(ip: str) -> bool:
+    setname = "blacklist_v6" if ":" in ip else "blacklist_v4"
+    try:
+        r = subprocess.run(
+            [NFT, "add", "element", "inet", "secubox_blacklist", setname,
+             "{ " + ip + " timeout " + ESCALATE_TTL + " }"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def _nft_quarantine(ip: str) -> bool:
+    setname = "quarantine_v6" if ":" in ip else "quarantine_v4"
+    try:
+        r = subprocess.run(
+            [NFT, "add", "element", "inet", "secubox_blacklist", setname,
+             "{ " + ip + " timeout " + ESCALATE_TTL + " }"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def _cscli_decision(ip: str, reason: str) -> bool:
+    try:
+        r = subprocess.run(
+            ["cscli", "decisions", "add", "--ip", ip,
+             "--duration", ESCALATE_TTL, "--reason", reason, "--type", "ban"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def evaluate_and_apply() -> Dict:
+    """Run one escalation cycle. Returns a summary of actions taken.
+    No-op (beyond reading aggregates) unless a source is opted-in."""
+    policy = load_policy()
+    summary: Dict = {
+        "ts": int(time.time()),
+        "policy": {k: v for k, v in policy.items()},
+        "opgrade_escalated": 0,
+        "antibot_escalated": 0,
+        "devices_quarantined": 0,
+        "ips_added": 0,
+        "actions": [],
+    }
+
+    from . import social as _social
+    from . import device_blocks as _devblk
+
+    win = policy["window_hours"]
+    agg = _social.aggregate(hours=win)
+
+    # ── operator-grade / state-adjacent hosts ──
+    if policy["opgrade_enabled"]:
+        for row in agg.get("by_opgrade", []):
+            vendor = row.get("opgrade_vendor", "?")
+            clients = int(row.get("clients", 0) or 0)
+            events = int(row.get("events", 0) or 0)
+            if clients < policy["opgrade_min_clients"] or events < policy["opgrade_min_events"]:
+                continue
+            # The aggregate is keyed by vendor, not host — escalate the
+            # vendor's known host fragments by resolving them. We use the
+            # social_opgrade src sites? No — opgrade is host-stable in
+            # social_host_meta. Resolve the vendor's representative hosts.
+            # Conservative: skip if we can't map a concrete host.
+            host = _OPGRADE_VENDOR_HOST.get(vendor)
+            if not host:
+                continue
+            ips = _resolve_ips(host)
+            added = 0
+            for ip in ips:
+                if _nft_add_blacklist(ip):
+                    added += 1
+                if policy["use_crowdsec"]:
+                    _cscli_decision(ip, f"secubox-escalate:opgrade:{vendor}")
+            if added:
+                summary["opgrade_escalated"] += 1
+                summary["ips_added"] += added
+                summary["actions"].append(f"opgrade {vendor} -> +{added} ip ({host})")
+                _audit(f"ESCALATE opgrade vendor={vendor} host={host} clients={clients} events={events} ips=+{added} ttl={ESCALATE_TTL}")
+
+    # ── anti-bot endpoints (opt-in ; many are legit infra) ──
+    if policy["antibot_enabled"]:
+        for row in agg.get("by_antibot", []):
+            vendor = row.get("antibot_vendor", "?")
+            challenges = int(row.get("challenges", 0) or 0)
+            if challenges < policy["antibot_min_challenges"]:
+                continue
+            summary["antibot_escalated"] += 1
+            summary["actions"].append(f"antibot {vendor} flagged ({challenges})")
+            _audit(f"FLAG antibot vendor={vendor} challenges={challenges} (no auto-ban — review)")
+
+    # ── per-device DoH / bypass over threshold → quarantine ──
+    if policy["device_doh_enabled"]:
+        dev = _devblk.aggregate(hours=win)
+        for d in dev.get("by_device", []):
+            doh = int(d.get("doh", 0) or 0)
+            ip = d.get("ip", "")
+            if doh < policy["device_doh_threshold"] or not ip or ip == "unknown":
+                continue
+            if ip.startswith("ip:"):
+                ip = ip[3:]
+            if _nft_quarantine(ip):
+                summary["devices_quarantined"] += 1
+                summary["actions"].append(f"quarantine device {ip} (doh={doh})")
+                _audit(f"QUARANTINE device ip={ip} doh_attempts={doh} ttl={ESCALATE_TTL}")
+
+    return summary
+
+
+# Representative resolvable host per operator-grade vendor (data-broker
+# surfaces). Telco header-enrichment + consortium IDs aren't host-pinnable
+# this way, so they're skipped (flagged only). Conservative on purpose.
+_OPGRADE_VENDOR_HOST = {
+    "LiveRamp": "rlcdn.com",
+    "Oracle-BlueKai": "bluekai.com",
+    "Acxiom": "acxiom.com",
+    "Neustar": "agkn.com",
+    "Tapad": "tapad.com",
+    "Experian": "experian.com",
+}

--- a/packages/secubox-toolbox/systemd/secubox-escalate.service
+++ b/packages/secubox-toolbox/systemd/secubox-escalate.service
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Phase 13.D (#527) — escalation evaluator. DEFAULT OFF : set the
+# SECUBOX_ESCALATE_* env in a drop-in to opt a source in.
+[Unit]
+Description=SecuBox detection->enforcement escalation evaluator
+Documentation=https://github.com/CyberMind-FR/secubox-deb/issues/527
+After=secubox-toolbox.service secubox-blacklist-sync.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/secubox-escalate
+User=root
+Nice=15
+IOSchedulingClass=idle
+TimeoutStartSec=90
+# All escalation sources OFF by default. Opt in via a drop-in, e.g.:
+#   [Service]
+#   Environment=SECUBOX_ESCALATE_OPGRADE=1
+#   Environment=SECUBOX_ESCALATE_DEVICE_DOH=1
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/secubox-toolbox/systemd/secubox-escalate.timer
+++ b/packages/secubox-toolbox/systemd/secubox-escalate.timer
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Phase 13.D (#527) — escalation evaluator every 10 min.
+[Unit]
+Description=SecuBox escalation evaluator timer (every 10 min)
+
+[Timer]
+OnBootSec=180s
+OnUnitActiveSec=10min
+AccuracySec=60s
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes #527. Completes Phase 13 (protection enforcement plane). Live on gk2 (secubox-toolbox 2.6.11). ALL SOURCES DEFAULT OFF.

- escalate.py evaluator: social-mapping (opgrade/antibot) + device-blocks aggregates → thresholds → escalate (blacklist IPs / cscli decision / device quarantine). Audit-logged, reversible, opt-in via SECUBOX_ESCALATE_* env.
- sbin/secubox-escalate + 10min timer. GET /admin/escalate status.

Verified: default-off cycle = 0 actions; synthetic device-DoH escalation quarantined a device + wrote audit entry. Detection factual; escalation separate/logged/reversible (#519 doctrine).

Closes #527.