### PR TITLE
fix(toolbox #658): ad-learn never self-blocks own infra + exact-host promotion

### DIFF
--- a/packages/secubox-toolbox/debian/changelog
+++ b/packages/secubox-toolbox/debian/changelog
@@ -1,3 +1,18 @@
+secubox-toolbox (2.6.57-1~bookworm1) bookworm; urgency=medium
+
+  * fix(#658): ad-learn hardening — never self-block own infrastructure.
+    - ad_ghost `_allowed` now ALWAYS allows the appliance's own domains
+      (`_SELF_REGS`, default {secubox.in}, env `SECUBOX_SELF_DOMAINS`) — hard-coded
+      so it survives a reflash with no allowlist file; this also stops own-infra
+      from ever being captured as a candidate (early-return).
+    - autolearn `_ad_feed` excludes own-infra AND promotes the EXACT candidate
+      host instead of its registrable — so a tracker subdomain
+      (analytics.tiktok.com) no longer blocks the parent site (tiktok.com).
+    Root cause: the aggressive learner self-promoted secubox.in → 204'd all
+    *.secubox.in for R3; live-mitigated via allowlist, now fixed at source.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 18 Jun 2026 19:00:00 +0200
+
 secubox-toolbox (2.6.56-1~bookworm1) bookworm; urgency=medium
 
   * feat(#656): Ad Intelligence — learn · act · measure.

--- a/packages/secubox-toolbox/mitmproxy_addons/ad_ghost.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/ad_ghost.py
@@ -50,6 +50,12 @@ _EST_BYTES_PER_REQ = 45000  # honest estimate per blocked ad/tracker request
 # #656 — operator allowlist (host or registrable, one per line, # comments).
 # Allowlist ALWAYS wins: an allowlisted host is never 204'd nor recorded.
 _ALLOW_PATH = "/var/lib/secubox/toolbox/ad-allowlist.txt"
+# #658 — the appliance's OWN domains. NEVER blocked/learned (the aggressive
+# learner once self-promoted secubox.in → 204'd all *.secubox.in for R3).
+# Hard-coded (env-overridable) so it survives a reflash with no allowlist file.
+_SELF_REGS = {d.strip().lower() for d in
+              os.environ.get("SECUBOX_SELF_DOMAINS", "secubox.in").split(",")
+              if d.strip()}
 # Path heuristics for 3rd-party ad/track candidate capture (learning only).
 _AD_PATH = re.compile(r"/ads?/|/adserver|/pagead|/gampad|/doubleclick|/beacon|"
                       r"/pixel|/collect|/track(ing)?|/telemetry|/metric", re.I)
@@ -109,6 +115,10 @@ def _allowed(host: str) -> bool:
         pass
     h = (host or "").lower()
     reg = _registrable(h) or h
+    # #658 — own infra always allowed (never block/capture our own domains),
+    # independent of the allowlist file (reflash-safe).
+    if reg in _SELF_REGS or any(h == d or h.endswith("." + d) for d in _SELF_REGS):
+        return True
     return h in _allow or reg in _allow
 
 

--- a/packages/secubox-toolbox/sbin/secubox-toolbox-autolearn
+++ b/packages/secubox-toolbox/sbin/secubox-toolbox-autolearn
@@ -176,6 +176,11 @@ def _ad_feed() -> int:
         sys.stderr.write(f"autolearn: ad query failed: {e}\n")
         return -1
     allow = _load_ad_allowlist()
+    # #658 — never promote the appliance's own domains (the learner once
+    # self-promoted secubox.in). Hard default + env-overridable.
+    self_doms = {d.strip().lower() for d in
+                 os.environ.get("SECUBOX_SELF_DOMAINS", "secubox.in").split(",")
+                 if d.strip()}
     promoted: set = set()
     for r in rows:
         h = (r[0] or "").lower().strip(".")
@@ -184,7 +189,12 @@ def _ad_feed() -> int:
         reg = registrable(h) or h
         if h in allow or reg in allow:
             continue
-        promoted.add(reg)
+        if reg in self_doms or any(h == d or h.endswith("." + d) for d in self_doms):
+            continue
+        # #658 — promote the EXACT host, NOT the registrable: blocking a tracker
+        # subdomain (analytics.tiktok.com) must never block the parent site
+        # (tiktok.com). Dedicated ad hosts are already registrable-level.
+        promoted.add(h)
     if not promoted:
         return 0
     # MERGE with existing learned-trackers.txt (union, dedup, cap).

--- a/packages/secubox-toolbox/tests/test_ad_learn_hardening.py
+++ b/packages/secubox-toolbox/tests/test_ad_learn_hardening.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+"""#658 — ad-learn must never self-block own infra; promote exact host not registrable."""
+import sys
+import pathlib
+import importlib
+import sqlite3
+import importlib.util
+
+ADDON_DIR = pathlib.Path(__file__).resolve().parents[1] / "mitmproxy_addons"
+sys.path.insert(0, str(ADDON_DIR))
+
+
+def test_allowed_never_blocks_own_infra(monkeypatch, tmp_path):
+    # point the allowlist file at a nonexistent path → only the hard-coded
+    # _SELF_REGS guard can allow secubox.in
+    import ad_ghost
+    importlib.reload(ad_ghost)
+    monkeypatch.setattr(ad_ghost, "_ALLOW_PATH", str(tmp_path / "nope.txt"))
+    assert ad_ghost._allowed("admin.gk2.secubox.in") is True   # own infra
+    assert ad_ghost._allowed("kbin.gk2.secubox.in") is True
+    assert ad_ghost._allowed("secubox.in") is True
+    assert ad_ghost._allowed("ads.doubleclick.net") is False   # real ad host still blockable
+
+
+def _load_autolearn():
+    p = pathlib.Path(__file__).resolve().parents[1] / "sbin" / "secubox-toolbox-autolearn"
+    spec = importlib.util.spec_from_loader("autolearn_h", loader=None)
+    mod = importlib.util.module_from_spec(spec)
+    exec(compile(p.read_text(), str(p), "exec"), mod.__dict__)
+    return mod
+
+
+def test_ad_feed_exact_host_and_excludes_self(tmp_path, monkeypatch):
+    db = tmp_path / "t.db"
+    con = sqlite3.connect(db)
+    con.executescript(
+        "CREATE TABLE ad_candidates(host TEXT, site TEXT, hits INT, last_seen REAL, PRIMARY KEY(host,site));"
+        # analytics.tiktok.com seen on 2 sites → promote EXACT, not tiktok.com
+        "INSERT INTO ad_candidates VALUES('analytics.tiktok.com','a.com',1,0);"
+        "INSERT INTO ad_candidates VALUES('analytics.tiktok.com','b.com',1,0);"
+        # our own admin host seen on 2 sites → must NOT promote
+        "INSERT INTO ad_candidates VALUES('admin.gk2.secubox.in','a.com',1,0);"
+        "INSERT INTO ad_candidates VALUES('admin.gk2.secubox.in','b.com',1,0);")
+    con.commit(); con.close()
+    out = tmp_path / "learned.txt"
+    monkeypatch.setenv("SECUBOX_AUTOLEARN_DB", str(db))
+    monkeypatch.setenv("SECUBOX_AUTOLEARN_OUT", str(out))
+    monkeypatch.setenv("SECUBOX_AD_ALLOWLIST", str(tmp_path / "allow.txt"))
+    monkeypatch.setenv("SECUBOX_AD_MIN_SITES", "2")
+    monkeypatch.setenv("SECUBOX_SELF_DOMAINS", "secubox.in")
+    al = _load_autolearn()
+    al._ad_feed()
+    learned = set(out.read_text().split())
+    assert "analytics.tiktok.com" in learned          # exact host promoted
+    assert "tiktok.com" not in learned                # NOT the parent site
+    assert "admin.gk2.secubox.in" not in learned      # own infra excluded
+    assert "secubox.in" not in learned


### PR DESCRIPTION
Fixes the #656 self-block of secubox.in. ad_ghost _allowed always allows own-infra (_SELF_REGS, reflash-safe); autolearn _ad_feed excludes own-infra + promotes exact host (no registrable over-fold). 117 tests green, reviewed APPROVED.