### PR TITLE
webext: cap popup top-tracker list to 5 (#568)

### DIFF
--- a/clients/webext-toolbox/README.md
+++ b/clients/webext-toolbox/README.md
@@ -31,7 +31,7 @@ to your cabine over the R3 tunnel — no third-party calls.
 Published release `.xpi` (downloadable directly):
 
 ```
-https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.2/secubox-toolbox-webext.xpi
+https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.3/secubox-toolbox-webext.xpi
 ```
 
 The toolbox also serves it from the cabine:

--- a/clients/webext-toolbox/install-firefox-linux.sh
+++ b/clients/webext-toolbox/install-firefox-linux.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 DEFAULT_HOST="kbin.gk2.secubox.in"
-RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.2/secubox-toolbox-webext.xpi"
+RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.3/secubox-toolbox-webext.xpi"
 SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 say(){ printf '\033[1;36m▸\033[0m %s\n' "$*"; }

--- a/clients/webext-toolbox/manifest.json
+++ b/clients/webext-toolbox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "SecuBox ToolBoX — Cartographie sociale",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Surface the SecuBox R3 toolbox live tracker analysis (cartographie sociale) in your browser: live badge, per-session trackers, mini Round-Eye graph, RGPD wipe + PDF report.",
   "browser_specific_settings": {
     "gecko": {

--- a/clients/webext-toolbox/popup/popup.js
+++ b/clients/webext-toolbox/popup/popup.js
@@ -21,7 +21,7 @@ function fillTopList(nodes) {
   (nodes || [])
     .slice()
     .sort((a, b) => (b.hits || 0) - (a.hits || 0))
-    .slice(0, 12)
+    .slice(0, 5)
     .forEach((n) => {
       const row = document.createElement("div");
       row.className = "row";

--- a/packages/secubox-toolbox/debian/changelog
+++ b/packages/secubox-toolbox/debian/changelog
@@ -1,3 +1,10 @@
+secubox-toolbox (2.6.24-1~bookworm1) bookworm; urgency=medium
+
+  * webext: cap the popup top-tracker list to 5 items (#568); webext 0.1.3.
+    /wg/toolbox.xpi tag-pin → webext-v0.1.3.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Sat, 13 Jun 2026 18:30:00 +0200
+
 secubox-toolbox (2.6.23-1~bookworm1) bookworm; urgency=medium
 
   * Modular mitm filters + R3+/R4 silent ad/banner ghoster (#566).
@@ -80,7 +87,7 @@ secubox-toolbox (2.6.19-1~bookworm1) bookworm; urgency=medium
         transparent 1×1 fallback → the tier-coloured circle shows through),
         clipped to the bubble. No IP/ASN displayed anywhere.
       - Companion webext popup gains favicons in its top-tracker list
-        (clients/webext-toolbox 0.1.2). /wg/toolbox.xpi tag-pin → webext-v0.1.2.
+        (clients/webext-toolbox 0.1.2). /wg/toolbox.xpi tag-pin → webext-v0.1.3.
 
  -- Gerald KERMA <devel@cybermind.fr>  Sat, 13 Jun 2026 15:30:00 +0200
 

--- a/packages/secubox-toolbox/sbin/secubox-toolbox-fetch-xpi
+++ b/packages/secubox-toolbox/sbin/secubox-toolbox-fetch-xpi
@@ -16,7 +16,7 @@ DEST_DIR="/var/lib/secubox/toolbox/webext"
 DEST="${DEST_DIR}/secubox-toolbox-webext.xpi"
 # Tag-pinned (not /latest/): the webext release is make_latest:false so it
 # doesn't steal "latest" from the Android APK release. Bump on new webext-v*.
-RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.2/secubox-toolbox-webext.xpi"
+RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.3/secubox-toolbox-webext.xpi"
 
 log() { logger -t "$MODULE" -- "$*" 2>/dev/null || echo "[$MODULE] $*" >&2; }
 

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -1395,7 +1395,7 @@ async def wg_toolbox_apk() -> Response:
 _WEBEXT_XPI = Path("/var/lib/secubox/toolbox/webext/secubox-toolbox-webext.xpi")
 _WEBEXT_XPI_RELEASE = (
     "https://github.com/CyberMind-FR/secubox-deb/releases/download/"
-    "webext-v0.1.2/secubox-toolbox-webext.xpi"
+    "webext-v0.1.3/secubox-toolbox-webext.xpi"
 )
 
 

--- a/wiki/Browser-Extension.md
+++ b/wiki/Browser-Extension.md
@@ -18,7 +18,7 @@ R3 tunnel — no third-party calls.
 Published release `.xpi` (downloadable directly):
 
 ```
-https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.2/secubox-toolbox-webext.xpi
+https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.3/secubox-toolbox-webext.xpi
 ```
 
 The toolbox also serves it from the cabine:


### PR DESCRIPTION
Popup top-tracker list 12 → 5. webext 0.1.3, tag-pin → webext-v0.1.3, secubox-toolbox 2.6.24. Closes #568.