### PR TITLE
webext popup: protection stats + live filter toggles (#574)

### DIFF
--- a/clients/webext-toolbox/README.md
+++ b/clients/webext-toolbox/README.md
@@ -31,7 +31,7 @@ to your cabine over the R3 tunnel — no third-party calls.
 Published release `.xpi` (downloadable directly):
 
 ```
-https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.3/secubox-toolbox-webext.xpi
+https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.4/secubox-toolbox-webext.xpi
 ```
 
 The toolbox also serves it from the cabine:

--- a/clients/webext-toolbox/api.js
+++ b/clients/webext-toolbox/api.js
@@ -89,6 +89,29 @@ async function wipe(host, token) {
   return await resp.json();
 }
 
+// #574 — protection stats + modular filter toggles (cabine admin API).
+async function ghost(host) {
+  try {
+    const r = await fetch(`${baseUrl(host)}/admin/ghost`, { credentials: "omit" });
+    return r.ok ? await r.json() : null;
+  } catch (_) { return null; }
+}
+async function getAdminFilters(host) {
+  try {
+    const r = await fetch(`${baseUrl(host)}/admin/filters`, { credentials: "omit" });
+    return r.ok ? await r.json() : null;
+  } catch (_) { return null; }
+}
+async function setAdminFilters(host, patch) {
+  const r = await fetch(`${baseUrl(host)}/admin/filters`, {
+    method: "POST", credentials: "omit",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(patch),
+  });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return await r.json();
+}
+
 // Favicon of a major site/tracker via the cabine's server-side proxy
 // (7-day cached PNG, transparent 1×1 fallback) — no third-party call.
 function faviconUrl(host, domain) {
@@ -112,6 +135,9 @@ const SbxApi = {
   r3Check,
   graph,
   wipe,
+  ghost,
+  getAdminFilters,
+  setAdminFilters,
   faviconUrl,
   socialUrl,
   reportUrl,

--- a/clients/webext-toolbox/install-firefox-linux.sh
+++ b/clients/webext-toolbox/install-firefox-linux.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 DEFAULT_HOST="kbin.gk2.secubox.in"
-RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.3/secubox-toolbox-webext.xpi"
+RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.4/secubox-toolbox-webext.xpi"
 SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 say(){ printf '\033[1;36m▸\033[0m %s\n' "$*"; }

--- a/clients/webext-toolbox/manifest.json
+++ b/clients/webext-toolbox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "SecuBox ToolBoX — Cartographie sociale",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Surface the SecuBox R3 toolbox live tracker analysis (cartographie sociale) in your browser: live badge, per-session trackers, mini Round-Eye graph, RGPD wipe + PDF report.",
   "browser_specific_settings": {
     "gecko": {

--- a/clients/webext-toolbox/popup/popup.css
+++ b/clients/webext-toolbox/popup/popup.css
@@ -69,6 +69,14 @@ button.danger { color: var(--cinnabar); border-color: var(--cinnabar); }
 .row .fav { width: 16px; height: 16px; border-radius: 3px; flex-shrink: 0; background: #1a1a22; object-fit: contain; }
 .row .dom { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .row .hits { color: var(--muted); }
+
+/* #574 — protection panel */
+#protect { margin: 8px 0; padding: 8px; background: #0e0e15; border: 1px solid #222; border-radius: 8px; }
+.phead { color: var(--matrix); font-weight: 700; font-size: 12px; margin-bottom: 6px; }
+.gstat { color: var(--muted); font-weight: 400; font-size: 10px; }
+.tg { display: flex; align-items: center; gap: 6px; font-size: 11px; padding: 3px 0; }
+.tg select { margin-left: auto; background: #14141c; color: var(--text); border: 1px solid #333; border-radius: 4px; }
+#protect input { accent-color: var(--void); }
 .tier { font-size: 9px; padding: 1px 4px; border-radius: 3px; }
 .tier.cdn { background: #1d2a33; color: var(--cyan); }
 .tier.ab { background: #2a1416; color: var(--cinnabar); }

--- a/clients/webext-toolbox/popup/popup.html
+++ b/clients/webext-toolbox/popup/popup.html
@@ -36,6 +36,17 @@
 
     <div class="toplist" id="topList"></div>
 
+    <section id="protect">
+      <div class="phead">🛡 Protection <span id="ghostStat" class="gstat"></span></div>
+      <label class="tg"><input type="checkbox" data-f="ad_ghost"> Masquer pubs/bannières (R3+)</label>
+      <label class="tg"><input type="checkbox" data-f="ad_ghost_block"> Bloquer hôtes pub (économie)</label>
+      <label class="tg"><input type="checkbox" data-f="banner"> Bannière transparence</label>
+      <label class="tg">Mode protecteur
+        <select data-f="protective"><option value="off">off</option><option value="alert">alert</option><option value="spoof">spoof</option></select>
+      </label>
+      <p id="protectMsg" class="muted"></p>
+    </section>
+
     <div class="actions">
       <button id="openFull">🗺️ Cartographie complète</button>
       <button id="pdf">📄 Rapport PDF</button>

--- a/clients/webext-toolbox/popup/popup.js
+++ b/clients/webext-toolbox/popup/popup.js
@@ -64,6 +64,41 @@ function paint(data) {
   fillTopList(data.nodes);
 }
 
+// #574 — protection stats + live filter toggles in the popup.
+async function loadProtection() {
+  const sec = $("protect");
+  if (!sec) return;
+  const g = await api.ghost(curHost);
+  if (g) {
+    $("ghostStat").textContent =
+      `${g.blocked_requests || 0} bloqués · ~${g.mb_saved_est || 0} Mo · ${g.pages_cleaned || 0} nettoyées`;
+  }
+  const f = await api.getAdminFilters(curHost);
+  if (!f) { sec.style.opacity = "0.5"; return; }
+  sec.style.opacity = "1";
+  sec.querySelectorAll("[data-f]").forEach((el) => {
+    const k = el.dataset.f;
+    if (el.type === "checkbox") el.checked = !!f[k];
+    else el.value = f[k];
+  });
+  if (!sec.dataset.wired) {
+    sec.dataset.wired = "1";
+    sec.querySelectorAll("[data-f]").forEach((el) => {
+      el.addEventListener("change", async () => {
+        const v = el.type === "checkbox" ? el.checked : el.value;
+        try {
+          await api.setAdminFilters(curHost, { [el.dataset.f]: v });
+          $("protectMsg").textContent = "✓ appliqué";
+          setTimeout(() => ($("protectMsg").textContent = ""), 1000);
+          loadProtection();
+        } catch (e) {
+          $("protectMsg").textContent = "erreur : " + e.message;
+        }
+      });
+    });
+  }
+}
+
 async function load() {
   const cfg = await api.getConfig();
   curHost = cfg.host || api.DEFAULTS.host;
@@ -87,6 +122,7 @@ async function load() {
     const data = await api.graph(cfg.host, cfg.token, cfg.since);
     paint(data);
     $("liveMsg").textContent = "";
+    loadProtection();
   } catch (e) {
     if (String(e.message) === "token-expired") {
       // token died — drop it and go back to pairing

--- a/packages/secubox-toolbox/debian/changelog
+++ b/packages/secubox-toolbox/debian/changelog
@@ -1,3 +1,13 @@
+secubox-toolbox (2.6.27-1~bookworm1) bookworm; urgency=medium
+
+  * webext popup: protection stats + live filter toggles (#574); webext
+    0.1.4. New 🛡 Protection panel — ghost savings (blocked / ~Mo / pages
+    cleaned via /admin/ghost) + live toggles for ad_ghost / ad_ghost_block /
+    banner / protective(off|alert|spoof) via /admin/filters. Top-tracker
+    list stays top-5. /wg/toolbox.xpi tag-pin → webext-v0.1.4.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Sun, 14 Jun 2026 12:00:00 +0200
+
 secubox-toolbox (2.6.26-1~bookworm1) bookworm; urgency=medium
 
   * Banner: colourful emoji-chip "guirlande" (#572). The right-side stat
@@ -25,7 +35,7 @@ secubox-toolbox (2.6.25-1~bookworm1) bookworm; urgency=medium
 secubox-toolbox (2.6.24-1~bookworm1) bookworm; urgency=medium
 
   * webext: cap the popup top-tracker list to 5 items (#568); webext 0.1.3.
-    /wg/toolbox.xpi tag-pin → webext-v0.1.3.
+    /wg/toolbox.xpi tag-pin → webext-v0.1.4.
 
  -- Gerald KERMA <devel@cybermind.fr>  Sat, 13 Jun 2026 18:30:00 +0200
 
@@ -111,7 +121,7 @@ secubox-toolbox (2.6.19-1~bookworm1) bookworm; urgency=medium
         transparent 1×1 fallback → the tier-coloured circle shows through),
         clipped to the bubble. No IP/ASN displayed anywhere.
       - Companion webext popup gains favicons in its top-tracker list
-        (clients/webext-toolbox 0.1.2). /wg/toolbox.xpi tag-pin → webext-v0.1.3.
+        (clients/webext-toolbox 0.1.2). /wg/toolbox.xpi tag-pin → webext-v0.1.4.
 
  -- Gerald KERMA <devel@cybermind.fr>  Sat, 13 Jun 2026 15:30:00 +0200
 

--- a/packages/secubox-toolbox/sbin/secubox-toolbox-fetch-xpi
+++ b/packages/secubox-toolbox/sbin/secubox-toolbox-fetch-xpi
@@ -16,7 +16,7 @@ DEST_DIR="/var/lib/secubox/toolbox/webext"
 DEST="${DEST_DIR}/secubox-toolbox-webext.xpi"
 # Tag-pinned (not /latest/): the webext release is make_latest:false so it
 # doesn't steal "latest" from the Android APK release. Bump on new webext-v*.
-RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.3/secubox-toolbox-webext.xpi"
+RELEASE_URL="https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.4/secubox-toolbox-webext.xpi"
 
 log() { logger -t "$MODULE" -- "$*" 2>/dev/null || echo "[$MODULE] $*" >&2; }
 

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -1395,7 +1395,7 @@ async def wg_toolbox_apk() -> Response:
 _WEBEXT_XPI = Path("/var/lib/secubox/toolbox/webext/secubox-toolbox-webext.xpi")
 _WEBEXT_XPI_RELEASE = (
     "https://github.com/CyberMind-FR/secubox-deb/releases/download/"
-    "webext-v0.1.3/secubox-toolbox-webext.xpi"
+    "webext-v0.1.4/secubox-toolbox-webext.xpi"
 )
 
 

--- a/wiki/Browser-Extension.md
+++ b/wiki/Browser-Extension.md
@@ -18,7 +18,7 @@ R3 tunnel — no third-party calls.
 Published release `.xpi` (downloadable directly):
 
 ```
-https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.3/secubox-toolbox-webext.xpi
+https://github.com/CyberMind-FR/secubox-deb/releases/download/webext-v0.1.4/secubox-toolbox-webext.xpi
 ```
 
 The toolbox also serves it from the cabine:


### PR DESCRIPTION
Interactive stats + quick access in the XPI: a 🛡 Protection panel showing ghost savings (blocked / ~Mo saved / pages cleaned) and **live toggles** for ad_ghost / ad_ghost_block / banner / protective(off|alert|spoof) via /admin/ghost + /admin/filters. Top-tracker list stays top-5. webext 0.1.4, tag-pin → webext-v0.1.4, secubox-toolbox 2.6.27. Closes #574.