### PR TITLE
fix(#662): relay upstream redirects instead of following them

### DIFF
--- a/packages/secubox-toolbox-ng/cmd/sbxmitm/main.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxmitm/main.go
@@ -336,7 +336,16 @@ func (px *Proxy) mitmPipeline(tconn *tls.Conn, rawClient net.Conn, host, verdict
 	req.Header.Set("Accept-Encoding", "gzip")
 
 	// proxy upstream, inject into HTML bodies.
-	up := &http.Client{Timeout: 30 * time.Second}
+	//
+	// CheckRedirect: a MITM proxy must NOT follow 3xx itself — it relays the
+	// redirect to the client so the BROWSER follows it (correct URL bar, origin,
+	// cookie scope, method semantics). Go's http.Client follows by default, which
+	// would collapse a 301/302 into the final 200 under the original URL (wrong).
+	// Mirror mitmproxy's pass-through behaviour.
+	up := &http.Client{
+		Timeout:       30 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
 	if dialHost != "" {
 		// Transparent: pin the TCP dial to the captured original-dst, do TLS with
 		// ServerName=host, verify the cert against host (verification stays ON).

--- a/packages/secubox-toolbox-ng/debian/changelog
+++ b/packages/secubox-toolbox-ng/debian/changelog
@@ -1,3 +1,12 @@
+secubox-toolbox-ng (0.1.4-1~bookworm1) bookworm; urgency=medium
+
+  * proxy: do NOT follow upstream redirects — relay 3xx to the client so the
+    browser follows it (correct URL/origin/cookies). Go's default http.Client
+    followed them, collapsing 301/302 into a final 200 under the original URL.
+    (ref #662)
+
+ -- Gerald KERMA <devel@cybermind.fr>  Wed, 18 Jun 2026 20:10:00 +0000
+
 secubox-toolbox-ng (0.1.3-1~bookworm1) bookworm; urgency=medium
 
   * banner: inject into COMPRESSED HTML too. Pin upstream Accept-Encoding to gzip


### PR DESCRIPTION
Found while verifying ad-blocking: `google-analytics.com` returned Go=200 vs Python=301. Cause: the Go engine's upstream `http.Client` follows 3xx by default, collapsing a 301/302 into the final 200 under the ORIGINAL URL — wrong for a MITM proxy. A proxy must relay the redirect so the BROWSER follows it (correct URL bar, origin, cookie scope, method).

Fix: `CheckRedirect: ErrUseLastResponse` on the upstream client (mirrors mitmproxy). Verified live: google-analytics.com now 301 (parity with Python), ad exchanges still 204, content pages still 200 + banner.

Ad-blocking verification (same session): doubleclick/googlesyndication/adnxs/pubmatic/criteo/scorecardresearch/adservice.google all 204; legit sites clean — no false positives.