### PR TITLE
kbin PDF report: include DPI-Exfil stats (closes #701)

### DIFF
--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -2562,6 +2562,7 @@ async def report_me(request: Request) -> Response:
         mac_hash = macmod.hash_mac(mac, salt)
     session = _aggregate_session(mac_hash)
     data = reports.build_report_data(mac_hash, session)
+    data["dpi_exfil"] = _dpi_stats(mac_hash)  # #701 — DPI parity with the HTML report
     pdf_bytes = reports.render_pdf(data)
     fname = f"gondwana-toolbox-{mac_hash[:8]}.pdf"
     return Response(

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -218,6 +218,40 @@ def render_pdf(report: dict) -> bytes:
             _bullet(pdf, f"{a.get('emoji', '?')} {a.get('app', '?')} ({a.get('category', '?')}) - {a.get('count', 0)} connexions", font_size=8)
         pdf.ln(2)
 
+    # ── DPI / EXFILTRATION (R3 per-device + overall) — #701 (parity with HTML) ──
+    dexf = report.get("dpi_exfil") or {}
+    dme = dexf.get("me") or {}
+    dall = dexf.get("all") or {}
+    if dme.get("present") or dall.get("categories"):
+        _section(pdf, "DPI / EXFILTRATION (TUNNEL R3)")
+
+        def _donut_lines(title: str, items: list) -> None:
+            if not items:
+                return
+            pdf.set_font(getattr(pdf, "_secubox_family", "Helvetica"), "B", 9)
+            pdf.cell(0, 5, _ascii_safe(title), ln=True)
+            for it in items:
+                _bullet(pdf, f"{it.get('emoji', '')} {it.get('label', '?')} - {it.get('pct', 0)}%", font_size=8)
+
+        if dme.get("present"):
+            up_mo = round((dme.get("up", 0) or 0) / 1048576, 1)
+            dn_mo = round((dme.get("down", 0) or 0) / 1048576, 1)
+            _kv(pdf, "Cet appareil",
+                f"{dme.get('flows', 0)} flux | {up_mo} Mo envoyes | {dn_mo} Mo recus | {dme.get('alert_count', 0)} alertes")
+            _donut_lines("Categories de service", dme.get("categories"))
+            _donut_lines("Protocoles", dme.get("protocols"))
+            _donut_lines("Alertes exfiltration", dme.get("alerts"))
+            _donut_lines("Top destinations (envoi)", dme.get("destinations"))
+        else:
+            _bullet(pdf, "Aucune donnee DPI pour cet appareil (surfer via le tunnel R3).", font_size=8)
+
+        if dall.get("categories"):
+            pdf.ln(1)
+            _kv(pdf, "Reseau (tous appareils)",
+                f"{dall.get('devices', 0)} appareils | {dall.get('flows', 0)} flux | {dall.get('alert_count', 0)} alertes")
+            _donut_lines("Categories (global)", dall.get("categories"))
+        pdf.ln(2)
+
     # ── Geo top hosts (avec drapeaux + ASN) ──
     geo_hosts = report.get("geo_top_hosts") or []
     if geo_hosts:


### PR DESCRIPTION
PDF parity with the HTML report tabs (#699). /report/me embeds a 'DPI / EXFILTRATION (TUNNEL R3)' section: this device's flows/Mo-up/Mo-down/alert KPIs + category/protocol/alert/destination breakdowns (%), plus a board-wide overall summary. Fail-soft when the device wasn't in the latest capture window.

Live on gk2 (kbin + admin 200): 114 KB PDF renders the section with emoji category breakdown.

Closes #701