### PR TITLE
dpi Phase 3: nDPId daemon CI cross-build (QEMU arm64) + package wiring (ref #722)

### DIFF
--- a/.github/workflows/build-ndpid.yml
+++ b/.github/workflows/build-ndpid.yml
@@ -1,0 +1,93 @@
+name: Build nDPId (arm64)
+
+# #722 — nDPId is a C daemon needing libnDPI >= 5.0 (Debian bookworm ships 4.2),
+# so we bundle nDPI via `cmake -DBUILD_NDPI=ON`. The repo's normal package build
+# cross-compiles on an amd64 runner (-a arm64) which can't link this C tree, so
+# we do a NATIVE arm64 build inside a QEMU-emulated debian:bookworm container and
+# commit the resulting binaries into packages/secubox-ndpid/bin/ so the
+# secubox-ndpid .deb ships them self-contained (no build deps in the deb build).
+#
+# Manual: Actions → "Build nDPId (arm64)" → Run. Bump NDPID_REF to update.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ndpid_ref:
+        description: 'nDPId git ref (tag/branch/commit)'
+        required: true
+        default: 'main'
+
+permissions:
+  contents: write   # commit the built binaries back
+
+env:
+  NDPID_REPO: https://github.com/utoni/nDPId
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (arm64 binfmt)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Native arm64 build of nDPId (bundled nDPI)
+        run: |
+          set -euxo pipefail
+          mkdir -p out
+          docker run --rm --platform linux/arm64 \
+            -e NDPID_REF="${{ github.event.inputs.ndpid_ref }}" \
+            -e NDPID_REPO="${NDPID_REPO}" \
+            -v "$PWD/out:/out" debian:bookworm-slim bash -euxo pipefail -c '
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update -qq
+              apt-get install -y --no-install-recommends \
+                build-essential cmake git ca-certificates pkg-config \
+                autoconf automake libtool flex bison gettext \
+                libpcap-dev zlib1g-dev wget unzip
+              git clone --depth 1 --branch "$NDPID_REF" "$NDPID_REPO" /src \
+                || git clone "$NDPID_REPO" /src
+              cd /src && git rev-parse HEAD
+              cmake -S . -B build \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DBUILD_NDPI=ON \
+                -DBUILD_EXAMPLES=ON \
+                -DENABLE_SYSTEMD=OFF \
+                -DENABLE_CRYPTO=OFF
+              cmake --build build -j"$(nproc)"
+              # collect the daemon + the JSON distributor
+              cp -v build/nDPId /out/nDPId
+              cp -v build/nDPIsrvd /out/nDPIsrvd
+              ( cd /out && file nDPId nDPIsrvd && sha256sum nDPId nDPIsrvd > SHA256SUMS )
+            '
+          file out/nDPId out/nDPIsrvd
+
+      - name: Stage binaries into the package
+        run: |
+          set -euxo pipefail
+          mkdir -p packages/secubox-ndpid/bin
+          install -m 0755 out/nDPId    packages/secubox-ndpid/bin/nDPId
+          install -m 0755 out/nDPIsrvd packages/secubox-ndpid/bin/nDPIsrvd
+          cp out/SHA256SUMS packages/secubox-ndpid/bin/SHA256SUMS
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ndpid-arm64
+          path: out/
+
+      - name: Commit binaries back
+        run: |
+          set -euxo pipefail
+          git config user.name  "secubox-ci"
+          git config user.email "ci@cybermind.fr"
+          git add packages/secubox-ndpid/bin/nDPId packages/secubox-ndpid/bin/nDPIsrvd packages/secubox-ndpid/bin/SHA256SUMS
+          if git diff --cached --quiet; then
+            echo "no binary change"; exit 0
+          fi
+          git commit -m "build(ndpid): nDPId arm64 binaries from ${{ github.event.inputs.ndpid_ref }} (ref #722)"
+          git push

--- a/packages/secubox-ndpid/bin/README.md
+++ b/packages/secubox-ndpid/bin/README.md
@@ -1,0 +1,6 @@
+# nDPId arm64 binaries (CI-populated)
+
+`nDPId` + `nDPIsrvd` are built by `.github/workflows/build-ndpid.yml`
+(QEMU arm64 native build, bundled libnDPI via `cmake -DBUILD_NDPI=ON`) and
+committed here, then shipped to `/usr/sbin` by `debian/rules`. Do not edit by
+hand. Bump the nDPId ref via the workflow's `ndpid_ref` input. (#722)

--- a/packages/secubox-ndpid/debian/changelog
+++ b/packages/secubox-ndpid/debian/changelog
@@ -1,3 +1,14 @@
+secubox-ndpid (1.1.0-1~bookworm1) bookworm; urgency=low
+
+  * #722 Phase 3 — nDPId daemon build pipeline: .github/workflows/build-ndpid.yml
+    does a QEMU arm64 native build (bundled libnDPI via cmake -DBUILD_NDPI=ON) and
+    commits nDPId + nDPIsrvd to bin/. Package now Architecture: arm64, ships those
+    to /usr/sbin (guarded), Depends libpcap0.8 (dropped the external ndpid dep).
+    Daemon service + secubox-dpi-flowcap JSON cutover land in the follow-on once
+    CI produces a validated binary.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Mon, 22 Jun 2026 14:10:00 +0000
+
 secubox-ndpid (1.0.1-1~bookworm1) bookworm; urgency=low
 
   * Rewrite Description to identify this as the nDPId-engine DPI

--- a/packages/secubox-ndpid/debian/control
+++ b/packages/secubox-ndpid/debian/control
@@ -6,8 +6,8 @@ Build-Depends: debhelper-compat (= 13)
 Standards-Version: 4.6.2
 
 Package: secubox-ndpid
-Architecture: all
-Depends: ${misc:Depends}, secubox-core (>= 1.0.0), ndpid | ndpi-reader, python3-zmq
+Architecture: arm64
+Depends: ${misc:Depends}, secubox-core (>= 1.0.0), libpcap0.8
 Recommends: secubox-dpi
 Description: SecuBox nDPId — DPI dashboard with JA3/JA4 TLS fingerprinting
  nDPId-backed deep packet inspection dashboard: JA3/JA3S/JA4 TLS

--- a/packages/secubox-ndpid/debian/rules
+++ b/packages/secubox-ndpid/debian/rules
@@ -13,3 +13,9 @@ override_dh_auto_install:
 	[ -f config/ndpid.toml ] && install -m 644 config/ndpid.toml debian/secubox-ndpid/etc/secubox/ || true
 	install -d debian/secubox-ndpid/usr/bin
 	[ -f scripts/ndpidctl ] && install -m 755 scripts/ndpidctl debian/secubox-ndpid/usr/bin/ || true
+	# #722 — nDPId daemon + JSON distributor (arm64, built by build-ndpid.yml and
+	# committed to bin/). Guarded so the package still builds before CI populates
+	# bin/; once present they ship to /usr/sbin.
+	install -d debian/secubox-ndpid/usr/sbin
+	[ -f bin/nDPId ]    && install -m 755 bin/nDPId    debian/secubox-ndpid/usr/sbin/nDPId    || true
+	[ -f bin/nDPIsrvd ] && install -m 755 bin/nDPIsrvd debian/secubox-ndpid/usr/sbin/nDPIsrvd || true


### PR DESCRIPTION
nDPId needs libnDPI>=5.0 (bookworm has 4.2) and the sandbox can't C-cross. build-ndpid.yml does a QEMU arm64 native build (cmake -DBUILD_NDPI=ON bundles libnDPI), commits nDPId+nDPIsrvd to packages/secubox-ndpid/bin/. secubox-ndpid → arch arm64, ships them to /usr/sbin (guarded), Depends libpcap0.8. Workflow is manual (workflow_dispatch). Follow-on: daemon service + secubox-dpi-flowcap JSON cutover once CI yields a validated binary; ndpiReader PoC stays as fallback.

Refs #722