### PR TITLE
fix(threat-analyst): build-safe service enable (#595)

### DIFF
--- a/packages/secubox-threat-analyst/debian/changelog
+++ b/packages/secubox-threat-analyst/debian/changelog
@@ -1,3 +1,13 @@
+secubox-threat-analyst (1.4.2-1~bookworm1) bookworm; urgency=medium
+
+  * fix(postinst): build-safe service enable (#595). A plain `systemctl
+    enable` no-ops during offline/image-build installs, so the unit ended
+    up DISABLED on the live board → /threat-analyst/ page loaded but its
+    backend (stats/alerts/rules) was down. Now uses deb-systemd-helper
+    (persists the enable to first boot) + guarded daemon-reload/start.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Sun, 15 Jun 2026 11:00:00 +0200
+
 secubox-threat-analyst (1.4.1-1~bookworm1) bookworm; urgency=low
 
   * Rewrite Description to identify this as the AI agent that

--- a/packages/secubox-threat-analyst/debian/postinst
+++ b/packages/secubox-threat-analyst/debian/postinst
@@ -1,9 +1,26 @@
 #!/bin/sh
 set -e
 if [ "$1" = "configure" ]; then
-    systemctl daemon-reload
-    systemctl enable secubox-threat-analyst.service || true
-    systemctl start secubox-threat-analyst.service || true
+    # #595 — build-safe enable: a plain `systemctl enable` no-ops during an
+    # offline / image-build (chroot) install, leaving the unit DISABLED on
+    # the live board (caught on gk2: /threat-analyst/ backend down). Use
+    # deb-systemd-helper (records the enable, applies on first boot) and only
+    # touch the running system when systemd is actually up.
+    if [ -d /run/systemd/system ]; then
+        systemctl daemon-reload || true
+    fi
+    if command -v deb-systemd-helper >/dev/null 2>&1; then
+        deb-systemd-helper enable secubox-threat-analyst.service >/dev/null 2>&1 || true
+    else
+        systemctl enable secubox-threat-analyst.service || true
+    fi
+    if [ -d /run/systemd/system ]; then
+        if command -v deb-systemd-invoke >/dev/null 2>&1; then
+            deb-systemd-invoke start secubox-threat-analyst.service >/dev/null 2>&1 || true
+        else
+            systemctl start secubox-threat-analyst.service || true
+        fi
+    fi
 fi
 #DEBHELPER#
 exit 0


### PR DESCRIPTION
Service ended up disabled on the live board (offline/image-build install no-ops `systemctl enable`), so /threat-analyst/ loaded but its backend was down. Now uses `deb-systemd-helper enable` (persists to first boot) + guarded daemon-reload/start. (Live already started+enabled manually.) Closes #595.