### PR TITLE
fix(waf): port live mitmproxy fixes to source — mitmproxy-11 routing + routes bind-mount

### DIFF
--- a/packages/secubox-mitmproxy/addons/secubox_waf.py
+++ b/packages/secubox-mitmproxy/addons/secubox_waf.py
@@ -919,6 +919,28 @@ class SecuBoxWAF:
         except Exception:
             ctx.log.warn(f"BAN FAILED for {ip} ({reason}) : LAPI off + cscli unavailable")
     
+    def requestheaders(self, flow: http.HTTPFlow):
+        # #603 — mitmproxy 11 opens the upstream connection BETWEEN the
+        # requestheaders and request hooks, so upstream redirection must
+        # happen here. Doing it in request() (below) is too late: the
+        # socket is already connected to the original Host, so routed
+        # vhosts went to their public DNS IP instead of the internal
+        # backend. Setting flow.server_conn.address here fixes routing.
+        try:
+            host = flow.request.pretty_host
+            if host in self.routes:
+                bip, bport = self.routes[host]
+                orig = flow.request.headers.get('Host', host)
+                flow.request.host = bip
+                flow.request.port = bport
+                try:
+                    flow.server_conn.address = (bip, bport)
+                except Exception:
+                    pass
+                flow.request.headers['Host'] = orig
+        except Exception as e:
+            ctx.log.warn(f'[requestheaders-route] {e}')
+
     def request(self, flow: http.HTTPFlow):
         # Connection close (Phase 6.J leak fix, ref #496) — prevents mitmproxy
         # from accumulating idle keep-alive sockets to upstream backends.

--- a/packages/secubox-mitmproxy/debian/changelog
+++ b/packages/secubox-mitmproxy/debian/changelog
@@ -1,3 +1,15 @@
+secubox-mitmproxy (1.0.5-1~bookworm1) bookworm; urgency=medium
+
+  * fix(waf): mitmproxy-11 upstream routing (#603). The addon only redirected
+    the upstream in the `request` hook, but mitmproxy 11 opens the upstream
+    connection between `requestheaders` and `request` — so routed vhosts
+    connected to their public DNS IP instead of the internal backend (the WAF
+    was effectively pass-through). Added a `requestheaders` hook that sets
+    `flow.server_conn.address` before the connect. Ported from the live gk2
+    fix that restored apt.secubox.in + all inspected vhosts.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Mon, 15 Jun 2026 16:00:00 +0200
+
 secubox-mitmproxy (1.0.4-1~bookworm1) bookworm; urgency=medium
 
   * Pre-route SELF_HOSTS guard. When a client targets the box by

--- a/packages/secubox-waf/debian/changelog
+++ b/packages/secubox-waf/debian/changelog
@@ -1,3 +1,18 @@
+secubox-waf (1.2.3-1~bookworm1) bookworm; urgency=medium
+
+  * fix(waf): mitmproxy-11 upstream routing — `requestheaders` hook in the
+    addon copy (#603, kept in sync with secubox-mitmproxy).
+  * fix(wafctl): bind-mount the host-maintained
+    /srv/mitmproxy/haproxy-routes.json into the LXC at the addon's read path
+    (/data/mitmproxy/haproxy-routes.json). The two had drifted (in-LXC copy
+    went stale → routes_count: 0 → no routing). Also ensures the host file
+    exists at provision time.
+  * doc(service): warn that any ExecStart drop-in MUST keep
+    `--set confdir=/data/mitmproxy` (a cookie_audit drop-in once dropped it
+    and crash-looped the WAF on ProtectHome).
+
+ -- Gerald KERMA <devel@cybermind.fr>  Mon, 15 Jun 2026 16:00:00 +0200
+
 secubox-waf (1.2.2-1~bookworm1) bookworm; urgency=medium
 
   * Phase 11+ (#509) — double-buffered cache for WAF stats consumed by

--- a/packages/secubox-waf/mitmproxy/secubox_waf.py
+++ b/packages/secubox-waf/mitmproxy/secubox_waf.py
@@ -775,6 +775,28 @@ class SecuBoxWAF:
         except Exception:
             ctx.log.warn(f"BAN FAILED for {ip} ({reason})")
     
+    def requestheaders(self, flow: http.HTTPFlow):
+        # #603 — mitmproxy 11 opens the upstream connection BETWEEN the
+        # requestheaders and request hooks, so upstream redirection must
+        # happen here. Doing it in request() (below) is too late: the
+        # socket is already connected to the original Host, so routed
+        # vhosts went to their public DNS IP instead of the internal
+        # backend. Setting flow.server_conn.address here fixes routing.
+        try:
+            host = flow.request.pretty_host
+            if host in self.routes:
+                bip, bport = self.routes[host]
+                orig = flow.request.headers.get('Host', host)
+                flow.request.host = bip
+                flow.request.port = bport
+                try:
+                    flow.server_conn.address = (bip, bport)
+                except Exception:
+                    pass
+                flow.request.headers['Host'] = orig
+        except Exception as e:
+            ctx.log.warn(f'[requestheaders-route] {e}')
+
     def request(self, flow: http.HTTPFlow):
         # Connection close (Phase 6.J leak fix, ref #496) — prevents mitmproxy
         # from accumulating idle keep-alive sockets to upstream backends.

--- a/packages/secubox-waf/scripts/wafctl
+++ b/packages/secubox-waf/scripts/wafctl
@@ -82,6 +82,13 @@ cmd_install() {
     # Create symlink for lxc-* commands
     ln -sf "$LXC_PATH/$LXC_NAME" "/var/lib/lxc/$LXC_NAME"
 
+    # Ensure the host-maintained routes file exists so the bind-mount below has
+    # a source (#603). haproxyctl writes this file on the host; the WAF addon
+    # inside the LXC reads /data/mitmproxy/haproxy-routes.json — the bind-mount
+    # keeps them the same file instead of two copies that drift apart.
+    mkdir -p /srv/mitmproxy
+    [ -f /srv/mitmproxy/haproxy-routes.json ] || echo '{}' > /srv/mitmproxy/haproxy-routes.json
+
     # Configure container
     cat >> "$LXC_PATH/$LXC_NAME/config" << CONF
 
@@ -91,6 +98,12 @@ lxc.net.0.link = br-lxc
 lxc.net.0.flags = up
 lxc.net.0.ipv4.address = $LXC_IP/24
 lxc.net.0.ipv4.gateway = 10.100.0.1
+
+# Routes: bind-mount the host-maintained haproxy routes into the path the WAF
+# addon reads. Without this the addon loaded an empty/stale in-LXC copy
+# (routes_count: 0) so no upstream routing happened and every inspected vhost
+# went to its public DNS IP. (#603)
+lxc.mount.entry = /srv/mitmproxy/haproxy-routes.json data/mitmproxy/haproxy-routes.json none bind,create=file 0 0
 
 # Autostart
 lxc.start.auto = 1

--- a/packages/secubox-waf/systemd/mitmproxy.service
+++ b/packages/secubox-waf/systemd/mitmproxy.service
@@ -12,6 +12,10 @@ Type=simple
 User=mitmproxy
 Group=mitmproxy
 WorkingDirectory=/data/mitmproxy
+# WARNING (#603): any ExecStart override (drop-in) MUST keep
+# `--set confdir=/data/mitmproxy`. Without it mitmdump falls back to
+# ~/.mitmproxy, which ProtectHome=true makes inaccessible → PermissionError
+# crash-loop. A cookie_audit drop-in once dropped this flag and downed the WAF.
 ExecStart=/opt/mitmproxy/bin/mitmdump \
     --mode regular \
     --listen-host 0.0.0.0 \


### PR DESCRIPTION
Closes #603

Ports the live gk2 WAF fixes (HISTORY 2026-06-15) into source so re-provisioning produces a working WAF.

## Changes
- **mitmproxy-11 routing** — added a `requestheaders` hook to **both** synced `secubox_waf.py` copies (`secubox-mitmproxy/addons/`, `secubox-waf/mitmproxy/`). mitmproxy 11 opens the upstream connection *between* `requestheaders` and `request`, so the existing in-`request` redirect was too late and routed vhosts connected to their public DNS IP instead of the internal backend (WAF effectively pass-through). Now sets `flow.server_conn.address` in `requestheaders`.
- **Route-file drift** — `wafctl` now bind-mounts the host-maintained `/srv/mitmproxy/haproxy-routes.json` into the LXC at the addon's read path `/data/mitmproxy/haproxy-routes.json` (they had drifted → `routes_count: 0` → no routing), and ensures the host file exists at provision time.
- **confdir guard** — comment in `mitmproxy.service` warning that any ExecStart drop-in must keep `--set confdir=/data/mitmproxy` (a `cookie_audit` drop-in once dropped it → ProtectHome `PermissionError` crash-loop).

Bumps secubox-mitmproxy 1.0.5, secubox-waf 1.2.3.