### PR TITLE
fix(webui): metrics mitm=0 + threats shows IPs (#593)

### DIFF
--- a/packages/secubox-toolbox/debian/changelog
+++ b/packages/secubox-toolbox/debian/changelog
@@ -1,3 +1,16 @@
+secubox-toolbox (2.6.37-1~bookworm1) bookworm; urgency=medium
+
+  * fix(webui): metrics mitm=0 + threats list full of IPs (#593).
+      - /admin/metrics + the report metrics read journalctl `-u
+        secubox-toolbox-mitm` (the dead R2 unit) → always 0. Now a glob
+        `secubox-toolbox-mitm*` matches the live R3 workers
+        (…-mitm-wg-worker@N) ; connections counted from `server connect`.
+      - /admin/social-aggregate `by_tracker_domain` listed raw IPs (incl.
+        the cabine's own WAN IP as the top "tracker"). Now folds to the
+        registrable domain (eTLD+1) and drops IP literals (`_is_ip`).
+
+ -- Gerald KERMA <devel@cybermind.fr>  Sun, 14 Jun 2026 17:30:00 +0200
+
 secubox-toolbox (2.6.36-1~bookworm1) bookworm; urgency=medium
 
   * fix(autolearn): exclude anti-bot vendors from the auto-block list (#589

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -1543,15 +1543,14 @@ def _aggregate_session(mac_hash: str) -> dict:
     # Without -u for both, R3 clients always saw 0 connections in metrics.
     try:
         out = _sp.run(
-            ["journalctl",
-             "-u", "secubox-toolbox-mitm",
-             "-u", "secubox-toolbox-mitm-wg",
+            # #593 — glob matches the live R3 workers (…-mitm-wg-worker@N).
+            ["journalctl", "-u", "secubox-toolbox-mitm*",
              "--since", "-30min", "--no-pager"],
             capture_output=True, text=True, timeout=5, check=False,
         ).stdout
     except Exception:
         out = ""
-    connections = out.count("client connect")
+    connections = out.count("server connect")
     successful = out.count("<< 2") + out.count("<< 30")
     tls_pinned = out.count("Client TLS handshake failed")
     hosts: set[str] = set()
@@ -3028,10 +3027,12 @@ async def admin_metrics() -> dict:
     # Mitmproxy live stats (from journal)
     try:
         out = _sp.run(
-            ["journalctl", "-u", "secubox-toolbox-mitm", "--since", "-30min", "--no-pager"],
-            capture_output=True, text=True, timeout=3, check=False,
+            # #593 — glob matches the LIVE R3 workers (…-mitm-wg-worker@N),
+            # not just the (dead) R2 …-mitm unit → real numbers.
+            ["journalctl", "-u", "secubox-toolbox-mitm*", "--since", "-30min", "--no-pager"],
+            capture_output=True, text=True, timeout=4, check=False,
         ).stdout
-        metrics["mitm"]["connections"] = out.count("client connect")
+        metrics["mitm"]["connections"] = out.count("server connect")
         metrics["mitm"]["tls_pinned"] = out.count("Client TLS handshake failed")
         hosts: set[str] = set()
         for line in out.splitlines():

--- a/packages/secubox-toolbox/secubox_toolbox/social.py
+++ b/packages/secubox-toolbox/secubox_toolbox/social.py
@@ -33,6 +33,7 @@ import concurrent.futures as _futures
 import hashlib
 import json
 import logging
+import re
 import sqlite3
 import time
 from pathlib import Path
@@ -693,6 +694,15 @@ _MULTI_LABEL_TLDS = {
 }
 
 
+_IP_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
+
+
+def _is_ip(host: str) -> bool:
+    """True for an IPv4/IPv6 literal (to keep IPs out of domain views)."""
+    h = host or ""
+    return bool(_IP_RE.match(h)) or ":" in h
+
+
 def _registrable_domain(host: str) -> str:
     """Cheap eTLD+1 : www.lemonde.fr → lemonde.fr ; a.b.example.co.uk →
     example.co.uk. Raw IPs and single-label hosts pass through."""
@@ -1040,16 +1050,27 @@ def aggregate(hours: int = 24) -> Dict:
                 "WHERE ts >= ?",
                 (since,),
             ).fetchone()[0]
-            out["by_tracker_domain"] = [
-                dict(r)
-                for r in c.execute(
-                    "SELECT tracker_domain, COUNT(*) AS hits, "
-                    "COUNT(DISTINCT client_mac_hash) AS clients "
-                    "FROM social_edges WHERE ts >= ? "
-                    "GROUP BY tracker_domain ORDER BY hits DESC LIMIT 50",
-                    (since,),
-                ).fetchall()
-            ]
+            # #593 — fold to registrable domain + drop IP literals (the raw
+            # column otherwise surfaces IPs, incl. the cabine's own WAN IP,
+            # as the top "tracker"). Over-fetch, fold in Python, top 50.
+            _byd: dict = {}
+            for r in c.execute(
+                "SELECT tracker_domain, COUNT(*) AS hits, "
+                "COUNT(DISTINCT client_mac_hash) AS clients "
+                "FROM social_edges WHERE ts >= ? "
+                "GROUP BY tracker_domain ORDER BY hits DESC LIMIT 400",
+                (since,),
+            ).fetchall():
+                td = r["tracker_domain"] or ""
+                if not td or _is_ip(td):
+                    continue
+                dom = _registrable_domain(td)
+                e = _byd.setdefault(dom, {"tracker_domain": dom, "hits": 0,
+                                         "clients": 0})
+                e["hits"] += r["hits"]
+                e["clients"] = max(e["clients"], r["clients"])
+            out["by_tracker_domain"] = sorted(
+                _byd.values(), key=lambda x: -x["hits"])[:50]
             out["by_client"] = [
                 dict(r)
                 for r in c.execute(


### PR DESCRIPTION
Two WebUI bugs: **metrics** read journalctl `-u secubox-toolbox-mitm` (dead R2 unit) → always 0 ; now a glob `secubox-toolbox-mitm*` matches the live R3 workers, connections from `server connect`. **Threats** `by_tracker_domain` listed raw IPs (incl. the cabine's own WAN IP as #1) ; now folds to registrable domain + drops IP literals. secubox-toolbox 2.6.37. Closes #593.