### PR TITLE
Tag-pinned .xpi release URL — don't steal "latest" from the APK (#532)

### DIFF
--- a/.github/workflows/build-webext.yml
+++ b/.github/workflows/build-webext.yml
@@ -50,11 +50,14 @@ jobs:
 
       # On webext-v* tags, publish the .xpi as a release asset under the
       # stable name the toolbox fetch helper + /wg/toolbox.xpi expect.
-      # `latest/download/secubox-toolbox-webext.xpi` resolves to the
-      # newest release.
+      # make_latest:false so this client release does NOT steal the
+      # "latest" pointer from the Android APK release (which the APK
+      # endpoint resolves via /releases/latest/download/…). The xpi
+      # endpoint/fetcher therefore use a tag-pinned download URL.
       - name: Publish release
         if: startsWith(github.ref, 'refs/tags/webext-v')
         uses: softprops/action-gh-release@v2
         with:
           files: clients/webext-toolbox/web-ext-artifacts/secubox-toolbox-webext.xpi
           fail_on_unmatched_files: true
+          make_latest: false

--- a/packages/secubox-toolbox/debian/changelog
+++ b/packages/secubox-toolbox/debian/changelog
@@ -3,12 +3,14 @@ secubox-toolbox (2.6.14-1~bookworm1) bookworm; urgency=medium
   * Serve the browser ToolBoX extension .xpi from the toolbox (#532).
       - api.py GET /wg/toolbox.xpi : serves the local .xpi
         (/var/lib/secubox/toolbox/webext/secubox-toolbox-webext.xpi) with
-        content-type application/x-xpinstall ; if absent, 302 → the latest
-        public GitHub release asset (button never dead-ends).
+        content-type application/x-xpinstall ; if absent, 302 → the
+        tag-pinned GitHub release asset (button never dead-ends). The
+        webext release is published make_latest:false so it does not steal
+        "latest" from the Android APK release.
       - /wg/onboard : new "🧩 Extension navigateur (cartographie)" button
         on both the inline + _install_panels variants.
-      - sbin/secubox-toolbox-fetch-xpi : pulls the latest release asset
-        into the serve path (best-effort, ZIP-magic sanity check).
+      - sbin/secubox-toolbox-fetch-xpi : pulls the release asset into the
+        serve path (best-effort, ZIP-magic sanity check).
       - postinst : create the webext serve dir + best-effort first fetch.
       - New client clients/webext-toolbox/ (MV3 Firefox/Chromium): live
         tracker badge + popup mini Round-Eye graph over /social/* ;

--- a/packages/secubox-toolbox/sbin/secubox-toolbox-fetch-xpi
+++ b/packages/secubox-toolbox/sbin/secubox-toolbox-fetch-xpi
@@ -14,7 +14,9 @@ readonly MODULE="secubox-toolbox-fetch-xpi"
 
 DEST_DIR="/var/lib/secubox/toolbox/webext"
 DEST="${DEST_DIR}/secubox-toolbox-webext.xpi"
-RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/latest/download/secubox-toolbox-webext.xpi"
+# Tag-pinned (not /latest/): the webext release is make_latest:false so it
+# doesn't steal "latest" from the Android APK release. Bump on new webext-v*.
+RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.0/secubox-toolbox-webext.xpi"
 
 log() { logger -t "$MODULE" -- "$*" 2>/dev/null || echo "[$MODULE] $*" >&2; }
 

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -1368,10 +1368,13 @@ async def wg_toolbox_apk() -> Response:
 
 
 # Browser extension (Firefox .xpi), same serve pattern as the APK (#532).
+# Tag-pinned URL (not /latest/): the webext release is published with
+# make_latest:false so it does not steal "latest" from the Android APK
+# release. Bump the tag here when a new webext-v* release is cut.
 _WEBEXT_XPI = Path("/var/lib/secubox/toolbox/webext/secubox-toolbox-webext.xpi")
 _WEBEXT_XPI_RELEASE = (
-    "https://github.com/CyberMind-FR/secubox-deb/releases/latest/download/"
-    "secubox-toolbox-webext.xpi"
+    "https://github.com/CyberMind-FR/secubox-deb/releases/download/"
+    "webext-v0.1.0/secubox-toolbox-webext.xpi"
 )
 
 


### PR DESCRIPTION
## Why
Publishing the `webext-v*` release with the default settings would mark it as the repo's **Latest** release (it's newer than `android-v0.1.0`). That breaks the Android app's fallback, which resolves `/releases/latest/download/secubox-toolbox-android.apk` — the webext release doesn't carry the APK asset.

## Fix
- `build-webext.yml`: publish with `make_latest: false`.
- `/wg/toolbox.xpi` endpoint + `secubox-toolbox-fetch-xpi`: use the **tag-pinned** download URL (`releases/download/webext-v0.1.0/…`) instead of `latest/download/…`.

Two independent client artifacts on separate tag series can't both rely on `/latest/`; the APK keeps "latest", the xpi is tag-pinned (bump the constant per `webext-v*` release — noted in code).

Refs #532.