### PR TITLE
sbxmitm: forged leaves valid 365d not 24h — stop daily cert expiry (closes #689)

### DIFF
--- a/packages/secubox-toolbox-ng/cmd/sbxmitm/main.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxmitm/main.go
@@ -129,8 +129,12 @@ func (c *CA) forge(host string) (*tls.Certificate, error) {
 	tmpl := &x509.Certificate{
 		SerialNumber: serial,
 		Subject:      pkix.Name{CommonName: host},
-		NotBefore:    time.Now().Add(-1 * time.Hour),
-		NotAfter:     time.Now().Add(24 * time.Hour),
+		// #689 — forged leaves must outlive the (non-evicting) cert cache, else a
+		// long-running worker keeps serving an expired leaf and every client
+		// reports "certificat expiré". 365d forward + 48h back-skew = 367d span,
+		// safely under Apple's 398-day max-validity rule for server certs.
+		NotBefore:    time.Now().Add(-48 * time.Hour),
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		DNSNames:     []string{host},


### PR DESCRIPTION
The Go MITM engine forged leaf certs with 24h validity while its per-host cert cache never evicts → long-running workers served expired leaves → clients (iOS Safari) saw "certificat expiré" for any forged site (most visibly kbin.gk2.secubox.in). Worker restart masked it for ~24h, then recurred.

Forge leaves with `NotBefore=now-48h`, `NotAfter=now+365d` (367d span, under Apple's 398-day server-cert max). Full interception preserved — no splice/passthrough.

Verified live on gk2: forged kbin leaf nb=2026-06-20 na=2027-06-22, issuer still "Gondwana ToolBoX R3 CA".

Closes #689