### PR TITLE
Make live ops fixes permanent: core traversal fix + dirs-guard timer + toolbox stream_inject default (closes #630)

### DIFF
--- a/packages/secubox-core/debian/changelog
+++ b/packages/secubox-core/debian/changelog
@@ -1,3 +1,14 @@
+secubox-core (1.1.7-1~bookworm1) bookworm; urgency=medium
+
+  * fix(postinst): /var/lib/secubox + /usr/share/secubox/www were set 0750,
+    breaking traversal for non-secubox daemons (kbin/toolbox 500) — now 0755
+    (same reasoning the postinst already applied to /etc/secubox).
+  * feat: secubox-dirs-guard timer — re-asserts the shared /…/secubox parents
+    to 0755 every minute, self-healing the recurring 0750 clobber from module
+    postinsts (closes #630).
+
+ -- Gerald Kerma <devel@cybermind.fr>  Tue, 17 Jun 2026 11:00:00 +0200
+
 secubox-core (1.1.6-1~bookworm1) bookworm; urgency=medium
 
   * postinst: relax /etc/secubox to 0755 (was 0750). Non-secubox daemons

--- a/packages/secubox-core/debian/postinst
+++ b/packages/secubox-core/debian/postinst
@@ -18,8 +18,12 @@ case "$1" in
     # secubox:secubox), so opening the parent dir does NOT leak secrets.
     install -d -o secubox -g secubox -m 755 /etc/secubox
     install -d -m 1777 /run/secubox  # World-writable for all service sockets
-    install -d -o secubox -g secubox -m 750 /var/lib/secubox
-    install -d -o secubox -g secubox -m 750 /usr/share/secubox/www
+    # Same reasoning as /etc/secubox above: these SHARED parents must be 0755 so
+    # every secubox-* daemon (running as its own user, not in group secubox) can
+    # traverse to its own subtree. 0750 here broke kbin/toolbox repeatedly
+    # (#626/#630). Per-module leaves + secrets stay restricted.
+    install -d -o secubox -g secubox -m 755 /var/lib/secubox
+    install -d -o secubox -g secubox -m 755 /usr/share/secubox/www
 
     # ── tmpfiles.d for persistent /run/secubox ──
     systemd-tmpfiles --create 2>/dev/null || true
@@ -69,6 +73,11 @@ case "$1" in
 
     # Enable runtime directory service (ensures /run/secubox exists before other services)
     systemctl enable --now secubox-runtime.service 2>/dev/null || true
+
+    # Shared-dir traversal guard (#630): self-heals the recurring 0750 clobber
+    # (from this and other module postinsts) that breaks kbin/toolbox.
+    systemctl enable --now secubox-dirs-guard.timer 2>/dev/null || true
+    systemctl start secubox-dirs-guard.service 2>/dev/null || true
 
     # ── Python dependencies (ensure compatible versions) ──
     # Debian bookworm ships old pydantic v1 and fastapi, upgrade via pip

--- a/packages/secubox-core/debian/rules
+++ b/packages/secubox-core/debian/rules
@@ -58,6 +58,18 @@ override_dh_auto_install:
 	install -m 644 tmpfiles.d/secubox.conf \
 	               debian/secubox-core/usr/lib/tmpfiles.d/
 
+	# Shared-dir traversal guard (#630): keep /var/{lib,log,cache} + /etc +
+	# /usr/share /secubox parents at 0755 so every secubox-* user can traverse.
+	# Counters the recurring `install -d -m 0750 …/secubox` clobber in module
+	# postinsts that breaks kbin/toolbox.
+	install -d debian/secubox-core/usr/sbin
+	install -m 755 usr/sbin/secubox-dirs-guard.sh \
+	               debian/secubox-core/usr/sbin/secubox-dirs-guard.sh
+	install -m 644 systemd/secubox-dirs-guard.service \
+	               debian/secubox-core/usr/lib/systemd/system/
+	install -m 644 systemd/secubox-dirs-guard.timer \
+	               debian/secubox-core/usr/lib/systemd/system/
+
 	# LED scripts and services
 	install -d debian/secubox-core/usr/sbin
 	install -m 755 usr/sbin/secubox-led-heartbeat \

--- a/packages/secubox-core/systemd/secubox-dirs-guard.service
+++ b/packages/secubox-core/systemd/secubox-dirs-guard.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=SecuBox shared-dir traversal guard (keep /…/secubox parents 0755)
+Documentation=https://github.com/CyberMind-FR/secubox-deb
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/secubox-dirs-guard.sh
+Nice=10

--- a/packages/secubox-core/systemd/secubox-dirs-guard.timer
+++ b/packages/secubox-core/systemd/secubox-dirs-guard.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Re-assert SecuBox shared-dir perms every minute
+[Timer]
+OnCalendar=*:0/1
+AccuracySec=10s
+Persistent=true
+[Install]
+WantedBy=timers.target

--- a/packages/secubox-core/usr/sbin/secubox-dirs-guard.sh
+++ b/packages/secubox-core/usr/sbin/secubox-dirs-guard.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# SecuBox-Deb :: shared-dir traversal guard
+# Keep the shared SecuBox parent dirs traversable (0755) so EVERY secubox-* user
+# can reach its own subtree. Counters the recurring `install -d -m 0750 …/secubox`
+# clobber in various module postinsts that breaks kbin/toolbox (#626/#630).
+# chmod-only (owner-agnostic); runs every minute via secubox-dirs-guard.timer.
+for d in /var/lib/secubox /var/log/secubox /var/cache/secubox /etc/secubox /usr/share/secubox; do
+    [ -d "$d" ] || continue
+    [ "$(stat -c %a "$d" 2>/dev/null)" = "755" ] || chmod 0755 "$d" 2>/dev/null || true
+done
+exit 0

--- a/packages/secubox-toolbox/debian/changelog
+++ b/packages/secubox-toolbox/debian/changelog
@@ -1,3 +1,11 @@
+secubox-toolbox (2.6.41-1~bookworm1) bookworm; urgency=medium
+
+  * perf(ttfb): stream_inject now defaults ON (#630) — phase-2 streaming loader
+    inject is the default (workers ~71MB/8% vs ~100MB/28%). Operators can still
+    toggle it off via /etc/secubox/toolbox/filters.json.
+
+ -- Gerald Kerma <devel@cybermind.fr>  Tue, 17 Jun 2026 11:00:00 +0200
+
 secubox-toolbox (2.6.40-1~bookworm1) bookworm; urgency=medium
 
   * fix(postinst): stop clobbering shared parent dir modes (#620). The

--- a/packages/secubox-toolbox/secubox_toolbox/filters.py
+++ b/packages/secubox-toolbox/secubox_toolbox/filters.py
@@ -22,7 +22,7 @@ DEFAULTS: Dict = {
     "ad_ghost": True,               # R3+/R4 silent ad/banner/widget ghosting
     "ad_ghost_block": True,         # 204 known ad/tracker hosts (save bandwidth)
     "media_cache": False,           # #577 shared media proxy-cache (opt-in)
-    "stream_inject": False,         # #620 stream loader inject (TTFB) — opt-in, phase 2
+    "stream_inject": True,          # #620/#630 stream loader inject (TTFB) — default on
     "autolearn": True,              # #589 also block auto-learned bad hosts
     "ad_ghost_categories": {        # cosmetic ghost groups
         "ads": True,


### PR DESCRIPTION
Packages the 2026-06-17 live fixes into source: (1) secubox-core postinst no longer sets /var/lib/secubox + /usr/share/secubox/www to 0750 (root cause of recurring kbin/toolbox 500s) — now 0755; (2) ships secubox-dirs-guard.timer (re-asserts shared /…/secubox parents to 0755 every minute, self-healing any stray 0750 clobber); (3) toolbox stream_inject defaults ON (the TTFB/resource win). Verified live: re-broke /var/lib/secubox to 750, core install restored 755 + guard active; kbin 200.