### PR TITLE
feat(#662 Phase 3): Go block/splice decision engine + cross-engine parity harness

### DIFF
--- a/packages/secubox-toolbox-ng/cmd/sbxmitm/main.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxmitm/main.go
@@ -129,38 +129,14 @@ func (c *CA) forge(host string) (*tls.Certificate, error) {
 	return tc, nil
 }
 
-// ── Pure handler logic (the ported addon decisions) ─────────────────────────
-
-type Policy struct {
-	AdHosts     []string // ad_ghost: 204 these (suffix match)
-	SpliceHosts []string // tls_splice: passthrough, no MITM (suffix match)
-	Inject      []byte   // banner / ad-CSS marker injected before </head> or </body>
-}
-
-func suffixMatch(host string, pats []string) bool {
-	h := strings.ToLower(strings.TrimSpace(host))
-	for _, p := range pats {
-		p = strings.ToLower(p)
-		if h == p || strings.HasSuffix(h, "."+p) {
-			return true
-		}
-	}
-	return false
-}
-
-// action: "block" (204), "splice" (passthrough), or "mitm".
-func (p Policy) action(host string) string {
-	if suffixMatch(host, p.SpliceHosts) {
-		return "splice"
-	}
-	if suffixMatch(host, p.AdHosts) {
-		return "block"
-	}
-	return "mitm"
-}
+// ── Pure handler logic ───────────────────────────────────────────────────────
+//
+// The decision surface (Decide / action / registrable / splice helpers) lives
+// in policy.go, ported from the Python addons and proven at parity by the
+// cross-engine harness. The body-inject helper is kept here next to the wiring.
 
 // injectMarker inserts p.Inject before </head> (else </body>, else prepends).
-func (p Policy) injectMarker(body []byte) []byte {
+func (p *Policy) injectMarker(body []byte) []byte {
 	if len(p.Inject) == 0 || bytes.Contains(body, p.Inject) {
 		return body
 	}
@@ -201,7 +177,7 @@ func ja4ish(h *tls.ClientHelloInfo) string {
 
 type Proxy struct {
 	ca     *CA
-	pol    Policy
+	pol    *Policy
 	jaSink func(string) // JA4 observations (logged; a sidecar in prod)
 }
 
@@ -290,13 +266,17 @@ func main() {
 	if err != nil {
 		log.Fatalf("CA load: %v", err)
 	}
+	// Load the BLOCK/SPLICE policy from the SAME on-disk config the Python
+	// addons read (defaults + env overrides). Missing files are tolerated
+	// (best-effort, like the addons): the engine then simply MITMs everything.
+	pol, err := LoadPolicy(PolicyOpts{})
+	if err != nil {
+		log.Fatalf("policy load: %v", err)
+	}
+	pol.Inject = []byte("<!-- sbx-ng banner -->")
 	px := &Proxy{
-		ca: ca,
-		pol: Policy{
-			AdHosts:     []string{"doubleclick.net", "googlesyndication.com"},
-			SpliceHosts: []string{"googlevideo.com", "fbcdn.net"},
-			Inject:      []byte("<!-- sbx-ng banner -->"),
-		},
+		ca:     ca,
+		pol:    pol,
 		jaSink: func(s string) { log.Printf("ja4 %s", s) },
 	}
 	srv := &http.Server{Addr: *addr, Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/packages/secubox-toolbox-ng/cmd/sbxmitm/main_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxmitm/main_test.go
@@ -72,24 +72,13 @@ func TestForgeChainsToCA(t *testing.T) {
 	}
 }
 
-func TestActionDecision(t *testing.T) {
-	p := Policy{AdHosts: []string{"doubleclick.net"}, SpliceHosts: []string{"googlevideo.com"}}
-	cases := map[string]string{
-		"ads.doubleclick.net": "block",
-		"doubleclick.net":     "block",
-		"r1.googlevideo.com":  "splice",
-		"news.example.com":    "mitm",
-		"notdoubleclick.net":  "mitm",
-	}
-	for host, want := range cases {
-		if got := p.action(host); got != want {
-			t.Errorf("action(%q)=%q want %q", host, got, want)
-		}
-	}
-}
+// NOTE (#662 Phase 3): the old TestActionDecision drove the removed hardcoded
+// Policy{AdHosts, SpliceHosts} fields. The decision surface now loads from
+// disk (LoadPolicy) and mirrors the Python addons; coverage moved to
+// TestParityDecide / TestPolicyActionVerbs in policy_test.go.
 
 func TestInjectMarker(t *testing.T) {
-	p := Policy{Inject: []byte("<!--SBX-->")}
+	p := &Policy{Inject: []byte("<!--SBX-->")}
 	out := string(p.injectMarker([]byte("<html><head></head><body>hi</body></html>")))
 	if !contains(out, "<!--SBX--></head>") {
 		t.Fatalf("marker not injected before </head>: %s", out)

--- a/packages/secubox-toolbox-ng/cmd/sbxmitm/policy.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxmitm/policy.go
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: LicenseRef-CMSD-1.0
+// Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+//
+// SecuBox-Deb :: toolbox-ng :: policy layer (#662 Phase 3)
+//
+// Ports the toolbox BLOCK (ad_ghost) and SPLICE (tls_splice) decision logic
+// into the Go core, reading the SAME on-disk config files the Python addons
+// use. Python is the source of truth; this mirrors it byte-for-byte on the
+// decision surface, proven by the cross-engine parity harness
+// (testdata/parity-fixtures.json + policy_test.go ↔ tests/test_engine_parity.py).
+//
+// Pure standard library — no external modules, no go.sum.
+package main
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// ── ad_ghost: static ad/tracker host pattern (port of _AD_HOST) ──────────────
+//
+// Python (mitmproxy_addons/ad_ghost.py):
+//
+//	_AD_HOST = re.compile(
+//	    r"(?:^|\.)(?:doubleclick|googlesyndication|googleadservices|"
+//	    r"googletagservices|adservice\.google|amazon-adsystem|adnxs|adsrvr|"
+//	    r"adform|criteo|rubiconproject|taboola|outbrain|smartadserver|moatads|"
+//	    r"scorecardresearch|2mdn|adroll|pubmatic|openx|casalemedia|"
+//	    r"yieldlove|sharethrough|teads|3lift|adsystem|adserver)",
+//	    re.IGNORECASE)
+//
+// Every construct here — non-capturing groups, `^`, `\.`, alternation, the
+// case-insensitive flag — is RE2-safe, so it translates 1:1 to Go regexp via
+// the `(?i)` inline flag. No fallback substring split was needed.
+const adHostPattern = `(?i)(?:^|\.)(?:doubleclick|googlesyndication|googleadservices|` +
+	`googletagservices|adservice\.google|amazon-adsystem|adnxs|adsrvr|` +
+	`adform|criteo|rubiconproject|taboola|outbrain|smartadserver|moatads|` +
+	`scorecardresearch|2mdn|adroll|pubmatic|openx|casalemedia|` +
+	`yieldlove|sharethrough|teads|3lift|adsystem|adserver)`
+
+// _2L_TLD: two-level public suffixes (port of ad_ghost._2L_TLD).
+var twoLevelTLD = map[string]bool{
+	"co.uk": true, "com.au": true, "co.jp": true, "co.nz": true,
+	"com.br": true, "co.za": true, "gouv.fr": true,
+}
+
+// ── PolicyOpts: configurable file paths (env-overridable, like Python) ───────
+
+// PolicyOpts holds the on-disk paths the loaders read. Empty fields fall back
+// to the real production defaults (or the env override) in LoadPolicy.
+type PolicyOpts struct {
+	AllowPath        string   // ad-allowlist.txt        (_ALLOW_PATH)
+	LearnedPath      string   // learned-trackers.txt    (_LEARNED_PATH)
+	SpliceSeedPath   string   // conf/tls-splice-seed.conf (SEED_PATH)
+	SpliceLearnPath  string   // splice-learned.txt      (LEARNED_PATH)
+	PureTrackersPath string   // pure-trackers.txt       (PURE_PATH)
+	FortknoxSites    []string // filters.json fortknox_sites
+	SelfDomains      []string // _SELF_REGS (default {secubox.in}, env SECUBOX_SELF_DOMAINS)
+}
+
+// defaultPolicyOpts returns the production defaults, honoring the same env vars
+// the Python addons read.
+func defaultPolicyOpts() PolicyOpts {
+	o := PolicyOpts{
+		AllowPath:        "/var/lib/secubox/toolbox/ad-allowlist.txt",
+		LearnedPath:      "/var/lib/secubox/toolbox/learned-trackers.txt",
+		SpliceSeedPath:   envOr("SECUBOX_SPLICE_SEED", "/usr/lib/secubox/toolbox/conf/tls-splice-seed.conf"),
+		SpliceLearnPath:  envOr("SECUBOX_SPLICE_LEARNED", "/var/lib/secubox/toolbox/splice-learned.txt"),
+		PureTrackersPath: envOr("SECUBOX_PURE_TRACKERS", "/var/lib/secubox/toolbox/pure-trackers.txt"),
+	}
+	// _SELF_REGS: env SECUBOX_SELF_DOMAINS (comma-split), default {secubox.in}.
+	self := os.Getenv("SECUBOX_SELF_DOMAINS")
+	if strings.TrimSpace(self) == "" {
+		self = "secubox.in"
+	}
+	for _, d := range strings.Split(self, ",") {
+		if d = strings.TrimSpace(strings.ToLower(d)); d != "" {
+			o.SelfDomains = append(o.SelfDomains, d)
+		}
+	}
+	return o
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// ── Policy: the loaded decision state ────────────────────────────────────────
+
+// Policy carries the loaded sets/regex and decides per-host actions. It also
+// keeps the legacy PoC fields (Inject) so the existing wiring/tests still work.
+type Policy struct {
+	adHost       *regexp.Regexp
+	learned      map[string]bool // learned-trackers (host or registrable, lowercased)
+	allow        map[string]bool // ad-allowlist (host or registrable, lowercased)
+	spliceSeed   map[string]bool // splice seed patterns
+	spliceLearn  map[string]bool // splice learned patterns
+	never        map[string]bool // pure-trackers ∪ fortknox (splice never-set)
+	selfRegs     map[string]bool // own-infra registrable domains
+	selfDomains  []string        // own-infra (for the host==d || host endswith .d guard)
+
+	// Legacy PoC fields kept so non-policy behaviour is unchanged.
+	Inject []byte // banner / ad-CSS marker injected before </head> or </body>
+}
+
+// loadLines mirrors the comment-stripping Python loaders (splice._load_lines,
+// ad_ghost._allowed's allowlist read): split on first '#', trim, lowercase,
+// skip blanks. Missing/unreadable file → empty set (best-effort).
+func loadLines(path string) map[string]bool {
+	return scanLines(path, true)
+}
+
+// loadLinesRaw mirrors ad_ghost._learned_set, which does NOT comment-strip —
+// learned-trackers.txt is a machine-generated one-host-per-line file. It does
+// `{ln.strip().lower() for ln in f if ln.strip()}`. Matching this exactly is
+// load-bearing for parity (a '#' in this file would be kept verbatim, not a
+// comment), so the Go core must mirror the divergent behaviour, not normalise it.
+func loadLinesRaw(path string) map[string]bool {
+	return scanLines(path, false)
+}
+
+func scanLines(path string, stripComments bool) map[string]bool {
+	out := map[string]bool{}
+	f, err := os.Open(path)
+	if err != nil {
+		return out
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() {
+		ln := sc.Text()
+		if stripComments {
+			if i := strings.IndexByte(ln, '#'); i >= 0 {
+				ln = ln[:i]
+			}
+		}
+		ln = strings.ToLower(strings.TrimSpace(ln))
+		if ln != "" {
+			out[ln] = true
+		}
+	}
+	return out
+}
+
+// LoadPolicy loads all backing files from opts (defaults applied for empty
+// fields) and compiles the ad-host regex. It never returns an error for missing
+// files (best-effort, like the Python addons), only for a regex-compile bug.
+func LoadPolicy(opts PolicyOpts) (*Policy, error) {
+	def := defaultPolicyOpts()
+	if opts.AllowPath == "" {
+		opts.AllowPath = def.AllowPath
+	}
+	if opts.LearnedPath == "" {
+		opts.LearnedPath = def.LearnedPath
+	}
+	if opts.SpliceSeedPath == "" {
+		opts.SpliceSeedPath = def.SpliceSeedPath
+	}
+	if opts.SpliceLearnPath == "" {
+		opts.SpliceLearnPath = def.SpliceLearnPath
+	}
+	if opts.PureTrackersPath == "" {
+		opts.PureTrackersPath = def.PureTrackersPath
+	}
+	if len(opts.SelfDomains) == 0 {
+		opts.SelfDomains = def.SelfDomains
+	}
+
+	re, err := regexp.Compile(adHostPattern)
+	if err != nil {
+		return nil, err
+	}
+
+	// never-set = pure-trackers ∪ fortknox_sites (mirrors TlsSplice._refresh_sets).
+	never := loadLines(opts.PureTrackersPath)
+	for _, s := range opts.FortknoxSites {
+		if s = strings.Trim(strings.ToLower(strings.TrimSpace(s)), "."); s != "" {
+			never[s] = true
+		}
+	}
+
+	selfRegs := map[string]bool{}
+	selfDomains := make([]string, 0, len(opts.SelfDomains))
+	for _, d := range opts.SelfDomains {
+		d = strings.ToLower(strings.TrimSpace(d))
+		if d == "" {
+			continue
+		}
+		selfRegs[d] = true
+		selfDomains = append(selfDomains, d)
+	}
+
+	return &Policy{
+		adHost:      re,
+		learned:     loadLinesRaw(opts.LearnedPath), // mirrors _learned_set (no comment-strip)
+		allow:       loadLines(opts.AllowPath),
+		spliceSeed:  loadLines(opts.SpliceSeedPath),
+		spliceLearn: loadLines(opts.SpliceLearnPath),
+		never:       never,
+		selfRegs:    selfRegs,
+		selfDomains: selfDomains,
+	}, nil
+}
+
+// ── registrable: port of ad_ghost._registrable ───────────────────────────────
+//
+//	host = host.split(":")[0].lower().strip(".")
+//	if not host or host.replace(".","").isdigit() or ":" in host: return None
+//	p = host.split(".")
+//	if len(p) <= 2: return host
+//	last2 = ".".join(p[-2:])
+//	return ".".join(p[-3:]) if (last2 in _2L_TLD and len(p) >= 3) else last2
+func registrable(host string) string {
+	host = strings.ToLower(host)
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i]
+	}
+	host = strings.Trim(host, ".")
+	if host == "" {
+		return ""
+	}
+	// host.replace(".","").isdigit() → all-digit IPv4-ish → no registrable.
+	if isAllDigits(strings.ReplaceAll(host, ".", "")) {
+		return ""
+	}
+	// The Python checks ":" in host AFTER stripping the port; a residual colon
+	// (e.g. an IPv6 literal) yields None. We already split on the first colon,
+	// so re-check the remainder for any colon to mirror exactly.
+	if strings.IndexByte(host, ':') >= 0 {
+		return ""
+	}
+	p := strings.Split(host, ".")
+	if len(p) <= 2 {
+		return host
+	}
+	last2 := strings.Join(p[len(p)-2:], ".")
+	if twoLevelTLD[last2] && len(p) >= 3 {
+		return strings.Join(p[len(p)-3:], ".")
+	}
+	return last2
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false // Python "".isdigit() is False
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// ── splice helpers: port of splice.host_matches / should_splice ──────────────
+
+// hostMatches: True if host == pattern OR host is a dotted-suffix subdomain.
+func hostMatches(host string, patterns map[string]bool) bool {
+	h := strings.Trim(strings.ToLower(host), ".")
+	if h == "" || len(patterns) == 0 {
+		return false
+	}
+	if patterns[h] {
+		return true
+	}
+	for p := range patterns {
+		if strings.HasSuffix(h, "."+p) {
+			return true
+		}
+	}
+	return false
+}
+
+// allowed: port of ad_ghost._allowed. Own-infra ALWAYS wins (reflash-safe),
+// then the operator allowlist (host or registrable).
+func (p *Policy) allowed(host string) bool {
+	h := strings.ToLower(host)
+	reg := registrable(h)
+	if reg == "" {
+		reg = h
+	}
+	// own infra: registrable in selfRegs, OR host == d || host endswith "."+d.
+	if p.selfRegs[reg] {
+		return true
+	}
+	for _, d := range p.selfDomains {
+		if h == d || strings.HasSuffix(h, "."+d) {
+			return true
+		}
+	}
+	return p.allow[h] || p.allow[reg]
+}
+
+// shouldSplice: port of splice.should_splice (never wins; then seed ∪ learned).
+func (p *Policy) shouldSplice(sni string) bool {
+	s := strings.Trim(strings.ToLower(sni), ".")
+	if s == "" {
+		return false
+	}
+	if hostMatches(s, p.never) {
+		return false
+	}
+	return hostMatches(s, p.spliceSeed) || hostMatches(s, p.spliceLearn)
+}
+
+// blockedByAd: port of the ad_ghost requestheaders block decision (sans the
+// allowlist guard, which Decide applies first): _AD_HOST match OR
+// registrable/host in learned-trackers.
+func (p *Policy) blockedByAd(host string) bool {
+	if p.adHost.MatchString(host) {
+		return true
+	}
+	reg := registrable(host)
+	if reg != "" && p.learned[reg] {
+		return true
+	}
+	return p.learned[strings.ToLower(host)]
+}
+
+// ── Decide: the unified cross-engine decision ────────────────────────────────
+//
+// action ∈ {"allow","block","splice","mitm"}. Precedence (mirrors the Python
+// across the two addons, documented in the harness):
+//
+//  1. own-infra / allowlist → "allow"  (ad_ghost._allowed; never block/splice)
+//  2. splice never-set check, then seed/learned → "splice"
+//     (tls_splice runs FIRST at the TLS layer; should_splice already excludes
+//     the never-set = pure-trackers ∪ fortknox, so a tracker that is also a
+//     splice candidate fails should_splice here and falls through to block)
+//  3. _AD_HOST / learned → "block"     (ad_ghost requestheaders, request layer)
+//  4. otherwise → "mitm"
+//
+// sni defaults to host when empty (the live engine splices on SNI == the TLS
+// host; for the parity harness host and sni are the same value).
+func (p *Policy) Decide(host, sni string) string {
+	if sni == "" {
+		sni = host
+	}
+	if p.allowed(host) {
+		return "allow"
+	}
+	if p.shouldSplice(sni) {
+		return "splice"
+	}
+	if p.blockedByAd(host) {
+		return "block"
+	}
+	return "mitm"
+}
+
+// action keeps the legacy 3-verb surface (block/splice/mitm) for the PoC
+// CONNECT wiring, derived from Decide: "allow" collapses to "mitm" (an
+// allowlisted host is intercepted normally, just never short-circuited).
+func (p *Policy) action(host string) string {
+	switch p.Decide(host, host) {
+	case "splice":
+		return "splice"
+	case "block":
+		return "block"
+	default: // "allow" and "mitm" both → normal interception
+		return "mitm"
+	}
+}

--- a/packages/secubox-toolbox-ng/cmd/sbxmitm/policy_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxmitm/policy_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: LicenseRef-CMSD-1.0
+// Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+//
+// Cross-engine parity harness — Go side (#662 Phase 3).
+//
+// Loads testdata/parity-fixtures.json + the testdata/config snapshot, runs
+// Policy.Decide on each host, and asserts == the fixture's expect. The Python
+// side (../secubox-toolbox/tests/test_engine_parity.py) loads the SAME files
+// and drives the SAME decision; both must agree → parity proven.
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type parityConfig struct {
+	AdAllowlist     string   `json:"ad_allowlist"`
+	LearnedTrackers string   `json:"learned_trackers"`
+	SpliceSeed      string   `json:"splice_seed"`
+	SpliceLearned   string   `json:"splice_learned"`
+	PureTrackers    string   `json:"pure_trackers"`
+	SelfDomains     []string `json:"self_domains"`
+	FortknoxSites   []string `json:"fortknox_sites"`
+}
+
+type parityFixture struct {
+	Host   string `json:"host"`
+	Expect string `json:"expect"`
+	Why    string `json:"why"`
+}
+
+type parityFile struct {
+	Config   parityConfig    `json:"config"`
+	Fixtures []parityFixture `json:"fixtures"`
+}
+
+// testdataDir resolves the testdata/ dir relative to this package
+// (cmd/sbxmitm → ../../testdata).
+func testdataDir(t *testing.T) string {
+	t.Helper()
+	d, err := filepath.Abs(filepath.Join("..", "..", "testdata"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func loadParityFile(t *testing.T) (parityFile, string) {
+	t.Helper()
+	dir := testdataDir(t)
+	raw, err := os.ReadFile(filepath.Join(dir, "parity-fixtures.json"))
+	if err != nil {
+		t.Fatalf("read fixtures: %v", err)
+	}
+	var pf parityFile
+	if err := json.Unmarshal(raw, &pf); err != nil {
+		t.Fatalf("parse fixtures: %v", err)
+	}
+	if len(pf.Fixtures) == 0 {
+		t.Fatal("no fixtures")
+	}
+	return pf, dir
+}
+
+func TestParityDecide(t *testing.T) {
+	pf, dir := loadParityFile(t)
+	cfgPath := func(rel string) string { return filepath.Join(dir, filepath.FromSlash(rel)) }
+
+	pol, err := LoadPolicy(PolicyOpts{
+		AllowPath:        cfgPath(pf.Config.AdAllowlist),
+		LearnedPath:      cfgPath(pf.Config.LearnedTrackers),
+		SpliceSeedPath:   cfgPath(pf.Config.SpliceSeed),
+		SpliceLearnPath:  cfgPath(pf.Config.SpliceLearned),
+		PureTrackersPath: cfgPath(pf.Config.PureTrackers),
+		FortknoxSites:    pf.Config.FortknoxSites,
+		SelfDomains:      pf.Config.SelfDomains,
+	})
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+
+	for _, fx := range pf.Fixtures {
+		got := pol.Decide(fx.Host, fx.Host)
+		if got != fx.Expect {
+			t.Errorf("Decide(%q)=%q want %q  (%s)", fx.Host, got, fx.Expect, fx.Why)
+		}
+	}
+}
+
+// TestPolicyActionVerbs checks the legacy 3-verb action() surface still wired
+// into the PoC CONNECT path: allow collapses to mitm; block/splice preserved.
+func TestPolicyActionVerbs(t *testing.T) {
+	pf, dir := loadParityFile(t)
+	cfgPath := func(rel string) string { return filepath.Join(dir, filepath.FromSlash(rel)) }
+	pol, err := LoadPolicy(PolicyOpts{
+		AllowPath:        cfgPath(pf.Config.AdAllowlist),
+		LearnedPath:      cfgPath(pf.Config.LearnedTrackers),
+		SpliceSeedPath:   cfgPath(pf.Config.SpliceSeed),
+		SpliceLearnPath:  cfgPath(pf.Config.SpliceLearned),
+		PureTrackersPath: cfgPath(pf.Config.PureTrackers),
+		FortknoxSites:    pf.Config.FortknoxSites,
+		SelfDomains:      pf.Config.SelfDomains,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := map[string]string{
+		"ads.doubleclick.net":          "block",
+		"r1.googlevideo.com":           "splice",
+		"news.example.com":             "mitm",
+		"notdoubleclick.net":           "mitm",
+		"analytics.example-allowed.com": "mitm", // allow → normal interception (mitm verb)
+		"hub.secubox.in":               "mitm", // own-infra → normal interception
+	}
+	for host, want := range cases {
+		if got := pol.action(host); got != want {
+			t.Errorf("action(%q)=%q want %q", host, got, want)
+		}
+	}
+}
+
+// TestRegistrable exercises the _registrable port incl. the 2-level TLD list.
+func TestRegistrable(t *testing.T) {
+	cases := map[string]string{
+		"a.b.example.com":    "example.com",
+		"example.com":        "example.com",
+		"com":                "com",
+		"a.b.example.co.uk":  "example.co.uk",
+		"example.co.uk":      "example.co.uk", // 2 labels → returned as-is
+		"x.y.z.example.com":  "example.com",
+		"1.2.3.4":            "",
+		"":                   "",
+	}
+	for in, want := range cases {
+		if got := registrable(in); got != want {
+			t.Errorf("registrable(%q)=%q want %q", in, got, want)
+		}
+	}
+}

--- a/packages/secubox-toolbox-ng/testdata/config/ad-allowlist.txt
+++ b/packages/secubox-toolbox-ng/testdata/config/ad-allowlist.txt
@@ -1,0 +1,4 @@
+# SecuBox toolbox-ng parity fixture: operator ad-allowlist.
+# Allowlist ALWAYS wins (never block, never splice, never record).
+analytics.example-allowed.com   # an allowlisted host
+criteo-but-allowed.example      # would-be-ad registrable, but allowlisted

--- a/packages/secubox-toolbox-ng/testdata/config/learned-trackers.txt
+++ b/packages/secubox-toolbox-ng/testdata/config/learned-trackers.txt
@@ -1,2 +1,3 @@
 learned-tracker.example
 pure-tracker.example
+commented-learned.example # inline comment — _learned_set keeps the FULL line, not comment-stripped

--- a/packages/secubox-toolbox-ng/testdata/config/learned-trackers.txt
+++ b/packages/secubox-toolbox-ng/testdata/config/learned-trackers.txt
@@ -1,0 +1,2 @@
+learned-tracker.example
+pure-tracker.example

--- a/packages/secubox-toolbox-ng/testdata/config/pure-trackers.txt
+++ b/packages/secubox-toolbox-ng/testdata/config/pure-trackers.txt
@@ -1,0 +1,3 @@
+# SecuBox toolbox-ng parity fixture: pure trackers — the splice never-set.
+# A host here is NEVER spliced even if it's a splice-seed/learned candidate.
+pure-tracker.example      # pure tracker AND in splice-learned → never wins → block

--- a/packages/secubox-toolbox-ng/testdata/config/splice-learned.txt
+++ b/packages/secubox-toolbox-ng/testdata/config/splice-learned.txt
@@ -1,0 +1,3 @@
+# SecuBox toolbox-ng parity fixture: auto-learned splice (never-HTML) hosts.
+assets.example-cdn.com    # a splice-learned host
+pure-tracker.example      # ALSO in pure-trackers (never) → never wins → not spliced

--- a/packages/secubox-toolbox-ng/testdata/config/tls-splice-seed.conf
+++ b/packages/secubox-toolbox-ng/testdata/config/tls-splice-seed.conf
@@ -1,0 +1,3 @@
+# SecuBox toolbox-ng parity fixture: shipped splice seed (pure-asset CDNs).
+googlevideo.com    # YouTube video streams
+fbcdn.net          # Facebook / Instagram media

--- a/packages/secubox-toolbox-ng/testdata/parity-fixtures.json
+++ b/packages/secubox-toolbox-ng/testdata/parity-fixtures.json
@@ -24,6 +24,8 @@
     {"host": "assets.example-cdn.com",        "expect": "splice", "why": "splice-learned host"},
     {"host": "mybank.example",                "expect": "mitm",   "why": "fortknox site in never-set; not in seed/learned → no splice; not ad/learned → mitm"},
     {"host": "notdoubleclick.net",            "expect": "mitm",   "why": "no-false-suffix negative — _AD_HOST requires (^|.) boundary"},
-    {"host": "news.example.com",              "expect": "mitm",   "why": "plain site"}
+    {"host": "news.example.com",              "expect": "mitm",   "why": "plain site"},
+    {"host": "notsecubox.in",                 "expect": "mitm",   "why": "own-infra FALSE-prefix negative — must NOT match self_domains"},
+    {"host": "commented-learned.example",     "expect": "mitm",   "why": "learned-trackers NOT comment-stripped (_learned_set keeps full line incl ' # ...'); bare host not in set → not blocked. Discriminates loadLinesRaw vs loadLines"}
   ]
 }

--- a/packages/secubox-toolbox-ng/testdata/parity-fixtures.json
+++ b/packages/secubox-toolbox-ng/testdata/parity-fixtures.json
@@ -1,0 +1,29 @@
+{
+  "_doc": "Cross-engine parity fixtures (#662 Phase 3). Both the Go core (policy_test.go) and the Python addons (tests/test_engine_parity.py) load THIS file plus the testdata/config snapshot, run their Decide logic on each host, and must agree. Python is the source of truth; Go matches it. action ∈ {allow, block, splice, mitm}.",
+  "config": {
+    "ad_allowlist": "config/ad-allowlist.txt",
+    "learned_trackers": "config/learned-trackers.txt",
+    "splice_seed": "config/tls-splice-seed.conf",
+    "splice_learned": "config/splice-learned.txt",
+    "pure_trackers": "config/pure-trackers.txt",
+    "self_domains": ["secubox.in"],
+    "fortknox_sites": ["mybank.example"]
+  },
+  "fixtures": [
+    {"host": "ads.doubleclick.net",          "expect": "block",  "why": "static ad host (_AD_HOST dotted-prefix doubleclick)"},
+    {"host": "doubleclick.net",               "expect": "block",  "why": "static ad host (_AD_HOST bare)"},
+    {"host": "criteo.com",                    "expect": "block",  "why": "static ad host (_AD_HOST criteo)"},
+    {"host": "learned-tracker.example",       "expect": "block",  "why": "auto-learned tracker (learned-trackers.txt)"},
+    {"host": "pure-tracker.example",          "expect": "block",  "why": "pure-tracker + splice-learned: never wins (no splice) → falls to block (also learned)"},
+    {"host": "hub.secubox.in",                "expect": "allow",  "why": "own-infra subdomain (self_domains) — never block/splice"},
+    {"host": "secubox.in",                    "expect": "allow",  "why": "own-infra apex"},
+    {"host": "analytics.example-allowed.com", "expect": "allow",  "why": "operator allowlisted host"},
+    {"host": "criteo-but-allowed.example",    "expect": "allow",  "why": "would-be-ad registrable but allowlisted → allowlist wins"},
+    {"host": "r1.googlevideo.com",            "expect": "splice", "why": "splice seed subdomain (CDN shard)"},
+    {"host": "googlevideo.com",               "expect": "splice", "why": "splice seed exact"},
+    {"host": "assets.example-cdn.com",        "expect": "splice", "why": "splice-learned host"},
+    {"host": "mybank.example",                "expect": "mitm",   "why": "fortknox site in never-set; not in seed/learned → no splice; not ad/learned → mitm"},
+    {"host": "notdoubleclick.net",            "expect": "mitm",   "why": "no-false-suffix negative — _AD_HOST requires (^|.) boundary"},
+    {"host": "news.example.com",              "expect": "mitm",   "why": "plain site"}
+  ]
+}

--- a/packages/secubox-toolbox/tests/test_engine_parity.py
+++ b/packages/secubox-toolbox/tests/test_engine_parity.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+"""Cross-engine parity harness — Python side (#662 Phase 3).
+
+Loads the SAME ``parity-fixtures.json`` and ``testdata/config`` snapshot the Go
+core uses (``../secubox-toolbox-ng/testdata``), drives the production Python
+decision logic — ``ad_ghost._allowed`` + ``_AD_HOST`` + the learned-trackers
+check, composed with ``splice.should_splice`` — under the SAME precedence as
+Go's ``Policy.Decide``, and asserts the action == the fixture's ``expect``.
+
+Python is the source of truth: if Go and Python ever diverge on a fixture, Go
+is fixed to match this. Both test files reading the identical inputs is what
+makes the parity meaningful.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from mitmproxy_addons import ad_ghost
+from secubox_toolbox import splice
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+# tests/ → packages/secubox-toolbox → packages → packages/secubox-toolbox-ng
+_NG_TESTDATA = os.path.normpath(
+    os.path.join(_HERE, "..", "..", "secubox-toolbox-ng", "testdata"))
+_FIXTURES = os.path.join(_NG_TESTDATA, "parity-fixtures.json")
+
+
+def _load_fixtures():
+    with open(_FIXTURES, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _cfg_path(rel: str) -> str:
+    return os.path.join(_NG_TESTDATA, rel.replace("/", os.sep))
+
+
+def _decide(host: str, sni: str, *, seed, learned_splice, never,
+            self_regs) -> str:
+    """Mirror Go's Policy.Decide precedence EXACTLY.
+
+      1. own-infra / allowlist (ad_ghost._allowed) → "allow"
+      2. splice never-set check, then seed/learned (splice.should_splice) → "splice"
+      3. _AD_HOST match OR registrable/host in learned-trackers → "block"
+      4. otherwise → "mitm"
+    """
+    # 1. allowlist + own-infra ALWAYS win first.
+    if ad_ghost._allowed(host):
+        return "allow"
+    # 2. splice (TLS layer runs first; never-set already excludes trackers).
+    if splice.should_splice(sni or host, seed, learned_splice, never):
+        return "splice"
+    # 3. ad_ghost block decision (request layer).
+    blocked = bool(ad_ghost._AD_HOST.search(host))
+    if not blocked:
+        reg = ad_ghost._registrable(host)
+        ls = ad_ghost._learned_set()
+        if (reg and reg in ls) or host.lower() in ls:
+            blocked = True
+    if blocked:
+        return "block"
+    # 4.
+    return "mitm"
+
+
+@pytest.fixture
+def parity_env(monkeypatch):
+    """Point the Python addon decision logic at the SAME testdata snapshot the
+    Go core loads, and load the splice sets the same way the addon does."""
+    data = _load_fixtures()
+    cfg = data["config"]
+
+    # ad_ghost: allowlist + learned-trackers paths, self-domains, fresh caches.
+    monkeypatch.setattr(ad_ghost, "_ALLOW_PATH", _cfg_path(cfg["ad_allowlist"]))
+    monkeypatch.setattr(ad_ghost, "_LEARNED_PATH", _cfg_path(cfg["learned_trackers"]))
+    monkeypatch.setattr(ad_ghost, "_SELF_REGS",
+                        {d.strip().lower() for d in cfg["self_domains"] if d.strip()})
+    # reset module-level caches so the monkeypatched paths are (re)read.
+    monkeypatch.setattr(ad_ghost, "_allow", set())
+    monkeypatch.setattr(ad_ghost, "_allow_mtime", 0.0)
+    monkeypatch.setattr(ad_ghost, "_learned", set())
+    monkeypatch.setattr(ad_ghost, "_learned_mtime", 0.0)
+    monkeypatch.setattr(ad_ghost, "_learned_check", 0.0)  # bypass the 60s cache
+
+    # splice: load seed/learned the addon way; never = pure-trackers ∪ fortknox.
+    seed = splice.load_splice_seed(_cfg_path(cfg["splice_seed"]))
+    learned_splice = splice.load_learned_splice(_cfg_path(cfg["splice_learned"]))
+    never = splice.load_learned_splice(_cfg_path(cfg["pure_trackers"]))
+    for s in cfg.get("fortknox_sites", []) or []:
+        never.add(str(s).lower().strip("."))
+
+    return {
+        "fixtures": data["fixtures"],
+        "seed": seed,
+        "learned_splice": learned_splice,
+        "never": never,
+        "self_regs": ad_ghost._SELF_REGS,
+    }
+
+
+def test_parity_decide(parity_env):
+    seed = parity_env["seed"]
+    learned_splice = parity_env["learned_splice"]
+    never = parity_env["never"]
+    self_regs = parity_env["self_regs"]
+
+    failures = []
+    for fx in parity_env["fixtures"]:
+        host = fx["host"]
+        got = _decide(host, host, seed=seed, learned_splice=learned_splice,
+                      never=never, self_regs=self_regs)
+        if got != fx["expect"]:
+            failures.append(
+                f"Decide({host!r})={got!r} want {fx['expect']!r}  ({fx.get('why')})")
+    assert not failures, "Python↔fixture parity mismatches:\n" + "\n".join(failures)
+
+
+def test_fixtures_present(parity_env):
+    # Guard: the fixture set must cover every action class, else "parity" is
+    # vacuously true for a missing branch.
+    actions = {fx["expect"] for fx in parity_env["fixtures"]}
+    assert actions == {"allow", "block", "splice", "mitm"}, actions


### PR DESCRIPTION
Ports the toolbox BLOCK/SPLICE decisions to Go reading the real config files (ad-allowlist/learned-trackers/pure-trackers/splice-seed/splice-learned + own-infra #658 + fortknox), mirroring ad_ghost/_allowed + splice.should_splice exactly (RE2 _AD_HOST, registrable+_2L, precedence allow>splice>block>mitm). Cross-engine parity harness: 17 shared fixtures asserted by BOTH a Go test and a Python test (anti-rig verified by the reviewer). go vet clean, arm64 builds, Python suite 129 green. ng package only — NOT wired to live R3.