### PR TITLE
Favicons of major sites in cartographie + XPI popup (drop IPs) (#555)

### DIFF
--- a/clients/webext-toolbox/README.md
+++ b/clients/webext-toolbox/README.md
@@ -31,7 +31,7 @@ to your cabine over the R3 tunnel — no third-party calls.
 Published release `.xpi` (downloadable directly):
 
 ```
-https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.1/secubox-toolbox-webext.xpi
+https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.2/secubox-toolbox-webext.xpi
 ```
 
 The toolbox also serves it from the cabine:

--- a/clients/webext-toolbox/api.js
+++ b/clients/webext-toolbox/api.js
@@ -89,6 +89,12 @@ async function wipe(host, token) {
   return await resp.json();
 }
 
+// Favicon of a major site/tracker via the cabine's server-side proxy
+// (7-day cached PNG, transparent 1×1 fallback) — no third-party call.
+function faviconUrl(host, domain) {
+  return `${baseUrl(host)}/social/favicon/${encodeURIComponent(domain || "")}`;
+}
+
 function socialUrl(host, token) {
   return `${baseUrl(host)}/social/${token}`;
 }
@@ -106,6 +112,7 @@ const SbxApi = {
   r3Check,
   graph,
   wipe,
+  faviconUrl,
   socialUrl,
   reportUrl,
   tokenFromUrl,

--- a/clients/webext-toolbox/install-firefox-linux.sh
+++ b/clients/webext-toolbox/install-firefox-linux.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 DEFAULT_HOST="kbin.gk2.secubox.in"
-RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.1/secubox-toolbox-webext.xpi"
+RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.2/secubox-toolbox-webext.xpi"
 SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 say(){ printf '\033[1;36m▸\033[0m %s\n' "$*"; }

--- a/clients/webext-toolbox/manifest.json
+++ b/clients/webext-toolbox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "SecuBox ToolBoX — Cartographie sociale",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Surface the SecuBox R3 toolbox live tracker analysis (cartographie sociale) in your browser: live badge, per-session trackers, mini Round-Eye graph, RGPD wipe + PDF report.",
   "browser_specific_settings": {
     "gecko": {

--- a/clients/webext-toolbox/popup/popup.css
+++ b/clients/webext-toolbox/popup/popup.css
@@ -66,6 +66,7 @@ button.danger { color: var(--cinnabar); border-color: var(--cinnabar); }
   display: flex; align-items: center; gap: 6px; padding: 3px 2px;
   border-bottom: 1px solid #1a1a22; font-size: 11px;
 }
+.row .fav { width: 16px; height: 16px; border-radius: 3px; flex-shrink: 0; background: #1a1a22; object-fit: contain; }
 .row .dom { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .row .hits { color: var(--muted); }
 .tier { font-size: 9px; padding: 1px 4px; border-radius: 3px; }

--- a/clients/webext-toolbox/popup/popup.js
+++ b/clients/webext-toolbox/popup/popup.js
@@ -8,6 +8,7 @@
 // SyntaxError that aborts popup.js. Use api.ext instead.
 const api = globalThis.SbxApi;
 const $ = (id) => document.getElementById(id);
+let curHost = api.DEFAULTS.host;   // for favicon URLs (#555)
 
 function show(which) {
   $("pair").hidden = which !== "pair";
@@ -24,6 +25,14 @@ function fillTopList(nodes) {
     .forEach((n) => {
       const row = document.createElement("div");
       row.className = "row";
+      // favicon of the major site/tracker (cabine proxy) — not an IP (#555)
+      const fav = document.createElement("img");
+      fav.className = "fav";
+      fav.loading = "lazy";
+      fav.alt = "";
+      fav.src = api.faviconUrl(curHost, n.domain || n.id);
+      fav.addEventListener("error", () => { fav.style.visibility = "hidden"; });
+      row.appendChild(fav);
       const dom = document.createElement("span");
       dom.className = "dom";
       dom.textContent = n.domain || n.id;
@@ -57,6 +66,7 @@ function paint(data) {
 
 async function load() {
   const cfg = await api.getConfig();
+  curHost = cfg.host || api.DEFAULTS.host;
   $("ver").textContent = "v" + (api.ext.runtime.getManifest().version || "");
 
   // tunnel indicator

--- a/packages/secubox-toolbox/debian/changelog
+++ b/packages/secubox-toolbox/debian/changelog
@@ -1,3 +1,15 @@
+secubox-toolbox (2.6.19-1~bookworm1) bookworm; urgency=medium
+
+  * Favicons of major sites in the cartographie (#555) — never IPs.
+      - social.js eye-view: site + tracker nodes render the site favicon
+        (same-origin /social/favicon/{domain} proxy, 7-day cached,
+        transparent 1×1 fallback → the tier-coloured circle shows through),
+        clipped to the bubble. No IP/ASN displayed anywhere.
+      - Companion webext popup gains favicons in its top-tracker list
+        (clients/webext-toolbox 0.1.2). /wg/toolbox.xpi tag-pin → webext-v0.1.2.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Sat, 13 Jun 2026 15:30:00 +0200
+
 secubox-toolbox (2.6.18-1~bookworm1) bookworm; urgency=medium
 
   * Cartographie donut-bubble view + geography rollups (#553).

--- a/packages/secubox-toolbox/sbin/secubox-toolbox-fetch-xpi
+++ b/packages/secubox-toolbox/sbin/secubox-toolbox-fetch-xpi
@@ -16,7 +16,7 @@ DEST_DIR="/var/lib/secubox/toolbox/webext"
 DEST="${DEST_DIR}/secubox-toolbox-webext.xpi"
 # Tag-pinned (not /latest/): the webext release is make_latest:false so it
 # doesn't steal "latest" from the Android APK release. Bump on new webext-v*.
-RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.1/secubox-toolbox-webext.xpi"
+RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.2/secubox-toolbox-webext.xpi"
 
 log() { logger -t "$MODULE" -- "$*" 2>/dev/null || echo "[$MODULE] $*" >&2; }
 

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -1374,7 +1374,7 @@ async def wg_toolbox_apk() -> Response:
 _WEBEXT_XPI = Path("/var/lib/secubox/toolbox/webext/secubox-toolbox-webext.xpi")
 _WEBEXT_XPI_RELEASE = (
     "https://github.com/CyberMind-FR/secubox-deb/releases/download/"
-    "webext-v0.1.1/secubox-toolbox-webext.xpi"
+    "webext-v0.1.2/secubox-toolbox-webext.xpi"
 )
 
 

--- a/packages/secubox-toolbox/www/toolbox/social.js
+++ b/packages/secubox-toolbox/www/toolbox/social.js
@@ -308,6 +308,19 @@
       .attr('stroke', d => (d.kind === 'tracker' && (d.cdn_vendor || d.antibot_vendor)) ? '#0a0a0f' : null)
       .attr('stroke-width', d => (d.kind === 'tracker' && (d.cdn_vendor || d.antibot_vendor)) ? 1.5 : 0);
 
+    // #555 — favicon of the major site/tracker (same-origin cabine proxy,
+    // 7-day cached, transparent 1×1 fallback so the coloured tier circle
+    // shows through when there's no icon). No IP shown anywhere.
+    nodeG.filter(d => d.kind !== 'eye').append('image')
+      .attr('href', d => '/social/favicon/' + encodeURIComponent(d.label || ''))
+      .attr('width', d => (d.kind === 'tracker' ? 7 : 10) * 1.7)
+      .attr('height', d => (d.kind === 'tracker' ? 7 : 10) * 1.7)
+      .attr('x', d => -(d.kind === 'tracker' ? 7 : 10) * 0.85)
+      .attr('y', d => -(d.kind === 'tracker' ? 7 : 10) * 0.85)
+      .attr('preserveAspectRatio', 'xMidYMid slice')
+      .attr('clip-path', 'circle()')
+      .attr('pointer-events', 'none');
+
     nodeG.filter(d => d.kind !== 'eye').append('text')
       .attr('x', 12).attr('y', 4)
       .text(d => (d.antibot_vendor ? '🤖 ' : '') + (d.label.length > 22 ? d.label.slice(0, 21) + '…' : d.label));

--- a/wiki/Browser-Extension.md
+++ b/wiki/Browser-Extension.md
@@ -18,7 +18,7 @@ R3 tunnel — no third-party calls.
 Published release `.xpi` (downloadable directly):
 
 ```
-https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.1/secubox-toolbox-webext.xpi
+https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.2/secubox-toolbox-webext.xpi
 ```
 
 The toolbox also serves it from the cabine:


### PR DESCRIPTION
Show the **favicon of major sites** instead of IPs, in both the metrics and the XPI — via the existing same-origin `/social/favicon/{domain}` proxy (7-day cached, transparent 1×1 fallback).

- **Toolbox metrics** (`social.js` eye view): site + tracker nodes render the favicon clipped into the bubble; the tier-coloured circle shows through when there's no icon. No IP/ASN anywhere.
- **XPI popup**: 16px favicon per row in the top-tracker list (`api.faviconUrl`). webext 0.1.2, `/wg/toolbox.xpi` tag-pin → `webext-v0.1.2`.

secubox-toolbox 2.6.19. Closes #555.