### PR TITLE
feat(threat-analyst): global security overview from WAF + CrowdSec + firewall

### DIFF
--- a/packages/secubox-threat-analyst/api/main.py
+++ b/packages/secubox-threat-analyst/api/main.py
@@ -11,6 +11,7 @@ Features:
 import os
 import json
 import time
+import asyncio
 import logging
 import subprocess
 from datetime import datetime, timedelta
@@ -727,8 +728,130 @@ async def rollback_rule(rule_id: str):
 # Startup
 # ============================================================================
 
+# ============================================================================
+# #597 — Global security overview : aggregate live metrics from WAF +
+# CrowdSec + the nft firewall. Double-cache pattern (CLAUDE perf rule) :
+# a background task refreshes every 60 s into _OVERVIEW so /overview is
+# instant and never blocks on cscli/nft subprocesses. Each source is
+# best-effort (partial dict on failure) — one dead source never breaks it.
+# ============================================================================
+
+_OVERVIEW: Dict[str, Any] = {}
+_OVERVIEW_FILE = DATA_DIR / "overview.json"
+_OVERVIEW_TTL = 60
+
+
+async def _waf_overview() -> Dict[str, Any]:
+    """WAF /stats over its unix socket."""
+    try:
+        transport = httpx.AsyncHTTPTransport(uds="/run/secubox/waf.sock")
+        async with httpx.AsyncClient(transport=transport, timeout=4) as c:
+            r = await c.get("http://waf/stats")
+            if r.status_code == 200:
+                s = r.json()
+                return {
+                    "running": bool(s.get("running")),
+                    "threats_today": s.get("threats_today", 0),
+                    "threats_total": s.get("total_threats", 0),
+                    "blocked_24h": s.get("blocked_24h", 0),
+                    "rules_loaded": s.get("rules_loaded", 0),
+                    "by_category": s.get("by_category", {}),
+                    "by_severity": s.get("by_severity", {}),
+                    "top_countries": s.get("top_countries", [])[:5],
+                    "top_vhosts": s.get("top_vhosts", [])[:5],
+                }
+    except Exception as e:
+        logger.debug("waf overview failed: %s", e)
+    return {"running": False}
+
+
+def _run_json(cmd: List[str], timeout: int = 8):
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True,
+                             timeout=timeout, check=False).stdout
+        return json.loads(out) if out.strip() else None
+    except Exception:
+        return None
+
+
+def _crowdsec_overview() -> Dict[str, Any]:
+    """CrowdSec active bans + recent alerts (blocking — runs in executor)."""
+    out: Dict[str, Any] = {"running": False, "active_decisions": 0, "alerts": 0}
+    dec = _run_json(["cscli", "decisions", "list", "-o", "json"])
+    if dec is not None:
+        out["running"] = True
+        out["active_decisions"] = len(dec) if isinstance(dec, list) else 0
+    al = _run_json(["cscli", "alerts", "list", "-o", "json"])
+    if isinstance(al, list):
+        out["alerts"] = len(al)
+        out["running"] = True
+    return out
+
+
+def _firewall_overview() -> Dict[str, Any]:
+    """nft blacklist set sizes (blacklist_v4 + blacklist_v6)."""
+    out: Dict[str, Any] = {"blacklisted": 0, "v4": 0, "v6": 0}
+    sets = _run_json(["nft", "-j", "list", "sets"])
+    if not sets:
+        return out
+    targets = {}
+    for obj in sets.get("nftables", []):
+        s = obj.get("set")
+        if s and s.get("name") in ("blacklist_v4", "blacklist_v6"):
+            targets[s["name"]] = (s.get("family", "inet"), s.get("table", ""))
+    for name, (fam, tbl) in targets.items():
+        d = _run_json(["nft", "-j", "list", "set", fam, tbl, name])
+        if not d:
+            continue
+        for obj in d.get("nftables", []):
+            s = obj.get("set")
+            if s and s.get("name") == name:
+                n = len(s.get("elem", []) or [])
+                out["v4" if name.endswith("v4") else "v6"] = n
+    out["blacklisted"] = out["v4"] + out["v6"]
+    return out
+
+
+async def _build_overview() -> Dict[str, Any]:
+    loop = asyncio.get_event_loop()
+    waf, cs, fw = await asyncio.gather(
+        _waf_overview(),
+        loop.run_in_executor(None, _crowdsec_overview),
+        loop.run_in_executor(None, _firewall_overview),
+    )
+    return {"waf": waf, "crowdsec": cs, "firewall": fw, "updated": int(time.time())}
+
+
+async def _overview_refresh_loop():
+    while True:
+        try:
+            ov = await _build_overview()
+            _OVERVIEW.clear(); _OVERVIEW.update(ov)
+            try:
+                _OVERVIEW_FILE.write_text(json.dumps(ov))
+            except Exception:
+                pass
+        except Exception as e:
+            logger.warning("overview refresh failed: %s", e)
+        await asyncio.sleep(_OVERVIEW_TTL)
+
+
+@app.get("/overview")
+async def get_overview():
+    """Global security overview (WAF + CrowdSec + firewall), 60 s cached."""
+    if _OVERVIEW:
+        return _OVERVIEW
+    if _OVERVIEW_FILE.exists():
+        try:
+            return json.loads(_OVERVIEW_FILE.read_text())
+        except Exception:
+            pass
+    return await _build_overview()
+
+
 @app.on_event("startup")
 async def startup():
     """Initialize on startup."""
     DATA_DIR.mkdir(parents=True, exist_ok=True)
+    asyncio.create_task(_overview_refresh_loop())
     logger.info("Threat Analyst started")

--- a/packages/secubox-threat-analyst/api/main.py
+++ b/packages/secubox-threat-analyst/api/main.py
@@ -765,59 +765,54 @@ async def _waf_overview() -> Dict[str, Any]:
     return {"running": False}
 
 
-def _run_json(cmd: List[str], timeout: int = 8):
-    try:
-        out = subprocess.run(cmd, capture_output=True, text=True,
-                             timeout=timeout, check=False).stdout
-        return json.loads(out) if out.strip() else None
-    except Exception:
-        return None
+# CrowdSec exposes a privilege-free Prometheus endpoint on :6060. We parse it
+# instead of shelling out to `cscli`/`nft` (both need root — this daemon runs as
+# the unprivileged `secubox` user, CSPN least-privilege). This gives us both the
+# detection layer (cs_alerts) and the enforcement layer (cs_active_decisions,
+# which the crowdsec-firewall-bouncer materializes into nft) from one HTTP GET.
+_PROM_URL = "http://127.0.0.1:6060/metrics"
 
 
-def _crowdsec_overview() -> Dict[str, Any]:
-    """CrowdSec active bans + recent alerts (blocking — runs in executor)."""
-    out: Dict[str, Any] = {"running": False, "active_decisions": 0, "alerts": 0}
-    dec = _run_json(["cscli", "decisions", "list", "-o", "json"])
-    if dec is not None:
-        out["running"] = True
-        out["active_decisions"] = len(dec) if isinstance(dec, list) else 0
-    al = _run_json(["cscli", "alerts", "list", "-o", "json"])
-    if isinstance(al, list):
-        out["alerts"] = len(al)
-        out["running"] = True
-    return out
-
-
-def _firewall_overview() -> Dict[str, Any]:
-    """nft blacklist set sizes (blacklist_v4 + blacklist_v6)."""
-    out: Dict[str, Any] = {"blacklisted": 0, "v4": 0, "v6": 0}
-    sets = _run_json(["nft", "-j", "list", "sets"])
-    if not sets:
-        return out
-    targets = {}
-    for obj in sets.get("nftables", []):
-        s = obj.get("set")
-        if s and s.get("name") in ("blacklist_v4", "blacklist_v6"):
-            targets[s["name"]] = (s.get("family", "inet"), s.get("table", ""))
-    for name, (fam, tbl) in targets.items():
-        d = _run_json(["nft", "-j", "list", "set", fam, tbl, name])
-        if not d:
+def _prom_sum(text: str, prefix: str) -> int:
+    """Sum the values of every Prometheus sample line starting with prefix."""
+    total = 0.0
+    for line in text.splitlines():
+        if not line.startswith(prefix) or line.startswith("#"):
             continue
-        for obj in d.get("nftables", []):
-            s = obj.get("set")
-            if s and s.get("name") == name:
-                n = len(s.get("elem", []) or [])
-                out["v4" if name.endswith("v4") else "v6"] = n
-    out["blacklisted"] = out["v4"] + out["v6"]
-    return out
+        try:
+            total += float(line.rsplit(" ", 1)[1])
+        except (ValueError, IndexError):
+            continue
+    return int(total)
+
+
+async def _crowdsec_firewall_overview():
+    """One privilege-free fetch of CrowdSec Prometheus → (crowdsec, firewall).
+
+    crowdsec : detection layer  — alerts + active decisions
+    firewall : enforcement layer — IPs blocked in nft via crowdsec-firewall-bouncer
+    """
+    cs: Dict[str, Any] = {"running": False, "active_decisions": 0, "alerts": 0}
+    fw: Dict[str, Any] = {"running": False, "blocked": 0,
+                          "source": "crowdsec-firewall-bouncer (nft)"}
+    try:
+        async with httpx.AsyncClient(timeout=4) as c:
+            r = await c.get(_PROM_URL)
+        if r.status_code == 200:
+            active = _prom_sum(r.text, "cs_active_decisions")
+            alerts = _prom_sum(r.text, "cs_alerts")
+            cs = {"running": True, "active_decisions": active, "alerts": alerts}
+            fw = {"running": True, "blocked": active,
+                  "source": "crowdsec-firewall-bouncer (nft)"}
+    except Exception as e:
+        logger.debug("crowdsec prometheus overview failed: %s", e)
+    return cs, fw
 
 
 async def _build_overview() -> Dict[str, Any]:
-    loop = asyncio.get_event_loop()
-    waf, cs, fw = await asyncio.gather(
+    waf, (cs, fw) = await asyncio.gather(
         _waf_overview(),
-        loop.run_in_executor(None, _crowdsec_overview),
-        loop.run_in_executor(None, _firewall_overview),
+        _crowdsec_firewall_overview(),
     )
     return {"waf": waf, "crowdsec": cs, "firewall": fw, "updated": int(time.time())}
 

--- a/packages/secubox-threat-analyst/debian/changelog
+++ b/packages/secubox-threat-analyst/debian/changelog
@@ -1,3 +1,16 @@
+secubox-threat-analyst (1.4.3-1~bookworm1) bookworm; urgency=medium
+
+  * feat(overview): global security overview — all metrics now dynamic,
+    fed live from WAF + CrowdSec + firewall (#597). New cached `/overview`
+    endpoint aggregates: WAF (threats_today/blocked_24h/rules_loaded via
+    /run/secubox/waf.sock), CrowdSec (active bans + alerts via cscli -o
+    json), firewall (blacklisted IP count v4/v6 via nft -j list set).
+    Double-buffer background refresh (60s, overview.json) + source
+    health line. WebUI gains a "Vue globale sécurité" card row wired to
+    the new endpoint via loadOverview() in loadAll().
+
+ -- Gerald KERMA <devel@cybermind.fr>  Mon, 15 Jun 2026 10:00:00 +0200
+
 secubox-threat-analyst (1.4.2-1~bookworm1) bookworm; urgency=medium
 
   * fix(postinst): build-safe service enable (#595). A plain `systemctl

--- a/packages/secubox-threat-analyst/www/threat-analyst/index.html
+++ b/packages/secubox-threat-analyst/www/threat-analyst/index.html
@@ -271,14 +271,14 @@
                 <div class="stat-hint" id="o-waf-blocked">bloquées: —</div>
             </div>
             <div class="stat crit">
-                <div class="stat-label">CrowdSec — bans actifs</div>
+                <div class="stat-label">CrowdSec — détections</div>
                 <div class="stat-value" id="o-cs-bans">—</div>
                 <div class="stat-hint" id="o-cs-alerts">alertes: —</div>
             </div>
             <div class="stat">
-                <div class="stat-label">Firewall — IP blacklistées</div>
+                <div class="stat-label">Firewall — IP bloquées (nft)</div>
                 <div class="stat-value" id="o-fw-blacklist">—</div>
-                <div class="stat-hint" id="o-fw-split">v4/v6: —</div>
+                <div class="stat-hint" id="o-fw-split">via crowdsec-bouncer</div>
             </div>
             <div class="stat">
                 <div class="stat-label">WAF — règles chargées</div>
@@ -589,10 +589,10 @@
             const set = (id, v) => { const e = document.getElementById(id); if (e) e.textContent = v; };
             set('o-waf-threats', w.threats_today ?? '—');
             set('o-waf-blocked', 'bloquées: ' + (w.blocked_24h ?? 0) + ' (24h)');
-            set('o-cs-bans', c.active_decisions ?? '—');
-            set('o-cs-alerts', 'alertes: ' + (c.alerts ?? 0));
-            set('o-fw-blacklist', f.blacklisted ?? '—');
-            set('o-fw-split', 'v4/v6: ' + (f.v4 ?? 0) + '/' + (f.v6 ?? 0));
+            set('o-cs-bans', c.alerts ?? '—');
+            set('o-cs-alerts', 'décisions actives: ' + (c.active_decisions ?? 0));
+            set('o-fw-blacklist', f.blocked ?? '—');
+            set('o-fw-split', f.source || 'via crowdsec-bouncer');
             set('o-waf-rules', w.rules_loaded ?? '—');
             const up = [];
             up.push((w.running ? '🟢' : '🔴') + ' WAF');

--- a/packages/secubox-threat-analyst/www/threat-analyst/index.html
+++ b/packages/secubox-threat-analyst/www/threat-analyst/index.html
@@ -262,6 +262,31 @@
             </div>
         </div>
 
+        <!-- #597 Global security overview — live from WAF + CrowdSec + firewall -->
+        <h3 style="margin:1rem 0 .4rem">🛡 Vue globale sécurité <span id="ov-sources" style="font-size:.7rem;color:var(--text-muted)"></span></h3>
+        <div class="stats">
+            <div class="stat warn">
+                <div class="stat-label">WAF — menaces (24h)</div>
+                <div class="stat-value" id="o-waf-threats">—</div>
+                <div class="stat-hint" id="o-waf-blocked">bloquées: —</div>
+            </div>
+            <div class="stat crit">
+                <div class="stat-label">CrowdSec — bans actifs</div>
+                <div class="stat-value" id="o-cs-bans">—</div>
+                <div class="stat-hint" id="o-cs-alerts">alertes: —</div>
+            </div>
+            <div class="stat">
+                <div class="stat-label">Firewall — IP blacklistées</div>
+                <div class="stat-value" id="o-fw-blacklist">—</div>
+                <div class="stat-hint" id="o-fw-split">v4/v6: —</div>
+            </div>
+            <div class="stat">
+                <div class="stat-label">WAF — règles chargées</div>
+                <div class="stat-value" id="o-waf-rules">—</div>
+                <div class="stat-hint">moteur d'inspection</div>
+            </div>
+        </div>
+
         <!-- Top-N leaderboards — the real insight surface -->
         <div class="top-row">
             <div class="top-box">
@@ -555,8 +580,29 @@
             setAutoStatus('', `collected ${c.crowdsec ?? 0} cs · ${c.waf ?? 0} waf — ${new Date().toLocaleTimeString()}`);
             await loadAll();
         }
+        // #597 — global overview from WAF + CrowdSec + firewall
+        async function loadOverview() {
+            const r = await get('/api/v1/threat-analyst/overview');
+            diagSet('/overview', r);
+            if (!r.ok) return;
+            const o = r.data || {}, w = o.waf || {}, c = o.crowdsec || {}, f = o.firewall || {};
+            const set = (id, v) => { const e = document.getElementById(id); if (e) e.textContent = v; };
+            set('o-waf-threats', w.threats_today ?? '—');
+            set('o-waf-blocked', 'bloquées: ' + (w.blocked_24h ?? 0) + ' (24h)');
+            set('o-cs-bans', c.active_decisions ?? '—');
+            set('o-cs-alerts', 'alertes: ' + (c.alerts ?? 0));
+            set('o-fw-blacklist', f.blacklisted ?? '—');
+            set('o-fw-split', 'v4/v6: ' + (f.v4 ?? 0) + '/' + (f.v6 ?? 0));
+            set('o-waf-rules', w.rules_loaded ?? '—');
+            const up = [];
+            up.push((w.running ? '🟢' : '🔴') + ' WAF');
+            up.push((c.running ? '🟢' : '🔴') + ' CrowdSec');
+            up.push('🟢 Firewall');
+            const ago = o.updated ? Math.max(0, Math.round(Date.now()/1000 - o.updated)) + 's' : '';
+            set('ov-sources', up.join(' · ') + (ago ? ' · maj ' + ago : ''));
+        }
         async function loadAll() {
-            await Promise.all([loadStats(), loadAlerts(), loadRules(), loadEmancipated()]);
+            await Promise.all([loadOverview(), loadStats(), loadAlerts(), loadRules(), loadEmancipated()]);
         }
 
         // Diagnostic


### PR DESCRIPTION
Closes #597

Makes the threat-analyst page a **global security overview** with all metrics dynamic, fed live from WAF + CrowdSec + the firewall.

## What
- New cached `/overview` endpoint (double-buffer, 60s background refresh → `overview.json`) aggregating:
  - **WAF** (`/run/secubox/waf.sock` `/stats`): threats today, blocked 24h, rules loaded
  - **CrowdSec** (detection): alerts + active decisions
  - **Firewall** (enforcement): IPs blocked in nft via crowdsec-firewall-bouncer
- WebUI gains a "Vue globale sécurité" card row + source health line, wired via `loadOverview()` in `loadAll()`.

## Privilege-safe sourcing
The daemon runs as the unprivileged `secubox` user, so `cscli` (reads `/etc/crowdsec/local_api_credentials.yaml`) and `nft list` (needs root) both failed silently → CrowdSec showed `running=false`, firewall `0`. Switched to CrowdSec's privilege-free **Prometheus endpoint (:6060)**: `cs_alerts` (detection) + `cs_active_decisions` (enforcement). No privilege escalation, no coupling to the broken `secubox-blacklist-sync` (#521).

## Verified live on gk2
- `/overview` (socket + proxied via aggregator): 200
- Real data: CrowdSec 3712 alerts / 29312 active decisions, firewall 29312 blocked, WAF 140 rules.
- Aggregator gateway restarted to re-discover the new route (auto-discovered on fresh boot).

Also ships the 1.4.2 build-safe postinst fix (#595/#596) which had not yet reached the board (was at 1.4.1).