### PR TITLE
ui(threat-analyst): limit Recent attacks table to 5 rows

### DIFF
--- a/packages/secubox-threat-analyst/debian/changelog
+++ b/packages/secubox-threat-analyst/debian/changelog
@@ -1,3 +1,11 @@
+secubox-threat-analyst (1.4.5-1~bookworm1) bookworm; urgency=medium
+
+  * ui: limit the Recent attacks table to 5 rows (#611), matching the Top-N
+    lists. Stats + leaderboards are unaffected (computed from the full alert
+    set before the table slice).
+
+ -- Gerald KERMA <devel@cybermind.fr>  Tue, 16 Jun 2026 09:00:00 +0200
+
 secubox-threat-analyst (1.4.4-1~bookworm1) bookworm; urgency=medium
 
   * feat(ingest): populate the headline stats + Top-N leaderboards with real

--- a/packages/secubox-threat-analyst/www/threat-analyst/index.html
+++ b/packages/secubox-threat-analyst/www/threat-analyst/index.html
@@ -460,7 +460,7 @@
                 document.getElementById('s-countries').textContent = 0;
                 return;
             }
-            const rows = alerts.slice(0, 100).map(a => {
+            const rows = alerts.slice(0, 5).map(a => {
                 const m = flatMeta(a);
                 return `<tr>
                     <td>${m.lastSeen ? esc(new Date(m.lastSeen).toLocaleString()) : '—'}</td>
@@ -472,7 +472,7 @@
                     <td><span class="mono">${m.hitCount}</span></td>
                 </tr>`;
             }).join('');
-            const extra = alerts.length > 100 ? `<div class="msg msg-empty">${alerts.length - 100} more not shown</div>` : '';
+            const extra = alerts.length > 5 ? `<div class="msg msg-empty">${alerts.length - 5} more not shown</div>` : '';
             c.innerHTML = `<table>
                 <thead><tr>
                     <th>Last seen</th><th>Sev</th><th>Source IP</th>


### PR DESCRIPTION
Closes #611

Recent attacks table capped at 100 → **5**, matching the Top-N lists. Stats + leaderboards unaffected (computed from the full alert set via renderTopFromAlerts before the table slice). Deployed live (1.4.5).