### PR TITLE
kbin PDF: visual donut charts (mitm/certs/ads/dpi) for device stats (closes #703)

### DIFF
--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -2479,6 +2479,43 @@ def _dpi_stats(mac_hash: str | None) -> dict:
     return {"me": me_stats, "all": all_stats}
 
 
+def _build_pdf_donuts(mac_hash: str | None, data: dict) -> list:
+    """#703 — assemble the 4 device-stat donuts for the PDF (mitm/certs/ads/dpi)
+    from LIVE sources (DPI collector + ad-block SQLite); the events table is
+    frozen post-#662 so we never read it. Each donut's segments carry pct +
+    cumulative start/end (via _dpi_donut)."""
+    me = (data.get("dpi_exfil") or {}).get("me") or {}
+    # ads — per-device blocked ad hosts (Go adstats → SQLite)
+    try:
+        ads = store.ad_client_stats(mac_hash, hours=24, top=6)
+    except Exception:
+        ads = {"total": 0, "top_hosts": []}
+    ads_segs = _dpi_donut([{"label": h.get("host", "?"), "emoji": "🚫",
+                            "count": int(h.get("hits", 0) or 0)} for h in ads.get("top_hosts", [])])
+    # certs — TLS-trust split from the protocol mix (what we could decrypt)
+    tls = quic = other = 0
+    for p in (me.get("protocols") or []):
+        nm = (p.get("label") or "").lower()
+        c = int(p.get("count", 0) or 0)
+        if "quic" in nm or "http3" in nm:
+            quic += c
+        elif "tls" in nm or "ssl" in nm or "https" in nm:
+            tls += c
+        else:
+            other += c
+    certs_segs = _dpi_donut([
+        {"label": "Inspecté (TLS)", "count": tls},
+        {"label": "Opaque (QUIC)", "count": quic},
+        {"label": "Autre", "count": other},
+    ])
+    return [
+        {"title": "🛰️ DPI — catégories", "hole": "DPI", "segments": me.get("categories") or []},
+        {"title": "🔍 MITM — protocoles", "hole": "proto", "segments": me.get("protocols") or []},
+        {"title": "🔒 Certs — confiance TLS", "hole": "certs", "segments": certs_segs},
+        {"title": "🚫 Pubs bloquées", "hole": str(ads.get("total", 0)), "segments": ads_segs},
+    ]
+
+
 # NOTE: route order matters in FastAPI — specific routes (/report/me,
 # /report/me/html) MUST be declared BEFORE the catch-all /report/{token},
 # otherwise FastAPI matches /report/me with token="me" and returns 404.
@@ -2563,6 +2600,7 @@ async def report_me(request: Request) -> Response:
     session = _aggregate_session(mac_hash)
     data = reports.build_report_data(mac_hash, session)
     data["dpi_exfil"] = _dpi_stats(mac_hash)  # #701 — DPI parity with the HTML report
+    data["pdf_donuts"] = _build_pdf_donuts(mac_hash, data)  # #703 — visual donuts
     pdf_bytes = reports.render_pdf(data)
     fname = f"gondwana-toolbox-{mac_hash[:8]}.pdf"
     return Response(

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -218,6 +218,9 @@ def render_pdf(report: dict) -> bytes:
             _bullet(pdf, f"{a.get('emoji', '?')} {a.get('app', '?')} ({a.get('category', '?')}) - {a.get('count', 0)} connexions", font_size=8)
         pdf.ln(2)
 
+    # ── DPI device donut charts (mitm/certs/ads/dpi) — #703 ──
+    _pdf_donut_grid(pdf, report.get("pdf_donuts") or [])
+
     # ── DPI / EXFILTRATION (R3 per-device + overall) — #701 (parity with HTML) ──
     dexf = report.get("dpi_exfil") or {}
     dme = dexf.get("me") or {}
@@ -643,6 +646,76 @@ def _bullet(pdf, text: str, font_size: int = 9) -> None:
             parts.append(word)
     safe = " ".join(parts)
     pdf.multi_cell(_page_w(pdf), 5, "  - " + safe)
+
+
+# #703 — visual donut charts in the PDF (fpdf2 solid_arc sectors + white hole).
+# RGB mirror of the HTML report palette.
+_PDF_DONUT_PALETTE = [
+    (0, 221, 68), (158, 118, 255), (255, 136, 102),
+    (102, 187, 255), (255, 179, 71), (255, 68, 102),
+]
+
+
+def _pdf_donut(pdf, x: float, y: float, w: float, title: str, hole: str, segs: list) -> None:
+    """Draw one donut (pie sectors + white centre hole) + legend inside a cell of
+    width w at (x, y). segs carry cumulative start/end percents (from _dpi_donut)."""
+    fam = getattr(pdf, "_secubox_family", "Helvetica")
+    pdf.set_xy(x, y)
+    pdf.set_font(fam, "B", 9)
+    pdf.set_text_color(0, 90, 64)
+    pdf.cell(w, 5, _ascii_safe(title)[:30], ln=False)
+    cx, cy, r, rh = x + 15, y + 23, 12.5, 8.0
+    if segs:
+        for i, s in enumerate(segs):
+            pdf.set_fill_color(*_PDF_DONUT_PALETTE[i % len(_PDF_DONUT_PALETTE)])
+            a0 = 90.0 - float(s.get("start", 0)) * 3.6
+            a1 = 90.0 - float(s.get("end", 0)) * 3.6
+            try:
+                pdf.solid_arc(cx, cy, r, a0, a1, clockwise=True, style="F")
+            except Exception:
+                pass
+        # centre hole (page is white)
+        pdf.set_fill_color(255, 255, 255)
+        pdf.ellipse(cx - rh, cy - rh, 2 * rh, 2 * rh, style="F")
+        if hole:
+            pdf.set_xy(cx - rh, cy - 2)
+            pdf.set_font(fam, "", 6)
+            pdf.set_text_color(110, 110, 110)
+            pdf.cell(2 * rh, 4, _ascii_safe(hole)[:8], align="C")
+        # legend (right of the donut)
+        ly = y + 8
+        for i, s in enumerate(segs[:6]):
+            pdf.set_fill_color(*_PDF_DONUT_PALETTE[i % len(_PDF_DONUT_PALETTE)])
+            pdf.rect(x + 33, ly + 0.6, 2.4, 2.4, style="F")
+            pdf.set_xy(x + 37, ly)
+            pdf.set_font(fam, "", 7)
+            pdf.set_text_color(40, 40, 40)
+            pdf.cell(w - 38, 3.5,
+                     _ascii_safe(f"{s.get('label', '?')[:16]}  {s.get('pct', 0)}%"), ln=False)
+            ly += 4
+    else:
+        pdf.set_xy(x, y + 20)
+        pdf.set_font(fam, "", 8)
+        pdf.set_text_color(120, 120, 120)
+        pdf.cell(w, 5, "Pas de donnees", ln=False)
+    pdf.set_text_color(0)
+
+
+def _pdf_donut_grid(pdf, donuts: list) -> None:
+    """Render up to 4 donuts in a 2x2 grid."""
+    if not donuts:
+        return
+    _section(pdf, "📊 STATS DE TON APPAREIL (graphiques)")
+    y0 = pdf.get_y() + 2
+    col_w = _page_w(pdf) / 2.0
+    row_h = 42.0
+    shown = donuts[:4]
+    for i, d in enumerate(shown):
+        col, row = i % 2, i // 2
+        _pdf_donut(pdf, pdf.l_margin + col * col_w, y0 + row * row_h, col_w - 4,
+                   d.get("title", ""), d.get("hole", ""), d.get("segments") or [])
+    rows = (len(shown) + 1) // 2
+    pdf.set_y(y0 + rows * row_h + 2)
 
 
 def _render_text_fallback(report: dict) -> str:


### PR DESCRIPTION
The PDF report gains a 2x2 grid of real donut charts (fpdf2 solid_arc + white hole + legend) for the device: DPI categories, MITM protocol mix, Certs TLS-trust split, and Pubs bloquées (top blocked ad hosts, total in the hole). Live sources only (DPI collector + ad-block SQLite; frozen events table never read).

Visually verified via pdftoppm on gk2 — 4 donuts with holes/legends and live ad counts.

Closes #703