### PR TITLE
ad_ghost: remove ad placeholders entirely (collapse)

### DIFF
--- a/packages/secubox-toolbox/debian/changelog
+++ b/packages/secubox-toolbox/debian/changelog
@@ -1,3 +1,11 @@
+secubox-toolbox (2.6.31-1~bookworm1) bookworm; urgency=medium
+
+  * ad_ghost: remove ad placeholders entirely (#584, reverses #576). Ghosted
+    ad slots now collapse with display:none — no black-hole/void, the space
+    disappears. Host-blocking (204) still saves the bandwidth.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Sun, 14 Jun 2026 14:00:00 +0200
+
 secubox-toolbox (2.6.30-1~bookworm1) bookworm; urgency=medium
 
   * ad_ghost: ghosted ads become a CSS "black hole" placeholder (#576).

--- a/packages/secubox-toolbox/mitmproxy_addons/ad_ghost.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/ad_ghost.py
@@ -109,24 +109,10 @@ def _style_for(cats: dict) -> bytes:
     if not sels:
         return b""
     sel = ",".join(sels)
-    # #576 — instead of display:none (a blank collapsed gap), replace the
-    # ghosted ad slot with a CSS-layered "black hole" : a dark void box
-    # (radial gradient + inset glow), its real content hidden, and a glowing
-    # accretion-disc drawn with ::after. Intentional reclaimed space, not a
-    # broken hole. !important throughout so page CSS can't fight it.
-    rule = (
-        sel + "{position:relative!important;background:#05010a!important;"
-        "background-image:radial-gradient(ellipse at center,#1a0030 0%,#05010a 60%,#000 100%)!important;"
-        "box-shadow:inset 0 0 40px #000,inset 0 0 10px #6e40c9!important;"
-        "border:0!important;border-radius:10px!important;overflow:hidden!important;"
-        "min-height:28px!important;}"
-        + sel + ">*{visibility:hidden!important;opacity:0!important;pointer-events:none!important;}"
-        + sel + "::after{content:''!important;position:absolute!important;top:50%!important;"
-        "left:50%!important;width:38px!important;height:38px!important;margin:-19px 0 0 -19px!important;"
-        "border-radius:50%!important;background:radial-gradient(circle,#000 42%,#6e40c9 44%,#00d4ff 52%,"
-        "rgba(0,0,0,0) 70%)!important;box-shadow:0 0 22px 6px rgba(110,64,201,.7)!important;"
-        "visibility:visible!important;opacity:.85!important;animation:none!important;}"
-    )
+    # #584 — NO placeholder : collapse the ghosted ad slot entirely so the
+    # space disappears (display:none), rather than leaving a void/black-hole.
+    # Host-blocking (204) still saves the bandwidth ; this just hides the box.
+    rule = sel + "{display:none!important;visibility:hidden!important;}"
     return (b"<style id=\"sbx-ghost-style\">" + rule.encode("utf-8") + b"</style>")
 
 


### PR DESCRIPTION
Reverses #576: ghosted ad slots collapse with `display:none` (the space disappears), no black-hole/void. Host-blocking (204) still saves the bandwidth. secubox-toolbox 2.6.31.