### PR TITLE
haproxy: smart self-healing error pages + wire errorfile in generator (closes #626)

### DIFF
--- a/docs/superpowers/specs/2026-06-17-haproxy-vhost-auto-discovery-design.md
+++ b/docs/superpowers/specs/2026-06-17-haproxy-vhost-auto-discovery-design.md
@@ -1,0 +1,56 @@
+<!-- SPDX-License-Identifier: LicenseRef-CMSD-1.0 -->
+# Spec — HAProxy complete dynamic vhost auto-discovery
+
+*2026-06-17 · landed for later (per user) · found while fixing #626/#627*
+
+## Problem
+`haproxyctl generate` must produce a COMPLETE config so regen never drops
+hand-maintained vhosts. Today ~10 vhosts live only in the hand-edited
+`/etc/haproxy/haproxy.cfg` — not in `haproxy.toml` or `cfg.d/`:
+
+- `kbin.gk2.secubox.in` → `toolbox_landing` (backend also live-only)
+- `matrix`, `gitea`, `peertube`, `photoprism` (.gk2.secubox.in) → `nginx_vhosts`
+
+These bypass the WAF today (route direct, not through `mitmproxy_inspector`).
+A clean regen omits them. PR #627 added a **drift guard** so regen refuses to
+clobber when its output has fewer vhosts/backends than live — safe, but not
+complete.
+
+## Design (approved direction: auto-discover from modules/LXC)
+1. **Drop-in registry.** Generator aggregates `haproxy.toml [vhosts.*]` **plus**
+   `/etc/secubox/vhosts.d/*.toml` — one file per module/LXC, dropped by that
+   module's postinst (self-registration). New modules appear automatically.
+2. **Per-vhost routing intent** replaces the blanket `waf_enabled` override
+   (which currently forces *every* vhost through the WAF):
+   ```toml
+   [vhost]
+   domain  = "peertube.gk2.secubox.in"
+   backend = "nginx_vhosts"     # or a module/LXC backend
+   ssl     = true
+   inspect = false              # true → mitmproxy_inspector (WAF); false → direct
+   ```
+3. **One-time migration.** Seed `vhosts.d/` from the ~10 drifted live entries
+   with their real backends + `inspect=false`; register `toolbox_landing` as a
+   known backend. After this, regen output == live → drift guard passes.
+4. **Module-registration helper** for postinsts (e.g. `haproxyctl vhost register
+   --from-file` or a tiny library) so each LXC/module declares its vhost.
+5. **Keep the drift guard** as the transition safety net.
+
+## Validation gate (non-negotiable)
+Never apply a regenerated cfg to production until a diff proves it reproduces all
+~100 live vhosts/backends 1:1 (drift-guard counts match).
+
+## Related: finish the traversal-footgun sweep (#623)
+The systemic `install -d -m 0750 .../secubox` footgun is broader than first
+swept: **multi-arg** forms like `install -d -m 0750 /run/secubox /var/lib/secubox
+…` (e.g. secubox-haproxy, fixed in #627) were missed by the earlier grep
+(`…/secubox/[a-z]` required a leaf). Re-sweep with a pattern that catches bare
+`/var/{lib,log,cache}/secubox` arguments, and add a **tmpfiles.d + periodic
+guard** so the shared parents self-heal to `0755` regardless of which package
+clobbers them (this is the root of the recurring kbin/toolbox 500s).
+
+## Status
+- Generator no longer crashes (set -e + dup-backend fixed, #627).
+- Drift guard prevents clobbering (#627).
+- Error pages live + served from `/etc/haproxy/secubox-errors/` (#627).
+- This auto-discovery rework + the #623 re-sweep are the remaining work.

--- a/packages/secubox-haproxy/debian/changelog
+++ b/packages/secubox-haproxy/debian/changelog
@@ -6,17 +6,20 @@ secubox-haproxy (1.3.1-1~bookworm1) bookworm; urgency=medium
         with live status + manual retry. {400,403,408,500}.http: branded static.
       - haproxyctl generator: wire errorfile directives (durable across regen)
         and persist retries 3 + option redispatch in defaults.
-      - Ship pages to /etc/haproxy/errors/; postinst regen-safe applies them.
+      - Ship pages to /etc/haproxy/secubox-errors/ (own dir; /etc/haproxy/errors
+        is owned by the haproxy package). errorfile wired there.
   * fix(generator): `haproxyctl generate` was broken (exited 1, produced no
     backends) — root causes: (a) `set -e` + `[ ] && [ ] && { }` vhost-loop
     chains aborted generation on the first non-SSL vhost; (b) duplicate
     `backend mitmproxy_inspector` (auto + user TOML) → fatal. Converted the
     chains to if/then/fi and dedup user backends already emitted.
-  * fix(postinst): keep /run/secubox + /var/lib/secubox at 0755 (was 0750,
-    breaking traversal for other daemons — kbin/toolbox 500).  — refuse to install a generated cfg with fewer
+  * fix(generator): drift guard — refuse to install a generated cfg with fewer
     vhosts/backends than the live one (prevents a successful regen from silently
     dropping hand-maintained vhosts like kbin/gitea/matrix not yet in
     haproxy.toml). Surfaces the drift instead of clobbering.
+  * fix(postinst): keep /run/secubox + /var/lib/secubox at 0755 (was set 0750,
+    breaking directory traversal for other secubox-* daemons — kbin/toolbox 500).
+    Only the haproxy-private leaves are 0750.
 
  -- Gerald Kerma <devel@cybermind.fr>  Tue, 17 Jun 2026 09:00:00 +0200
 

--- a/packages/secubox-haproxy/debian/changelog
+++ b/packages/secubox-haproxy/debian/changelog
@@ -1,3 +1,15 @@
+secubox-haproxy (1.3.1-1~bookworm1) bookworm; urgency=medium
+
+  * feat(errors): smart self-healing HAProxy error pages (closes #626).
+      - errors/{502,503,504}.http: branded pages that poll the URL and
+        auto-reload when the backend recovers (transient blips heal in-browser),
+        with live status + manual retry. {400,403,408,500}.http: branded static.
+      - haproxyctl generator: wire errorfile directives (durable across regen)
+        and persist retries 3 + option redispatch in defaults.
+      - Ship pages to /etc/haproxy/errors/; postinst regen-safe applies them.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Tue, 17 Jun 2026 09:00:00 +0200
+
 secubox-haproxy (1.3.0-1~bookworm1) bookworm; urgency=medium
 
   * sbin/haproxyctl: rewrite cmd_generate to be safe + complete (#286).

--- a/packages/secubox-haproxy/debian/changelog
+++ b/packages/secubox-haproxy/debian/changelog
@@ -12,7 +12,8 @@ secubox-haproxy (1.3.1-1~bookworm1) bookworm; urgency=medium
     chains aborted generation on the first non-SSL vhost; (b) duplicate
     `backend mitmproxy_inspector` (auto + user TOML) → fatal. Converted the
     chains to if/then/fi and dedup user backends already emitted.
-  * fix(generator): drift guard — refuse to install a generated cfg with fewer
+  * fix(postinst): keep /run/secubox + /var/lib/secubox at 0755 (was 0750,
+    breaking traversal for other daemons — kbin/toolbox 500).  — refuse to install a generated cfg with fewer
     vhosts/backends than the live one (prevents a successful regen from silently
     dropping hand-maintained vhosts like kbin/gitea/matrix not yet in
     haproxy.toml). Surfaces the drift instead of clobbering.

--- a/packages/secubox-haproxy/debian/changelog
+++ b/packages/secubox-haproxy/debian/changelog
@@ -7,6 +7,15 @@ secubox-haproxy (1.3.1-1~bookworm1) bookworm; urgency=medium
       - haproxyctl generator: wire errorfile directives (durable across regen)
         and persist retries 3 + option redispatch in defaults.
       - Ship pages to /etc/haproxy/errors/; postinst regen-safe applies them.
+  * fix(generator): `haproxyctl generate` was broken (exited 1, produced no
+    backends) — root causes: (a) `set -e` + `[ ] && [ ] && { }` vhost-loop
+    chains aborted generation on the first non-SSL vhost; (b) duplicate
+    `backend mitmproxy_inspector` (auto + user TOML) → fatal. Converted the
+    chains to if/then/fi and dedup user backends already emitted.
+  * fix(generator): drift guard — refuse to install a generated cfg with fewer
+    vhosts/backends than the live one (prevents a successful regen from silently
+    dropping hand-maintained vhosts like kbin/gitea/matrix not yet in
+    haproxy.toml). Surfaces the drift instead of clobbering.
 
  -- Gerald Kerma <devel@cybermind.fr>  Tue, 17 Jun 2026 09:00:00 +0200
 

--- a/packages/secubox-haproxy/debian/postinst
+++ b/packages/secubox-haproxy/debian/postinst
@@ -4,7 +4,12 @@ case "$1" in
   configure)
     id -u secubox >/dev/null 2>&1 || \
       adduser --system --group --no-create-home --home /var/lib/secubox --shell /usr/sbin/nologin secubox
-    install -d -o secubox -g secubox -m 750 /run/secubox /var/lib/secubox /var/lib/secubox/haproxy /var/lib/secubox/haproxy/config_backups
+    # Shared parents stay 0755 (traversable by every secubox-* daemon — setting
+    # them 0750 here broke kbin/toolbox by blocking traversal, #626). Only the
+    # haproxy-private leaves are restricted.
+    install -d -o secubox -g secubox -m 755 /run/secubox /var/lib/secubox
+    install -d -o secubox -g secubox -m 750 /var/lib/secubox/haproxy /var/lib/secubox/haproxy/config_backups
+    chmod 0755 /var/lib/secubox /run/secubox 2>/dev/null || true
     # Create /etc/haproxy if not present (haproxy is Recommends, not Depends)
     # Required for systemd namespace setup
     install -d -m 755 /etc/haproxy

--- a/packages/secubox-haproxy/debian/rules
+++ b/packages/secubox-haproxy/debian/rules
@@ -16,6 +16,9 @@ override_dh_auto_install:
 	[ -d www ] && cp -r www/. debian/secubox-haproxy/usr/share/secubox/www/ || true
 	install -d debian/secubox-haproxy/usr/share/secubox/menu.d
 	[ -d menu.d ] && cp -r menu.d/. debian/secubox-haproxy/usr/share/secubox/menu.d/ || true
+	# Smart self-healing HAProxy error pages (#626) — wired via errorfile in haproxyctl
+	install -d debian/secubox-haproxy/etc/haproxy/errors
+	[ -d errors ] && install -m 644 errors/*.http debian/secubox-haproxy/etc/haproxy/errors/ || true
 	# Modular nginx config
 	install -d debian/secubox-haproxy/etc/nginx/secubox.d
 	[ -f nginx/haproxy.conf ] && cp nginx/haproxy.conf debian/secubox-haproxy/etc/nginx/secubox.d/ || true

--- a/packages/secubox-haproxy/debian/rules
+++ b/packages/secubox-haproxy/debian/rules
@@ -16,9 +16,10 @@ override_dh_auto_install:
 	[ -d www ] && cp -r www/. debian/secubox-haproxy/usr/share/secubox/www/ || true
 	install -d debian/secubox-haproxy/usr/share/secubox/menu.d
 	[ -d menu.d ] && cp -r menu.d/. debian/secubox-haproxy/usr/share/secubox/menu.d/ || true
-	# Smart self-healing HAProxy error pages (#626) — wired via errorfile in haproxyctl
-	install -d debian/secubox-haproxy/etc/haproxy/errors
-	[ -d errors ] && install -m 644 errors/*.http debian/secubox-haproxy/etc/haproxy/errors/ || true
+	# Smart self-healing HAProxy error pages (#626) — wired via errorfile in
+	# haproxyctl. Own dir (NOT /etc/haproxy/errors, which the haproxy package owns).
+	install -d debian/secubox-haproxy/etc/haproxy/secubox-errors
+	[ -d errors ] && install -m 644 errors/*.http debian/secubox-haproxy/etc/haproxy/secubox-errors/ || true
 	# Modular nginx config
 	install -d debian/secubox-haproxy/etc/nginx/secubox.d
 	[ -f nginx/haproxy.conf ] && cp nginx/haproxy.conf debian/secubox-haproxy/etc/nginx/secubox.d/ || true

--- a/packages/secubox-haproxy/errors/400.http
+++ b/packages/secubox-haproxy/errors/400.http
@@ -1,0 +1,35 @@
+HTTP/1.1 400 Bad Request
+Cache-Control: no-store
+Connection: close
+Content-Type: text/html; charset=utf-8
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Bad request — SecuBox</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{min-height:100vh;background:#0a0a0f;color:#e8e6d9;font-family:system-ui,-apple-system,'Segoe UI',sans-serif;display:flex;align-items:center;justify-content:center;padding:24px;
+  background-image:radial-gradient(ellipse at 30% 20%,rgba(230,57,70,.06)0%,transparent 50%),radial-gradient(ellipse at 70% 80%,rgba(110,64,201,.05)0%,transparent 50%)}
+.card{max-width:520px;width:100%;text-align:center;background:rgba(17,23,32,.85);border:1px solid rgba(255,255,255,.08);border-radius:16px;padding:40px 32px;box-shadow:0 8px 40px rgba(0,0,0,.5)}
+.code{font-family:'JetBrains Mono',monospace;font-size:5.5rem;font-weight:700;line-height:1;color:#c9a84c;text-shadow:0 0 30px rgba(201,168,76,.4)}
+h1{font-size:1.5rem;font-weight:600;margin:12px 0 8px}
+p{color:#8a9aa8;font-size:.95rem;line-height:1.6;margin:6px 0}
+button{margin-top:22px;background:transparent;color:#00d4ff;border:1px solid #00d4ff;border-radius:8px;padding:10px 20px;font:inherit;font-size:.9rem;cursor:pointer;transition:all .2s}
+button:hover{background:#00d4ff;color:#0a0a0f}
+.brand{margin-top:28px;font-family:'JetBrains Mono',monospace;font-size:.72rem;color:#6b6b7a;letter-spacing:1px}
+.brand b{color:#0a5840;filter:brightness(1.6)}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="code">400</div>
+  <h1>Bad request</h1>
+  <p>The request could not be understood. Check the URL and try again.</p>
+  <button type="button" onclick="history.length>1?history.back():location.reload()">Go back</button>
+  <div class="brand">SecuBox<b>·</b> secured edge</div>
+</div>
+</body>
+</html>

--- a/packages/secubox-haproxy/errors/403.http
+++ b/packages/secubox-haproxy/errors/403.http
@@ -1,0 +1,35 @@
+HTTP/1.1 403 Forbidden
+Cache-Control: no-store
+Connection: close
+Content-Type: text/html; charset=utf-8
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Blocked — SecuBox</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{min-height:100vh;background:#0a0a0f;color:#e8e6d9;font-family:system-ui,-apple-system,'Segoe UI',sans-serif;display:flex;align-items:center;justify-content:center;padding:24px;
+  background-image:radial-gradient(ellipse at 30% 20%,rgba(230,57,70,.06)0%,transparent 50%),radial-gradient(ellipse at 70% 80%,rgba(110,64,201,.05)0%,transparent 50%)}
+.card{max-width:520px;width:100%;text-align:center;background:rgba(17,23,32,.85);border:1px solid rgba(255,255,255,.08);border-radius:16px;padding:40px 32px;box-shadow:0 8px 40px rgba(0,0,0,.5)}
+.code{font-family:'JetBrains Mono',monospace;font-size:5.5rem;font-weight:700;line-height:1;color:#e63946;text-shadow:0 0 30px rgba(230,57,70,.4)}
+h1{font-size:1.5rem;font-weight:600;margin:12px 0 8px}
+p{color:#8a9aa8;font-size:.95rem;line-height:1.6;margin:6px 0}
+button{margin-top:22px;background:transparent;color:#00d4ff;border:1px solid #00d4ff;border-radius:8px;padding:10px 20px;font:inherit;font-size:.9rem;cursor:pointer;transition:all .2s}
+button:hover{background:#00d4ff;color:#0a0a0f}
+.brand{margin-top:28px;font-family:'JetBrains Mono',monospace;font-size:.72rem;color:#6b6b7a;letter-spacing:1px}
+.brand b{color:#0a5840;filter:brightness(1.6)}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="code">403</div>
+  <h1>Blocked</h1>
+  <p>This request was blocked by the SecuBox WAF. If you believe this is a mistake, contact the operator.</p>
+  <button type="button" onclick="history.length>1?history.back():location.reload()">Go back</button>
+  <div class="brand">SecuBox<b>·</b> secured edge</div>
+</div>
+</body>
+</html>

--- a/packages/secubox-haproxy/errors/408.http
+++ b/packages/secubox-haproxy/errors/408.http
@@ -1,0 +1,35 @@
+HTTP/1.1 408 Request Timeout
+Cache-Control: no-store
+Connection: close
+Content-Type: text/html; charset=utf-8
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Request timeout — SecuBox</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{min-height:100vh;background:#0a0a0f;color:#e8e6d9;font-family:system-ui,-apple-system,'Segoe UI',sans-serif;display:flex;align-items:center;justify-content:center;padding:24px;
+  background-image:radial-gradient(ellipse at 30% 20%,rgba(230,57,70,.06)0%,transparent 50%),radial-gradient(ellipse at 70% 80%,rgba(110,64,201,.05)0%,transparent 50%)}
+.card{max-width:520px;width:100%;text-align:center;background:rgba(17,23,32,.85);border:1px solid rgba(255,255,255,.08);border-radius:16px;padding:40px 32px;box-shadow:0 8px 40px rgba(0,0,0,.5)}
+.code{font-family:'JetBrains Mono',monospace;font-size:5.5rem;font-weight:700;line-height:1;color:#c9a84c;text-shadow:0 0 30px rgba(201,168,76,.4)}
+h1{font-size:1.5rem;font-weight:600;margin:12px 0 8px}
+p{color:#8a9aa8;font-size:.95rem;line-height:1.6;margin:6px 0}
+button{margin-top:22px;background:transparent;color:#00d4ff;border:1px solid #00d4ff;border-radius:8px;padding:10px 20px;font:inherit;font-size:.9rem;cursor:pointer;transition:all .2s}
+button:hover{background:#00d4ff;color:#0a0a0f}
+.brand{margin-top:28px;font-family:'JetBrains Mono',monospace;font-size:.72rem;color:#6b6b7a;letter-spacing:1px}
+.brand b{color:#0a5840;filter:brightness(1.6)}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="code">408</div>
+  <h1>Request timeout</h1>
+  <p>The request took too long. Check your connection and try again.</p>
+  <button type="button" onclick="history.length>1?history.back():location.reload()">Go back</button>
+  <div class="brand">SecuBox<b>·</b> secured edge</div>
+</div>
+</body>
+</html>

--- a/packages/secubox-haproxy/errors/500.http
+++ b/packages/secubox-haproxy/errors/500.http
@@ -1,0 +1,35 @@
+HTTP/1.1 500 Internal Server Error
+Cache-Control: no-store
+Connection: close
+Content-Type: text/html; charset=utf-8
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Internal error — SecuBox</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{min-height:100vh;background:#0a0a0f;color:#e8e6d9;font-family:system-ui,-apple-system,'Segoe UI',sans-serif;display:flex;align-items:center;justify-content:center;padding:24px;
+  background-image:radial-gradient(ellipse at 30% 20%,rgba(230,57,70,.06)0%,transparent 50%),radial-gradient(ellipse at 70% 80%,rgba(110,64,201,.05)0%,transparent 50%)}
+.card{max-width:520px;width:100%;text-align:center;background:rgba(17,23,32,.85);border:1px solid rgba(255,255,255,.08);border-radius:16px;padding:40px 32px;box-shadow:0 8px 40px rgba(0,0,0,.5)}
+.code{font-family:'JetBrains Mono',monospace;font-size:5.5rem;font-weight:700;line-height:1;color:#e63946;text-shadow:0 0 30px rgba(230,57,70,.4)}
+h1{font-size:1.5rem;font-weight:600;margin:12px 0 8px}
+p{color:#8a9aa8;font-size:.95rem;line-height:1.6;margin:6px 0}
+button{margin-top:22px;background:transparent;color:#00d4ff;border:1px solid #00d4ff;border-radius:8px;padding:10px 20px;font:inherit;font-size:.9rem;cursor:pointer;transition:all .2s}
+button:hover{background:#00d4ff;color:#0a0a0f}
+.brand{margin-top:28px;font-family:'JetBrains Mono',monospace;font-size:.72rem;color:#6b6b7a;letter-spacing:1px}
+.brand b{color:#0a5840;filter:brightness(1.6)}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="code">500</div>
+  <h1>Internal error</h1>
+  <p>Something went wrong on our side. The incident is logged. Try again shortly.</p>
+  <button type="button" onclick="history.length>1?history.back():location.reload()">Go back</button>
+  <div class="brand">SecuBox<b>·</b> secured edge</div>
+</div>
+</body>
+</html>

--- a/packages/secubox-haproxy/errors/502.http
+++ b/packages/secubox-haproxy/errors/502.http
@@ -1,0 +1,70 @@
+HTTP/1.1 502 Bad Gateway
+Cache-Control: no-store, no-cache, must-revalidate
+Connection: close
+Content-Type: text/html; charset=utf-8
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Service recovering — SecuBox</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{min-height:100vh;background:#0a0a0f;color:#e8e6d9;font-family:system-ui,-apple-system,'Segoe UI',sans-serif;display:flex;align-items:center;justify-content:center;padding:24px;
+  background-image:radial-gradient(ellipse at 30% 20%,rgba(201,168,76,.06)0%,transparent 50%),radial-gradient(ellipse at 70% 80%,rgba(0,212,255,.05)0%,transparent 50%)}
+.card{max-width:520px;width:100%;text-align:center;background:rgba(17,23,32,.85);border:1px solid rgba(255,255,255,.08);border-radius:16px;padding:40px 32px;box-shadow:0 8px 40px rgba(0,0,0,.5)}
+.code{font-family:'JetBrains Mono',monospace;font-size:5.5rem;font-weight:700;line-height:1;color:#c9a84c;text-shadow:0 0 30px rgba(201,168,76,.4)}
+h1{font-size:1.5rem;font-weight:600;margin:12px 0 8px;color:#e8e6d9}
+p{color:#8a9aa8;font-size:.95rem;line-height:1.6;margin:6px 0}
+.dot{display:inline-block;width:10px;height:10px;border-radius:50%;background:#c9a84c;margin-right:8px;animation:pulse 1.2s ease-in-out infinite;vertical-align:middle}
+@keyframes pulse{0%,100%{opacity:.3;transform:scale(.85)}50%{opacity:1;transform:scale(1.15)}}
+.status{margin:24px 0 8px;font-family:'JetBrains Mono',monospace;font-size:.9rem;color:#00d4ff;min-height:1.4em}
+.status.ok{color:#00ff41}
+.bar{height:3px;background:rgba(255,255,255,.08);border-radius:3px;overflow:hidden;margin:16px 0}
+.bar>i{display:block;height:100%;width:30%;background:linear-gradient(90deg,transparent,#00d4ff,transparent);animation:scan 1.6s linear infinite}
+@keyframes scan{0%{transform:translateX(-120%)}100%{transform:translateX(400%)}}
+button{margin-top:18px;background:transparent;color:#c9a84c;border:1px solid #c9a84c;border-radius:8px;padding:10px 20px;font:inherit;font-size:.9rem;cursor:pointer;transition:all .2s}
+button:hover{background:#c9a84c;color:#0a0a0f}
+.brand{margin-top:28px;font-family:'JetBrains Mono',monospace;font-size:.72rem;color:#6b6b7a;letter-spacing:1px}
+.brand b{color:#0a5840;filter:brightness(1.6)}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="code" id="code">502</div>
+  <h1><span class="dot"></span>Service recovering</h1>
+  <p>This service is temporarily unavailable. It's being inspected by the SecuBox WAF and is recovering.</p>
+  <p>This page checks automatically and will reload the moment it's back — no need to refresh.</p>
+  <div class="bar"><i></i></div>
+  <div class="status" id="status">⟳ checking…</div>
+  <button id="retry" type="button">Retry now</button>
+  <div class="brand">SecuBox<b>·</b> secured edge — self-healing</div>
+</div>
+<script>
+(function(){
+  "use strict";
+  var s=document.getElementById('status'),attempt=0,delay=4000,timer=null;
+  function recovered(st){return st>0&&st<500;}
+  function check(){
+    attempt++;
+    s.className='status';s.textContent='⟳ checking… (attempt '+attempt+')';
+    fetch(location.href,{method:'GET',cache:'no-store',redirect:'manual',headers:{'x-secubox-healthcheck':'1'}})
+      .then(function(r){
+        if(recovered(r.type==='opaqueredirect'?200:r.status)){
+          s.className='status ok';s.textContent='✓ back online — reloading…';
+          clearTimeout(timer);setTimeout(function(){location.reload();},600);
+        }else{schedule();}
+      })
+      .catch(function(){schedule();});
+  }
+  function schedule(){
+    delay=Math.min(delay+1000,15000);
+    timer=setTimeout(check,delay);
+  }
+  document.getElementById('retry').addEventListener('click',function(){clearTimeout(timer);delay=4000;check();});
+  timer=setTimeout(check,2500);
+})();
+</script>
+</body>
+</html>

--- a/packages/secubox-haproxy/errors/503.http
+++ b/packages/secubox-haproxy/errors/503.http
@@ -1,0 +1,70 @@
+HTTP/1.1 503 Service Unavailable
+Cache-Control: no-store, no-cache, must-revalidate
+Connection: close
+Content-Type: text/html; charset=utf-8
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Service recovering — SecuBox</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{min-height:100vh;background:#0a0a0f;color:#e8e6d9;font-family:system-ui,-apple-system,'Segoe UI',sans-serif;display:flex;align-items:center;justify-content:center;padding:24px;
+  background-image:radial-gradient(ellipse at 30% 20%,rgba(201,168,76,.06)0%,transparent 50%),radial-gradient(ellipse at 70% 80%,rgba(0,212,255,.05)0%,transparent 50%)}
+.card{max-width:520px;width:100%;text-align:center;background:rgba(17,23,32,.85);border:1px solid rgba(255,255,255,.08);border-radius:16px;padding:40px 32px;box-shadow:0 8px 40px rgba(0,0,0,.5)}
+.code{font-family:'JetBrains Mono',monospace;font-size:5.5rem;font-weight:700;line-height:1;color:#c9a84c;text-shadow:0 0 30px rgba(201,168,76,.4)}
+h1{font-size:1.5rem;font-weight:600;margin:12px 0 8px;color:#e8e6d9}
+p{color:#8a9aa8;font-size:.95rem;line-height:1.6;margin:6px 0}
+.dot{display:inline-block;width:10px;height:10px;border-radius:50%;background:#c9a84c;margin-right:8px;animation:pulse 1.2s ease-in-out infinite;vertical-align:middle}
+@keyframes pulse{0%,100%{opacity:.3;transform:scale(.85)}50%{opacity:1;transform:scale(1.15)}}
+.status{margin:24px 0 8px;font-family:'JetBrains Mono',monospace;font-size:.9rem;color:#00d4ff;min-height:1.4em}
+.status.ok{color:#00ff41}
+.bar{height:3px;background:rgba(255,255,255,.08);border-radius:3px;overflow:hidden;margin:16px 0}
+.bar>i{display:block;height:100%;width:30%;background:linear-gradient(90deg,transparent,#00d4ff,transparent);animation:scan 1.6s linear infinite}
+@keyframes scan{0%{transform:translateX(-120%)}100%{transform:translateX(400%)}}
+button{margin-top:18px;background:transparent;color:#c9a84c;border:1px solid #c9a84c;border-radius:8px;padding:10px 20px;font:inherit;font-size:.9rem;cursor:pointer;transition:all .2s}
+button:hover{background:#c9a84c;color:#0a0a0f}
+.brand{margin-top:28px;font-family:'JetBrains Mono',monospace;font-size:.72rem;color:#6b6b7a;letter-spacing:1px}
+.brand b{color:#0a5840;filter:brightness(1.6)}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="code" id="code">503</div>
+  <h1><span class="dot"></span>Service recovering</h1>
+  <p>This service is temporarily unavailable. It's being inspected by the SecuBox WAF and is recovering.</p>
+  <p>This page checks automatically and will reload the moment it's back — no need to refresh.</p>
+  <div class="bar"><i></i></div>
+  <div class="status" id="status">⟳ checking…</div>
+  <button id="retry" type="button">Retry now</button>
+  <div class="brand">SecuBox<b>·</b> secured edge — self-healing</div>
+</div>
+<script>
+(function(){
+  "use strict";
+  var s=document.getElementById('status'),attempt=0,delay=4000,timer=null;
+  function recovered(st){return st>0&&st<500;}
+  function check(){
+    attempt++;
+    s.className='status';s.textContent='⟳ checking… (attempt '+attempt+')';
+    fetch(location.href,{method:'GET',cache:'no-store',redirect:'manual',headers:{'x-secubox-healthcheck':'1'}})
+      .then(function(r){
+        if(recovered(r.type==='opaqueredirect'?200:r.status)){
+          s.className='status ok';s.textContent='✓ back online — reloading…';
+          clearTimeout(timer);setTimeout(function(){location.reload();},600);
+        }else{schedule();}
+      })
+      .catch(function(){schedule();});
+  }
+  function schedule(){
+    delay=Math.min(delay+1000,15000);
+    timer=setTimeout(check,delay);
+  }
+  document.getElementById('retry').addEventListener('click',function(){clearTimeout(timer);delay=4000;check();});
+  timer=setTimeout(check,2500);
+})();
+</script>
+</body>
+</html>

--- a/packages/secubox-haproxy/errors/504.http
+++ b/packages/secubox-haproxy/errors/504.http
@@ -1,0 +1,70 @@
+HTTP/1.1 504 Gateway Timeout
+Cache-Control: no-store, no-cache, must-revalidate
+Connection: close
+Content-Type: text/html; charset=utf-8
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Service recovering — SecuBox</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{min-height:100vh;background:#0a0a0f;color:#e8e6d9;font-family:system-ui,-apple-system,'Segoe UI',sans-serif;display:flex;align-items:center;justify-content:center;padding:24px;
+  background-image:radial-gradient(ellipse at 30% 20%,rgba(201,168,76,.06)0%,transparent 50%),radial-gradient(ellipse at 70% 80%,rgba(0,212,255,.05)0%,transparent 50%)}
+.card{max-width:520px;width:100%;text-align:center;background:rgba(17,23,32,.85);border:1px solid rgba(255,255,255,.08);border-radius:16px;padding:40px 32px;box-shadow:0 8px 40px rgba(0,0,0,.5)}
+.code{font-family:'JetBrains Mono',monospace;font-size:5.5rem;font-weight:700;line-height:1;color:#c9a84c;text-shadow:0 0 30px rgba(201,168,76,.4)}
+h1{font-size:1.5rem;font-weight:600;margin:12px 0 8px;color:#e8e6d9}
+p{color:#8a9aa8;font-size:.95rem;line-height:1.6;margin:6px 0}
+.dot{display:inline-block;width:10px;height:10px;border-radius:50%;background:#c9a84c;margin-right:8px;animation:pulse 1.2s ease-in-out infinite;vertical-align:middle}
+@keyframes pulse{0%,100%{opacity:.3;transform:scale(.85)}50%{opacity:1;transform:scale(1.15)}}
+.status{margin:24px 0 8px;font-family:'JetBrains Mono',monospace;font-size:.9rem;color:#00d4ff;min-height:1.4em}
+.status.ok{color:#00ff41}
+.bar{height:3px;background:rgba(255,255,255,.08);border-radius:3px;overflow:hidden;margin:16px 0}
+.bar>i{display:block;height:100%;width:30%;background:linear-gradient(90deg,transparent,#00d4ff,transparent);animation:scan 1.6s linear infinite}
+@keyframes scan{0%{transform:translateX(-120%)}100%{transform:translateX(400%)}}
+button{margin-top:18px;background:transparent;color:#c9a84c;border:1px solid #c9a84c;border-radius:8px;padding:10px 20px;font:inherit;font-size:.9rem;cursor:pointer;transition:all .2s}
+button:hover{background:#c9a84c;color:#0a0a0f}
+.brand{margin-top:28px;font-family:'JetBrains Mono',monospace;font-size:.72rem;color:#6b6b7a;letter-spacing:1px}
+.brand b{color:#0a5840;filter:brightness(1.6)}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="code" id="code">504</div>
+  <h1><span class="dot"></span>Service is slow — recovering</h1>
+  <p>This service took too long to respond through the SecuBox WAF and is recovering.</p>
+  <p>This page checks automatically and will reload the moment it's back — no need to refresh.</p>
+  <div class="bar"><i></i></div>
+  <div class="status" id="status">⟳ checking…</div>
+  <button id="retry" type="button">Retry now</button>
+  <div class="brand">SecuBox<b>·</b> secured edge — self-healing</div>
+</div>
+<script>
+(function(){
+  "use strict";
+  var s=document.getElementById('status'),attempt=0,delay=4000,timer=null;
+  function recovered(st){return st>0&&st<500;}
+  function check(){
+    attempt++;
+    s.className='status';s.textContent='⟳ checking… (attempt '+attempt+')';
+    fetch(location.href,{method:'GET',cache:'no-store',redirect:'manual',headers:{'x-secubox-healthcheck':'1'}})
+      .then(function(r){
+        if(recovered(r.type==='opaqueredirect'?200:r.status)){
+          s.className='status ok';s.textContent='✓ back online — reloading…';
+          clearTimeout(timer);setTimeout(function(){location.reload();},600);
+        }else{schedule();}
+      })
+      .catch(function(){schedule();});
+  }
+  function schedule(){
+    delay=Math.min(delay+1000,15000);
+    timer=setTimeout(check,delay);
+  }
+  document.getElementById('retry').addEventListener('click',function(){clearTimeout(timer);delay=4000;check();});
+  timer=setTimeout(check,2500);
+})();
+</script>
+</body>
+</html>

--- a/packages/secubox-haproxy/sbin/haproxyctl
+++ b/packages/secubox-haproxy/sbin/haproxyctl
@@ -671,16 +671,18 @@ EOF
             local backend=$(echo "$section" | grep -E '^backend\s*=' | cut -d'"' -f2)
             local enabled=$(echo "$section" | grep -E '^enabled\s*=' | grep -q 'false' && echo "0" || echo "1")
             # WebUI strict-regex already covers admin.${SECUBOX_HOSTNAME}.${SECUBOX_DOMAIN_SUFFIX}
-            [ -n "$_admin_skip_domain" ] && [ "$domain" = "$_admin_skip_domain" ] && continue
+            if [ -n "$_admin_skip_domain" ] && [ "$domain" = "$_admin_skip_domain" ]; then continue; fi
 
-            [ "$enabled" = "1" ] && [ -n "$domain" ] && {
+            # NB: use if/then/fi, not `[ ] && [ ] && { }` — under `set -e` a
+            # short-circuited &&-chain (e.g. a non-SSL vhost) aborts generation.
+            if [ "$enabled" = "1" ] && [ -n "$domain" ]; then
                 echo "    acl host_$name hdr(host) -i $domain"
                 if [ "$waf_enabled" = "1" ]; then
                     echo "    use_backend mitmproxy_inspector if host_$name"
                 else
                     echo "    use_backend $backend if host_$name"
                 fi
-            }
+            fi
         done >> "$out"
     fi
 
@@ -719,16 +721,17 @@ EOF
             local ssl=$(echo "$section" | grep -E '^ssl\s*=' | grep -q 'true' && echo "1" || echo "0")
             local enabled=$(echo "$section" | grep -E '^enabled\s*=' | grep -q 'false' && echo "0" || echo "1")
             # WebUI strict-regex already covers admin.${SECUBOX_HOSTNAME}.${SECUBOX_DOMAIN_SUFFIX}
-            [ -n "$_admin_skip_domain" ] && [ "$domain" = "$_admin_skip_domain" ] && continue
+            if [ -n "$_admin_skip_domain" ] && [ "$domain" = "$_admin_skip_domain" ]; then continue; fi
 
-            [ "$enabled" = "1" ] && [ "$ssl" = "1" ] && [ -n "$domain" ] && {
+            # if/then/fi (not `&& { }`) — set -e safe for non-SSL vhosts.
+            if [ "$enabled" = "1" ] && [ "$ssl" = "1" ] && [ -n "$domain" ]; then
                 echo "    acl host_$name hdr(host) -i $domain"
                 if [ "$waf_enabled" = "1" ]; then
                     echo "    use_backend mitmproxy_inspector if host_$name"
                 else
                     echo "    use_backend $backend if host_$name"
                 fi
-            }
+            fi
         done >> "$out"
     fi
 
@@ -738,7 +741,8 @@ EOF
 EOF
 
     # WAF inspector backend (mitmproxy LXC container)
-    [ "$waf_enabled" = "1" ] && cat >> "$out" << EOF
+    # if/then/fi (not `&& cat`) — under set -e a false test here aborts generation.
+    if [ "$waf_enabled" = "1" ]; then cat >> "$out" << EOF
 # WAF Inspector Backend (mitmproxy LXC at $waf_ip:$waf_port)
 backend mitmproxy_inspector
     mode http
@@ -748,6 +752,7 @@ backend mitmproxy_inspector
     server waf ${waf_ip}:${waf_port} check
 
 EOF
+    fi
 
     # WebUI direct backend (issue #44 — for the strict-regex ACL above)
     # Only emit if SECUBOX_HOSTNAME is set (i.e., the strict ACL was injected).
@@ -763,6 +768,9 @@ EOF
     if [ -f "$CONF_PATH" ]; then
         grep '^\[backends\.' "$CONF_PATH" | while read -r line; do
             local name=$(echo "$line" | sed 's/\[backends\.//;s/\]//')
+            # Skip backends already emitted (mitmproxy_inspector/webui_direct are
+            # auto-generated above) to avoid duplicate-backend fatal errors.
+            if grep -q "^backend $name\$" "$out"; then continue; fi
             local section=$(sed -n "/^\[backends\.$name\]/,/^\[/p" "$CONF_PATH" | head -n -1)
             local mode=$(echo "$section" | grep -E '^mode\s*=' | cut -d'"' -f2 || echo "http")
             local balance=$(echo "$section" | grep -E '^balance\s*=' | cut -d'"' -f2 || echo "roundrobin")
@@ -775,11 +783,11 @@ backend $name
 EOF
             local i=0
             echo "$servers" | while read -r srv; do
-                [ -n "$srv" ] && {
+                if [ -n "$srv" ]; then
                     srv=$(echo "$srv" | tr -d ' ')
                     echo "    server srv$i $srv check" >> "$out"
                     i=$((i + 1))
-                }
+                fi
             done
             echo "" >> "$out"
         done
@@ -834,6 +842,22 @@ EOF
     # to the live cfg and only validated at the end, leaving the file in a
     # broken state on failure (recurring "broken-by-vhost-add" backups).
     if haproxy -c -f "$out" 2>/dev/null; then
+        # Drift guard (#626): refuse to overwrite a live config that has MORE
+        # vhosts/backends than we just generated — that means the live cfg holds
+        # entries absent from our inputs (haproxy.toml / cfg.d). Without this,
+        # a successful regen would silently drop hand-maintained vhosts (kbin,
+        # gitea, …). `local x=$(...)` masks grep's exit so set -e stays happy.
+        if [ -f "$CONFIG_DIR/haproxy.cfg" ]; then
+            local _nh=$(grep -c '^[[:space:]]*acl host_' "$out")
+            local _oh=$(grep -c '^[[:space:]]*acl host_' "$CONFIG_DIR/haproxy.cfg")
+            local _nb=$(grep -c '^backend ' "$out")
+            local _ob=$(grep -c '^backend ' "$CONFIG_DIR/haproxy.cfg")
+            if [ "${_nh:-0}" -lt "${_oh:-0}" ] || [ "${_nb:-0}" -lt "${_ob:-0}" ]; then
+                error "Drift guard: generated cfg has fewer vhosts/backends than live (acl ${_nh}<${_oh} or backend ${_nb}<${_ob}) — refusing to clobber. Migrate the missing entries into haproxy.toml/cfg.d first."
+                rm -f "$out"
+                return 1
+            fi
+        fi
         install -m 0644 -o root -g root "$out" "$CONFIG_DIR/haproxy.cfg"
         rm -f "$out"
         log "Configuration generated, validated and installed: $CONFIG_DIR/haproxy.cfg"

--- a/packages/secubox-haproxy/sbin/haproxyctl
+++ b/packages/secubox-haproxy/sbin/haproxyctl
@@ -620,9 +620,19 @@ defaults
     timeout connect 5s
     timeout client 30s
     timeout server 30s
+    retries 3
+    option redispatch
     option httplog
     option dontlognull
     option forwardfor
+    # Smart self-healing error pages (#626) — shipped by secubox-haproxy.
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
 
 frontend stats
     bind *:${stats_port}

--- a/packages/secubox-haproxy/sbin/haproxyctl
+++ b/packages/secubox-haproxy/sbin/haproxyctl
@@ -626,13 +626,13 @@ defaults
     option dontlognull
     option forwardfor
     # Smart self-healing error pages (#626) — shipped by secubox-haproxy.
-    errorfile 400 /etc/haproxy/errors/400.http
-    errorfile 403 /etc/haproxy/errors/403.http
-    errorfile 408 /etc/haproxy/errors/408.http
-    errorfile 500 /etc/haproxy/errors/500.http
-    errorfile 502 /etc/haproxy/errors/502.http
-    errorfile 503 /etc/haproxy/errors/503.http
-    errorfile 504 /etc/haproxy/errors/504.http
+    errorfile 400 /etc/haproxy/secubox-errors/400.http
+    errorfile 403 /etc/haproxy/secubox-errors/403.http
+    errorfile 408 /etc/haproxy/secubox-errors/408.http
+    errorfile 500 /etc/haproxy/secubox-errors/500.http
+    errorfile 502 /etc/haproxy/secubox-errors/502.http
+    errorfile 503 /etc/haproxy/secubox-errors/503.http
+    errorfile 504 /etc/haproxy/secubox-errors/504.http
 
 frontend stats
     bind *:${stats_port}


### PR DESCRIPTION
Smart self-healing 502/503/504 (poll + auto-reload on recovery) + branded static 400/403/408/500; haproxyctl emits errorfile + retries/redispatch. NOTE: deploy via package currently blocked by a pre-existing broken `haproxyctl generate` (postinst regen fails) — pages + errorfile wiring applied live in the meantime. Generator fix tracked separately.