### PR TITLE
fix(#662): strip Alt-Svc — stop HTTP/3 so traffic stays on MITM-able TCP

### DIFF
--- a/packages/secubox-toolbox-ng/cmd/sbxmitm/main.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxmitm/main.go
@@ -568,6 +568,11 @@ func (px *Proxy) mitmPipeline(tconn *tls.Conn, rawClient net.Conn, host, verdict
 			resp.ContentLength = int64(len(body))
 		}
 	}
+	// #662 — strip Alt-Svc so the browser is never told this origin offers HTTP/3
+	// (h3). With h3 unadvertised it keeps using HTTP/2 over TCP, which we MITM;
+	// otherwise it caches "h3 available" and keeps trying QUIC (UDP 443) — which
+	// bypasses this TCP proxy and is only best-effort blocked by the nft reject.
+	resp.Header.Del("Alt-Svc")
 	writeResponse(tconn, resp, body)
 }
 

--- a/packages/secubox-toolbox-ng/debian/changelog
+++ b/packages/secubox-toolbox-ng/debian/changelog
@@ -1,3 +1,12 @@
+secubox-toolbox-ng (0.1.14-1~bookworm1) bookworm; urgency=medium
+
+  * quic/banner: strip Alt-Svc response header so browsers stop learning/preferring
+    HTTP/3 (h3) and stay on HTTP/2-over-TCP (MITM-able). Complements the nft
+    udp443 reject; addresses sites where browsers ignore the reject and keep
+    retrying QUIC, bypassing inject/adblock/metrics. (ref #662)
+
+ -- Gerald KERMA <devel@cybermind.fr>  Thu, 19 Jun 2026 14:30:00 +0000
+
 secubox-toolbox-ng (0.1.13-1~bookworm1) bookworm; urgency=medium
 
   * banner: INLINE the banner (server-side bundle fetch, baked literals) instead


### PR DESCRIPTION
Browsers reached HTTP/3 sites over QUIC (UDP443), bypassing the TCP MITM (no banner/adblock/metrics). The nft udp443 reject helps but QUIC ignores ICMP + browsers cache 'h3 available'. Stripping the Alt-Svc response header stops the browser learning/preferring h3 → it stays on HTTP/2-over-TCP. Verified: google Alt-Svc removed via the engine. Complements the reject (master 7db7a73d).