### PR TITLE
fix(threat_intel): ThreatFox ioc_value field — 0 → 5000 IOCs (#530)

### DIFF
--- a/packages/secubox-toolbox/debian/changelog
+++ b/packages/secubox-toolbox/debian/changelog
@@ -1,3 +1,13 @@
+secubox-toolbox (2.6.12-1~bookworm1) bookworm; urgency=medium
+
+  * fix(threat_intel) #530 — ThreatFox ingested 0 IOCs for weeks because
+    the export/json/recent/ endpoint renamed the IOC field `ioc` →
+    `ioc_value`; the parser still read `ioc` and skipped every entry.
+    Now reads `ioc_value or ioc`. Unblocks Phase 13.B DNS-guard (domain
+    IOCs → resolved into the blacklist).
+
+ -- Gerald KERMA <devel@cybermind.fr>  Fri, 12 Jun 2026 17:00:00 +0200
+
 secubox-toolbox (2.6.11-1~bookworm1) bookworm; urgency=medium
 
   * Phase 13.D (#527, parent #519) — feedback loop : detections escalate

--- a/packages/secubox-toolbox/secubox_toolbox/threat_intel.py
+++ b/packages/secubox-toolbox/secubox_toolbox/threat_intel.py
@@ -152,12 +152,16 @@ async def ingest_threatfox(limit: int = 5000) -> int:
         return 0
     now = int(time.time())
     rows = []
-    # ThreatFox returns { "<id>": [ {ioc, ioc_type, malware, ...}, ... ], ... }
+    # ThreatFox returns { "<id>": [ {ioc_value, ioc_type, malware, ...}, ... ], ... }
+    # The export/json/recent/ endpoint uses `ioc_value` ; the legacy
+    # api/v1 endpoint used `ioc`. Support both so a future endpoint swap
+    # doesn't silently ingest 0 again (#530 : the field rename had us
+    # ingesting nothing, starving Phase 13.B DNS-guard of domain IOCs).
     for entries in data.values():
         if not isinstance(entries, list):
             continue
         for e in entries:
-            ioc = e.get("ioc", "")
+            ioc = e.get("ioc_value") or e.get("ioc") or ""
             ioc_type = e.get("ioc_type", "")
             malware = e.get("malware_printable") or e.get("malware") or "?"
             if not ioc:


### PR DESCRIPTION
Closes #530. The export/json/recent/ endpoint renamed ioc → ioc_value; the parser read e.get('ioc') and skipped every entry → 0 IOCs for weeks, starving Phase 13.B DNS-guard. Now reads ioc_value or ioc. Verified live on gk2: 0 → 5000 ingested (2935 domains + 1613 ips + 32 sha256). secubox-toolbox 2.6.12.