### PR TITLE
Aggregator résilience: sweep async (243 handlers) + threadpool 80 (#738)

### DIFF
--- a/packages/secubox-admin/api/main.py
+++ b/packages/secubox-admin/api/main.py
@@ -509,7 +509,7 @@ async def get_processes(
 
 
 @router.post("/reboot")
-async def reboot_system(request: SystemActionRequest, user=Depends(require_jwt)):
+def reboot_system(request: SystemActionRequest, user=Depends(require_jwt)):
     """Reboot the system (requires confirmation)."""
     if not request.confirm:
         raise HTTPException(status_code=400, detail="Confirmation required for reboot")
@@ -528,7 +528,7 @@ async def reboot_system(request: SystemActionRequest, user=Depends(require_jwt))
 
 
 @router.post("/shutdown")
-async def shutdown_system(request: SystemActionRequest, user=Depends(require_jwt)):
+def shutdown_system(request: SystemActionRequest, user=Depends(require_jwt)):
     """Shutdown the system (requires confirmation)."""
     if not request.confirm:
         raise HTTPException(status_code=400, detail="Confirmation required for shutdown")

--- a/packages/secubox-aggregator/aggregator/main.py
+++ b/packages/secubox-aggregator/aggregator/main.py
@@ -214,6 +214,19 @@ def _build_app() -> FastAPI:
     for name in cfg.get("modules", []):
         _mount_module(app, name)
 
+    @app.on_event("startup")
+    async def _raise_threadpool() -> None:
+        """Sync (`def`) route handlers — including the blocking ones converted
+        by the #738 async-sweep — run in AnyIO's default threadpool (40 tokens).
+        With ~110 modules sharing one process, raise the cap so concurrent
+        blocking calls don't queue head-of-line behind a full pool."""
+        try:
+            import anyio
+            anyio.to_thread.current_default_thread_limiter().total_tokens = 80
+            log.info("threadpool limiter raised to 80 tokens")
+        except Exception as e:  # never let this break startup
+            log.warning("could not raise threadpool limiter: %s", e)
+
     @app.get("/health")
     def health() -> dict:
         """Aggregator health. Reports per-module load state."""

--- a/packages/secubox-ai-insights/api/main.py
+++ b/packages/secubox-ai-insights/api/main.py
@@ -527,7 +527,7 @@ async def components():
 
 
 @app.get("/access")
-async def access():
+def access():
     """Show connection endpoints (public, three-fold: how)."""
     import socket
     hostname = socket.getfqdn()
@@ -1012,7 +1012,7 @@ async def analyze(req: AnalyzeRequest, user=Depends(require_jwt)):
 # ============================================================================
 
 @app.get("/integrations")
-async def get_integrations(user=Depends(require_jwt)):
+def get_integrations(user=Depends(require_jwt)):
     """Get CrowdSec/Suricata integration status."""
     config = _load_config()
 

--- a/packages/secubox-auth/api/main.py
+++ b/packages/secubox-auth/api/main.py
@@ -211,7 +211,7 @@ def _check_scope(authorization: Optional[str], expected_scope: str) -> dict:
 
 
 @_login_router.post("/login")
-async def _login_v2(req: _LoginIn, request: _Request, response: _Response):
+def _login_v2(req: _LoginIn, request: _Request, response: _Response):
     """Branching login: setup_token / mfa_token / enrollment_token / access_token."""
     ip = (request.headers.get("X-Forwarded-For", "").split(",")[0].strip()
           or request.headers.get("X-Real-IP", "")
@@ -298,7 +298,7 @@ async def _totp_enroll(request: _Request):
 
 
 @_login_router.post("/totp/confirm")
-async def _totp_confirm(req: _MfaIn, request: _Request, response: _Response):
+def _totp_confirm(req: _MfaIn, request: _Request, response: _Response):
     payload = _check_scope(request.headers.get("Authorization"), "totp-enroll")
     username = payload["sub"]
     secret = _pending.get(payload["jti"])
@@ -321,7 +321,7 @@ async def _totp_confirm(req: _MfaIn, request: _Request, response: _Response):
 
 
 @_login_router.post("/set-password")
-async def _set_password(req: _SetPasswordIn, request: _Request):
+def _set_password(req: _SetPasswordIn, request: _Request):
     auth_h = request.headers.get("Authorization", "")
     if not auth_h.lower().startswith("bearer "):
         raise HTTPException(status_code=401, detail="Token Bearer manquant")
@@ -888,7 +888,7 @@ async def get_history(limit: int = 100, event: Optional[str] = None, user=Depend
 
 
 @router.get("/logs")
-async def get_logs(lines: int = 100, user=Depends(require_jwt)):
+def get_logs(lines: int = 100, user=Depends(require_jwt)):
     """Get auth service logs."""
     try:
         r = subprocess.run(

--- a/packages/secubox-c3box/api/main.py
+++ b/packages/secubox-c3box/api/main.py
@@ -366,7 +366,7 @@ async def get_service(name: str):
 
 
 @app.post("/services/{name}/control", dependencies=[Depends(require_jwt)])
-async def control_service(name: str, action: ServiceAction, background_tasks: BackgroundTasks):
+def control_service(name: str, action: ServiceAction, background_tasks: BackgroundTasks):
     """Start, stop, or restart a service."""
     svc = next((s for s in SERVICES if s["name"] == name), None)
     if not svc:

--- a/packages/secubox-cdn/api/main.py
+++ b/packages/secubox-cdn/api/main.py
@@ -152,7 +152,7 @@ async def purge_cache(user=Depends(require_jwt)):
 
 
 @router.post("/purge_domain")
-async def purge_domain(domain: str, user=Depends(require_jwt)):
+def purge_domain(domain: str, user=Depends(require_jwt)):
     """Purger le cache d'un domaine."""
     target = CACHE_DIR / domain
     if target.exists():
@@ -276,14 +276,14 @@ async def clear_stats(user=Depends(require_jwt)):
 
 
 @router.get("/restart")
-async def restart(user=Depends(require_jwt)):
+def restart(user=Depends(require_jwt)):
     """Redémarrer le service cache."""
     r = subprocess.run(["systemctl", "reload", "nginx"], capture_output=True, text=True)
     return {"success": r.returncode == 0}
 
 
 @router.get("/logs")
-async def logs(lines: int = 50, user=Depends(require_jwt)):
+def logs(lines: int = 50, user=Depends(require_jwt)):
     """Logs du cache."""
     r = subprocess.run(
         ["tail", "-n", str(lines), "/var/log/nginx/cache.log"],

--- a/packages/secubox-certs/api/main.py
+++ b/packages/secubox-certs/api/main.py
@@ -349,7 +349,7 @@ async def cert_status():
 
 
 @router.get("/details/{domain}")
-async def cert_details(domain: str):
+def cert_details(domain: str):
     """Get detailed info for a specific certificate."""
     # Find the cert file
     pem_path = CERTS_DIR / f"{domain}.pem"
@@ -401,7 +401,7 @@ class CertRequest(BaseModel):
 
 
 @router.post("/check")
-async def check_domain(req: CertRequest):
+def check_domain(req: CertRequest):
     """Pre-flight checks before issuing certificate."""
     checks = []
     domain = req.domain
@@ -462,7 +462,7 @@ async def check_domain(req: CertRequest):
 
 
 @router.post("/issue")
-async def issue_certificate(req: CertRequest, background_tasks: BackgroundTasks):
+def issue_certificate(req: CertRequest, background_tasks: BackgroundTasks):
     """Issue a new certificate via ACME."""
     domain = req.domain
 
@@ -593,7 +593,7 @@ async def renew_all_expiring():
 
 
 @router.delete("/revoke/{domain}")
-async def revoke_certificate(domain: str):
+def revoke_certificate(domain: str):
     """Revoke and delete a certificate."""
     pem_path = CERTS_DIR / f"{domain}.pem"
     if not pem_path.exists():

--- a/packages/secubox-crowdsec/api/main.py
+++ b/packages/secubox-crowdsec/api/main.py
@@ -354,7 +354,7 @@ async def components():
 
 
 @app.get("/access")
-async def access():
+def access():
     """Show connection endpoints (public, three-fold: how)."""
     import socket
     hostname = socket.getfqdn()
@@ -464,7 +464,7 @@ async def console_enroll(req: ConsoleEnrollRequest, user=Depends(require_jwt)):
 
 
 @app.post("/capi/enroll")
-async def capi_enroll(user=Depends(require_jwt)):
+def capi_enroll(user=Depends(require_jwt)):
     """Auto-enroll to CAPI (Central API) for community blocklists."""
     log.info("Auto-enrolling to CAPI")
     try:
@@ -590,7 +590,7 @@ async def health():
 
 
 @app.get("/doctor")
-async def doctor():
+def doctor():
     """Layer 2: Diagnostic détaillé + can_repair."""
     issues = []
 
@@ -1235,7 +1235,7 @@ async def export_decisions(format: str = Query(default="json", enum=["json", "cs
 # ═══════════════════════════════════════════════════════════════════════
 
 @app.get("/decisions_stats")
-async def decisions_stats():
+def decisions_stats():
     """Get decision statistics for SOC dashboard (public).
 
     Returns counts, bouncers, and categories for the dashboard cards.
@@ -1305,7 +1305,7 @@ class BanRequest(BaseModel):
 
 
 @app.post("/ban")
-async def ban_ip(req: BanRequest, user=Depends(require_jwt)):
+def ban_ip(req: BanRequest, user=Depends(require_jwt)):
     """Ban an IP address (manual ban from SOC dashboard)."""
     log.info("Manual ban requested for %s by %s", req.ip, user.get("sub", "unknown"))
 
@@ -1347,7 +1347,7 @@ class UnbanRequest(BaseModel):
 
 
 @app.post("/unban")
-async def unban_ip(req: UnbanRequest, user=Depends(require_jwt)):
+def unban_ip(req: UnbanRequest, user=Depends(require_jwt)):
     """Remove ban for an IP address."""
     log.info("Unban requested for %s by %s", req.ip, user.get("sub", "unknown"))
 

--- a/packages/secubox-domoticz/api/main.py
+++ b/packages/secubox-domoticz/api/main.py
@@ -658,7 +658,7 @@ async def update_notifications(settings: NotificationSettings, user=Depends(requ
 # ============================================================================
 
 @router.get("/container/status")
-async def container_status(user=Depends(require_jwt)):
+def container_status(user=Depends(require_jwt)):
     """Get container status."""
     rt = detect_runtime()
     running = is_running()
@@ -688,7 +688,7 @@ async def container_status(user=Depends(require_jwt)):
 
 
 @router.post("/container/install")
-async def install_container(user=Depends(require_jwt)):
+def install_container(user=Depends(require_jwt)):
     """Pull and install Domoticz container."""
     rt = detect_runtime()
     if not rt:
@@ -810,7 +810,7 @@ async def restart_container(user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/logs")
-async def get_logs(lines: int = Query(100, ge=10, le=500), user=Depends(require_jwt)):
+def get_logs(lines: int = Query(100, ge=10, le=500), user=Depends(require_jwt)):
     """Get container logs."""
     rt = detect_runtime()
     logs = []

--- a/packages/secubox-dpi/api/main.py
+++ b/packages/secubox-dpi/api/main.py
@@ -405,7 +405,7 @@ def _setup_mirred(iface: str, mirror_if: str = "ifb0") -> dict:
     return {"steps": results, "interface": iface, "mirror": mirror_if}
 
 @router.get("/status")
-async def status(user=Depends(require_jwt)):
+def status(user=Depends(require_jwt)):
     cfg = get_config("dpi")
     netifyd_up = subprocess.run(["pgrep", "netifyd"], capture_output=True).returncode == 0
     iface = cfg.get("interface", "eth0")
@@ -653,26 +653,26 @@ async def save_settings(req: DpiSettingsRequest, user=Depends(require_jwt)):
 
 
 @router.post("/restart")
-async def restart(user=Depends(require_jwt)):
+def restart(user=Depends(require_jwt)):
     """Redémarrer netifyd."""
     r = subprocess.run(["systemctl", "restart", "netifyd"], capture_output=True, text=True)
     return {"success": r.returncode == 0}
 
 
 @router.post("/start")
-async def start(user=Depends(require_jwt)):
+def start(user=Depends(require_jwt)):
     r = subprocess.run(["systemctl", "start", "netifyd"], capture_output=True, text=True)
     return {"success": r.returncode == 0}
 
 
 @router.post("/stop")
-async def stop(user=Depends(require_jwt)):
+def stop(user=Depends(require_jwt)):
     r = subprocess.run(["systemctl", "stop", "netifyd"], capture_output=True, text=True)
     return {"success": r.returncode == 0}
 
 
 @router.get("/logs")
-async def logs(lines: int = 100, user=Depends(require_jwt)):
+def logs(lines: int = 100, user=Depends(require_jwt)):
     r = subprocess.run(
         ["journalctl", "-u", "netifyd", "-n", str(lines), "--no-pager"],
         capture_output=True, text=True, timeout=10
@@ -681,7 +681,7 @@ async def logs(lines: int = 100, user=Depends(require_jwt)):
 
 
 @router.get("/interface_list")
-async def interface_list(user=Depends(require_jwt)):
+def interface_list(user=Depends(require_jwt)):
     """Liste des interfaces."""
     r = subprocess.run(["ip", "-j", "link", "show"], capture_output=True, text=True)
     try:
@@ -692,7 +692,7 @@ async def interface_list(user=Depends(require_jwt)):
 
 
 @router.get("/tc_status")
-async def tc_status(user=Depends(require_jwt)):
+def tc_status(user=Depends(require_jwt)):
     """État tc mirred."""
     cfg = get_config("dpi")
     iface = cfg.get("interface", "eth0")
@@ -708,7 +708,7 @@ async def tc_status(user=Depends(require_jwt)):
 
 
 @router.post("/remove_mirred")
-async def remove_mirred(user=Depends(require_jwt)):
+def remove_mirred(user=Depends(require_jwt)):
     """Supprimer la configuration mirred."""
     cfg = get_config("dpi")
     iface = cfg.get("interface", "eth0")

--- a/packages/secubox-droplet/api/main.py
+++ b/packages/secubox-droplet/api/main.py
@@ -459,7 +459,7 @@ class RenameRequest(BaseModel):
 
 
 @router.post("/remove")
-async def remove(req: RemoveRequest, user=Depends(require_jwt)):
+def remove(req: RemoveRequest, user=Depends(require_jwt)):
     """Remove a droplet."""
     result = subprocess.run(
         ["dropletctl", "remove", req.name],
@@ -481,7 +481,7 @@ async def remove(req: RemoveRequest, user=Depends(require_jwt)):
 
 
 @router.post("/rename")
-async def rename(req: RenameRequest, user=Depends(require_jwt)):
+def rename(req: RenameRequest, user=Depends(require_jwt)):
     """Rename a droplet."""
     if not req.old or not req.new:
         raise HTTPException(400, "Old and new names required")

--- a/packages/secubox-gitea/api/main.py
+++ b/packages/secubox-gitea/api/main.py
@@ -296,7 +296,7 @@ def lxc_attach(command: str, timeout: int = 30) -> tuple:
 # =============================================================================
 
 @app.get("/status")
-async def status():
+def status():
     """Get unified Gitea status (public endpoint)"""
     running = lxc_running()
     installed = lxc_exists()
@@ -818,7 +818,7 @@ async def get_stats_history(hours: int = Query(default=24, le=168)):
 # =============================================================================
 
 @app.get("/repos/{owner}/{repo}", dependencies=[Depends(require_jwt)])
-async def get_repo_details(owner: str, repo: str):
+def get_repo_details(owner: str, repo: str):
     """Get detailed repository information."""
     repo_path = DATA_PATH / "git" / "repositories" / owner / f"{repo}.git"
 

--- a/packages/secubox-glances/api/main.py
+++ b/packages/secubox-glances/api/main.py
@@ -542,7 +542,7 @@ async def network_interfaces(user=Depends(require_jwt)):
 
 # Service control
 @router.post("/start")
-async def start_glances(user=Depends(require_jwt)):
+def start_glances(user=Depends(require_jwt)):
     """Start glances daemon."""
     try:
         # Start glances in web server mode
@@ -562,7 +562,7 @@ async def start_glances(user=Depends(require_jwt)):
 
 
 @router.post("/stop")
-async def stop_glances(user=Depends(require_jwt)):
+def stop_glances(user=Depends(require_jwt)):
     """Stop glances daemon."""
     try:
         result = subprocess.run(
@@ -581,7 +581,7 @@ async def stop_glances(user=Depends(require_jwt)):
 
 
 @router.post("/restart")
-async def restart_glances(user=Depends(require_jwt)):
+def restart_glances(user=Depends(require_jwt)):
     """Restart glances daemon."""
     try:
         result = subprocess.run(
@@ -657,7 +657,7 @@ async def update_config(config: GlancesConfig, user=Depends(require_jwt)):
 
 
 @router.get("/logs")
-async def get_logs(lines: int = Query(100, ge=1, le=1000), user=Depends(require_jwt)):
+def get_logs(lines: int = Query(100, ge=1, le=1000), user=Depends(require_jwt)):
     """Get glances service logs."""
     try:
         result = subprocess.run(

--- a/packages/secubox-gotosocial/api/main.py
+++ b/packages/secubox-gotosocial/api/main.py
@@ -215,7 +215,7 @@ async def health():
 
 
 @router.get("/status")
-async def status():
+def status():
     """Get GoToSocial service status."""
     cfg = get_config()
     rt = detect_runtime()
@@ -543,7 +543,7 @@ async def remove_allowed_domain(domain: str, user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/media/stats")
-async def get_media_stats(user=Depends(require_jwt)):
+def get_media_stats(user=Depends(require_jwt)):
     """Get media storage statistics."""
     cfg = get_config()
     data_path = Path(cfg.get("data_path", DATA_PATH_DEFAULT))
@@ -701,7 +701,7 @@ async def list_reports(resolved: bool = False, user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/container/status")
-async def container_status(user=Depends(require_jwt)):
+def container_status(user=Depends(require_jwt)):
     """Get container status details."""
     rt = detect_runtime()
     if not rt:
@@ -732,7 +732,7 @@ async def container_status(user=Depends(require_jwt)):
 
 
 @router.post("/container/install")
-async def install_gotosocial(user=Depends(require_jwt)):
+def install_gotosocial(user=Depends(require_jwt)):
     """Install GoToSocial container."""
     rt = detect_runtime()
     if not rt:
@@ -874,7 +874,7 @@ async def update_gotosocial(user=Depends(require_jwt)):
 
 
 @router.post("/container/uninstall")
-async def uninstall_gotosocial(user=Depends(require_jwt)):
+def uninstall_gotosocial(user=Depends(require_jwt)):
     """Uninstall GoToSocial container (preserves data)."""
     rt = detect_runtime()
     if not rt:
@@ -895,7 +895,7 @@ async def uninstall_gotosocial(user=Depends(require_jwt)):
 # ============================================================================
 
 @router.post("/backup")
-async def create_backup(user=Depends(require_jwt)):
+def create_backup(user=Depends(require_jwt)):
     """Create a backup of GoToSocial data."""
     cfg = get_config()
     data_path = Path(cfg.get("data_path", DATA_PATH_DEFAULT))
@@ -930,7 +930,7 @@ async def create_backup(user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/logs")
-async def get_logs(lines: int = 100, user=Depends(require_jwt)):
+def get_logs(lines: int = 100, user=Depends(require_jwt)):
     """Get container logs."""
     rt = detect_runtime()
     if not rt:

--- a/packages/secubox-haproxy/api/main.py
+++ b/packages/secubox-haproxy/api/main.py
@@ -1036,7 +1036,7 @@ class CertBundleRequest(BaseModel):
 
 
 @router.post("/certificates/bundle", dependencies=[Depends(require_jwt)])
-async def create_cert_bundle(req: CertBundleRequest):
+def create_cert_bundle(req: CertBundleRequest):
     """Create HAProxy certificate bundle (cert + key + chain → single PEM)."""
     cert_dir = Path(CERTS_DIR)
     if not cert_dir.exists():
@@ -1157,7 +1157,7 @@ class AcmeRequest(BaseModel):
 
 
 @router.post("/certificates/acme", dependencies=[Depends(require_jwt)])
-async def request_acme_certificate(req: AcmeRequest):
+def request_acme_certificate(req: AcmeRequest):
     """Request certificate via ACME (Let's Encrypt)."""
     cert_dir = Path(CERTS_DIR)
     if not cert_dir.exists():
@@ -1218,7 +1218,7 @@ async def request_acme_certificate(req: AcmeRequest):
 
 
 @router.post("/certificates/{name}/renew", dependencies=[Depends(require_jwt)])
-async def renew_certificate(name: str):
+def renew_certificate(name: str):
     """Renew an existing ACME certificate."""
     try:
         result = subprocess.run(
@@ -1257,7 +1257,7 @@ async def renew_certificate(name: str):
 # ── Auto-Repair ───────────────────────────────────────────────────
 
 @router.post("/repair", dependencies=[Depends(require_jwt)])
-async def repair_haproxy():
+def repair_haproxy():
     """Auto-repair HAProxy: check config, fix vhosts, reload."""
     repairs = []
 
@@ -1303,7 +1303,7 @@ async def repair_haproxy():
 
 
 @router.post("/certificates/repair", dependencies=[Depends(require_jwt)])
-async def repair_certificates():
+def repair_certificates():
     """Auto-repair: renew expiring certificates."""
     cert_dir = Path(CERTS_DIR)
     if not cert_dir.exists():
@@ -1464,7 +1464,7 @@ async def crowdsec_status():
 # ── Actions ───────────────────────────────────────────────────────
 
 @router.post("/reload", dependencies=[Depends(require_jwt)])
-async def reload_haproxy():
+def reload_haproxy():
     """Reload HAProxy."""
     result = subprocess.run(
         ["systemctl", "reload", "haproxy"],
@@ -1475,7 +1475,7 @@ async def reload_haproxy():
 
 
 @router.post("/restart", dependencies=[Depends(require_jwt)])
-async def restart_haproxy():
+def restart_haproxy():
     """Restart HAProxy."""
     result = subprocess.run(
         ["systemctl", "restart", "haproxy"],
@@ -1956,7 +1956,7 @@ async def get_config_backup(name: str, user=Depends(require_jwt)):
 
 
 @router.post("/config/restore/{name}")
-async def restore_config_backup(name: str, user=Depends(require_jwt)):
+def restore_config_backup(name: str, user=Depends(require_jwt)):
     """Restore configuration from backup."""
     backup_path = CONFIG_BACKUP_DIR / name
     if not backup_path.exists():
@@ -2005,7 +2005,7 @@ async def delete_config_backup(name: str, user=Depends(require_jwt)):
 
 
 @router.post("/config/diff")
-async def diff_config(backup_name: str = Query(...), user=Depends(require_jwt)):
+def diff_config(backup_name: str = Query(...), user=Depends(require_jwt)):
     """Compare current config with a backup."""
     backup_path = CONFIG_BACKUP_DIR / backup_name
     if not backup_path.exists():

--- a/packages/secubox-hexo/api/main.py
+++ b/packages/secubox-hexo/api/main.py
@@ -266,7 +266,7 @@ async def health():
 
 
 @router.get("/status")
-async def status():
+def status():
     """Get Hexo service status."""
     cfg = get_config()
     rt = detect_runtime()
@@ -333,7 +333,7 @@ async def get_blogs(user=Depends(require_jwt)):
 
 
 @router.post("/blog/create")
-async def create_blog(blog: BlogCreate, user=Depends(require_jwt)):
+def create_blog(blog: BlogCreate, user=Depends(require_jwt)):
     """Create a new Hexo blog."""
     rt = detect_runtime()
     if not rt:
@@ -730,7 +730,7 @@ async def get_blog_themes(name: str, user=Depends(require_jwt)):
 
 
 @router.post("/blog/{name}/theme/install")
-async def install_theme(name: str, theme: ThemeInstall, user=Depends(require_jwt)):
+def install_theme(name: str, theme: ThemeInstall, user=Depends(require_jwt)):
     """Install a theme."""
     blogs_path = get_blogs_path()
     blog_path = blogs_path / name
@@ -842,7 +842,7 @@ async def get_blog_plugins(name: str, user=Depends(require_jwt)):
 
 
 @router.post("/blog/{name}/plugin/install")
-async def install_plugin(name: str, plugin: PluginInstall, user=Depends(require_jwt)):
+def install_plugin(name: str, plugin: PluginInstall, user=Depends(require_jwt)):
     """Install a plugin."""
     blogs_path = get_blogs_path()
     blog_path = blogs_path / name
@@ -879,7 +879,7 @@ async def install_plugin(name: str, plugin: PluginInstall, user=Depends(require_
 
 
 @router.delete("/blog/{name}/plugin/{plugin_name}")
-async def remove_plugin(name: str, plugin_name: str, user=Depends(require_jwt)):
+def remove_plugin(name: str, plugin_name: str, user=Depends(require_jwt)):
     """Remove a plugin."""
     blogs_path = get_blogs_path()
     blog_path = blogs_path / name
@@ -920,7 +920,7 @@ async def remove_plugin(name: str, plugin_name: str, user=Depends(require_jwt)):
 # ============================================================================
 
 @router.post("/blog/{name}/generate")
-async def generate_blog(name: str, user=Depends(require_jwt)):
+def generate_blog(name: str, user=Depends(require_jwt)):
     """Generate static files."""
     blogs_path = get_blogs_path()
     blog_path = blogs_path / name
@@ -957,7 +957,7 @@ async def generate_blog(name: str, user=Depends(require_jwt)):
 
 
 @router.post("/blog/{name}/clean")
-async def clean_blog(name: str, user=Depends(require_jwt)):
+def clean_blog(name: str, user=Depends(require_jwt)):
     """Clean generated files."""
     blogs_path = get_blogs_path()
     blog_path = blogs_path / name
@@ -991,7 +991,7 @@ async def clean_blog(name: str, user=Depends(require_jwt)):
 
 
 @router.post("/blog/{name}/deploy")
-async def deploy_blog(name: str, config: DeployConfig = None, user=Depends(require_jwt)):
+def deploy_blog(name: str, config: DeployConfig = None, user=Depends(require_jwt)):
     """Deploy the blog."""
     blogs_path = get_blogs_path()
     blog_path = blogs_path / name
@@ -1085,7 +1085,7 @@ async def start_preview(name: str, user=Depends(require_jwt)):
 
 
 @router.post("/blog/{name}/preview/stop")
-async def stop_preview(name: str, user=Depends(require_jwt)):
+def stop_preview(name: str, user=Depends(require_jwt)):
     """Stop preview server."""
     rt = detect_runtime()
     if not rt:
@@ -1104,7 +1104,7 @@ async def stop_preview(name: str, user=Depends(require_jwt)):
 
 
 @router.get("/blog/{name}/preview/status")
-async def get_preview_status(name: str, user=Depends(require_jwt)):
+def get_preview_status(name: str, user=Depends(require_jwt)):
     """Get preview server status."""
     rt = detect_runtime()
     if not rt:
@@ -1141,7 +1141,7 @@ async def container_status(user=Depends(require_jwt)):
 
 
 @router.post("/container/install")
-async def install_container(user=Depends(require_jwt)):
+def install_container(user=Depends(require_jwt)):
     """Pull Node.js image for Hexo."""
     rt = detect_runtime()
     if not rt:
@@ -1170,7 +1170,7 @@ async def install_container(user=Depends(require_jwt)):
 
 
 @router.get("/logs")
-async def get_logs(lines: int = 50, user=Depends(require_jwt)):
+def get_logs(lines: int = 50, user=Depends(require_jwt)):
     """Get container logs."""
     rt = detect_runtime()
     if not rt:

--- a/packages/secubox-homeassistant/api/main.py
+++ b/packages/secubox-homeassistant/api/main.py
@@ -704,7 +704,7 @@ async def install_addon(
 
 
 @router.post("/hacs/install")
-async def install_hacs(user=Depends(require_jwt)):
+def install_hacs(user=Depends(require_jwt)):
     """Install HACS (Home Assistant Community Store)."""
     if not is_running():
         raise HTTPException(503, "Home Assistant not running")
@@ -741,7 +741,7 @@ async def install_hacs(user=Depends(require_jwt)):
 # ============================================================================
 
 @router.post("/backup/create")
-async def create_backup(
+def create_backup(
     req: BackupCreate,
     user=Depends(require_jwt)
 ):
@@ -798,7 +798,7 @@ async def list_backups(user=Depends(require_jwt)):
 
 
 @router.post("/backup/restore")
-async def restore_backup(path: str = Query(...), user=Depends(require_jwt)):
+def restore_backup(path: str = Query(...), user=Depends(require_jwt)):
     """Restore from backup."""
     backup_path = Path(path)
     if not backup_path.exists():
@@ -837,7 +837,7 @@ async def restore_backup(path: str = Query(...), user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/container/status")
-async def container_status(user=Depends(require_jwt)):
+def container_status(user=Depends(require_jwt)):
     """Get container/LXC status."""
     rt = detect_runtime()
     cfg = get_config()
@@ -882,7 +882,7 @@ async def container_status(user=Depends(require_jwt)):
 
 
 @router.post("/container/install")
-async def install_container(user=Depends(require_jwt)):
+def install_container(user=Depends(require_jwt)):
     """Pull Home Assistant container image or create LXC."""
     rt = detect_runtime()
     cfg = get_config()
@@ -1047,7 +1047,7 @@ async def restart_container(user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/logs")
-async def get_logs(lines: int = 100, user=Depends(require_jwt)):
+def get_logs(lines: int = 100, user=Depends(require_jwt)):
     """Get recent logs."""
     rt = detect_runtime()
     cfg = get_config()

--- a/packages/secubox-hub/api/main.py
+++ b/packages/secubox-hub/api/main.py
@@ -174,7 +174,7 @@ async def public_menu():
 
 
 @public_router.get("/info")
-async def public_info():
+def public_info():
     """Public info endpoint for login page (no auth required)."""
     # Get version from build-info.json
     version = "1.7.0"
@@ -699,7 +699,7 @@ async def security_summary(user=Depends(require_jwt)):
 
 
 @router.get("/network_summary")
-async def network_summary(user=Depends(require_jwt)):
+def network_summary(user=Depends(require_jwt)):
     """Résumé réseau with IP addresses."""
     import json
 
@@ -772,7 +772,7 @@ class ActionRequest(BaseModel):
 
 
 @router.post("/execute_action")
-async def execute_action(req: ActionRequest, user=Depends(require_jwt)):
+def execute_action(req: ActionRequest, user=Depends(require_jwt)):
     if req.action == "restart_services":
         for svc in list(MODULES.values())[:5]:
             subprocess.run(["systemctl", "restart", svc], capture_output=True)
@@ -844,7 +844,7 @@ async def set_theme(req: ThemeRequest, user=Depends(require_jwt)):
 
 
 @router.get("/version")
-async def version(user=Depends(require_jwt)):
+def version(user=Depends(require_jwt)):
     """Version SecuBox."""
     r = subprocess.run(["dpkg", "-l", "secubox-hub"], capture_output=True, text=True)
     version_str = "1.0.0"
@@ -878,7 +878,7 @@ class ServiceActionRequest(BaseModel):
 
 
 @router.post("/module_control")
-async def module_control(req: ServiceActionRequest, user=Depends(require_jwt)):
+def module_control(req: ServiceActionRequest, user=Depends(require_jwt)):
     """Contrôler un module."""
     if req.module not in MODULES:
         return {"success": False, "error": "Module inconnu"}
@@ -899,7 +899,7 @@ async def module_status(module: str, user=Depends(require_jwt)):
 
 
 @router.get("/module_logs")
-async def module_logs(module: str, lines: int = 50, user=Depends(require_jwt)):
+def module_logs(module: str, lines: int = 50, user=Depends(require_jwt)):
     """Logs d'un module."""
     if module not in MODULES:
         return {"error": "Module inconnu"}
@@ -928,7 +928,7 @@ async def uptime(user=Depends(require_jwt)):
 
 
 @router.get("/boot_mode")
-async def boot_mode(user=Depends(require_jwt)):
+def boot_mode(user=Depends(require_jwt)):
     """Get current boot mode (kiosk or console)."""
     kiosk_enabled = Path("/var/lib/secubox/.kiosk-enabled").exists()
     kiosk_running = False
@@ -954,7 +954,7 @@ async def boot_mode(user=Depends(require_jwt)):
 
 
 @router.get("/auth_mode")
-async def auth_mode(user=Depends(require_jwt)):
+def auth_mode(user=Depends(require_jwt)):
     """Get current authentication mode (ZKP or standard)."""
     # Check if ZKP authentication is enabled
     zkp_enabled = False
@@ -1089,7 +1089,7 @@ async def save_preferences(req: PreferencesRequest, user=Depends(require_jwt)):
 
 
 @router.get("/logs")
-async def logs(lines: int = 100, user=Depends(require_jwt)):
+def logs(lines: int = 100, user=Depends(require_jwt)):
     """Logs système."""
     r = subprocess.run(
         ["journalctl", "-n", str(lines), "--no-pager", "-o", "short"],
@@ -1099,7 +1099,7 @@ async def logs(lines: int = 100, user=Depends(require_jwt)):
 
 
 @router.get("/check_updates")
-async def check_updates(user=Depends(require_jwt)):
+def check_updates(user=Depends(require_jwt)):
     """Vérifier les mises à jour."""
     subprocess.run(["apt", "update"], capture_output=True)
     r = subprocess.run(["apt", "list", "--upgradable"], capture_output=True, text=True)
@@ -2051,7 +2051,7 @@ def _trigger_cache_refresh() -> None:
 
 
 @public_router.get("/firewall_summary")
-async def firewall_summary():
+def firewall_summary():
     """nftables stats for the SOC dashboard widget.
 
     Strategy: fresh cache → realtime → stale cache.

--- a/packages/secubox-hub/api/main.py
+++ b/packages/secubox-hub/api/main.py
@@ -153,24 +153,29 @@ def _load_menu_cache_from_file() -> dict:
 @public_router.get("/menu")
 async def public_menu():
     """Public menu endpoint for sidebar navigation (no auth required).
-    Returns basic menu structure without sensitive data.
-    Uses pre-computed cache for instant response.
+
+    Double-buffer cache: ALWAYS returns the current snapshot instantly and never
+    computes on the request path (a sync systemctl walk here, multiplied by the
+    sidebar's polling, is what froze the shared aggregator loop). The background
+    refresher — kicked here because mounted sub-apps get no startup/middleware —
+    fills the buffer within a few seconds; until then we serve the file snapshot
+    or an explicit `warming` placeholder.
     """
     global _menu_cache
+    _ensure_bg()
 
-    # Return from in-memory cache (instant)
+    # Active buffer (instant).
     if _menu_cache:
         return _menu_cache
 
-    # Fallback to file cache (fast startup)
+    # Cold start: last-good snapshot persisted to file (cheap read, no systemctl).
     file_cache = _load_menu_cache_from_file()
     if file_cache:
         _menu_cache = file_cache
         return file_cache
 
-    # Last resort: compute synchronously (only on first request before cache ready)
-    log.warning("Menu cache miss - computing synchronously")
-    return _compute_menu_sync()
+    # Nothing yet — never block; the background task will fill it shortly.
+    return {"categories": [], "total_installed": 0, "total_active": 0, "warming": True}
 
 
 @public_router.get("/info")
@@ -262,22 +267,20 @@ async def public_led_status():
 
 @public_router.get("/health-batch")
 async def public_health_batch():
-    """Batch health check for all modules — returns status for sidebar LEDs.
+    """Batch health snapshot for the sidebar LEDs.
 
-    Serves the TTL snapshot built by the background loop; on a cold miss it
-    builds it ONCE off the event loop. Never makes a synchronous systemctl call
-    on the request path.
+    Double-buffer cache: returns the last fully-built snapshot instantly and
+    NEVER rebuilds on the request path. The previous cold-miss rebuilt under a
+    lock, so concurrent sidebar polls serialized behind a ~3 s systemctl walk
+    and starved the shared loop. The background refresher (kicked here) swaps in
+    a complete snapshot atomically — so we never serve partial/bad counts.
     """
+    _ensure_bg()
     hb = _cache.get("health_batch")
-    if hb and (time.time() - _cache.get("health_batch_ts", 0)) < CACHE_TTL * 2:
+    if hb:
         return hb
-    async with _health_batch_lock:
-        # Re-check under the lock: a concurrent waiter may have just rebuilt it.
-        hb = _cache.get("health_batch")
-        if not hb or (time.time() - _cache.get("health_batch_ts", 0)) >= CACHE_TTL * 2:
-            await asyncio.to_thread(_refresh_health_batch)
-            hb = _cache.get("health_batch") or {"modules": {}, "count": 0}
-    return hb
+    # Not warmed yet — serve an explicit placeholder rather than block/compute.
+    return {"modules": {}, "count": 0, "warming": True}
 
 
 app.include_router(public_router)
@@ -503,17 +506,27 @@ async def startup():
     await _start_background_once()
 
 
+def _ensure_bg() -> None:
+    """Reliably kick the background warm-up + refresh loops from the request path.
+
+    Mounted in the aggregator, a sub-app receives neither startup/lifespan nor
+    `@app.middleware` events — so the navbar status endpoints trigger the warm-up
+    themselves on first hit. Fire-and-forget: never blocks or delays the request.
+    Idempotent (``_start_background_once`` guards on ``_bg_started``).
+    """
+    if _bg_started:
+        return
+    try:
+        asyncio.create_task(_start_background_once())
+    except RuntimeError:
+        # No running loop yet (e.g. import time) — a later request retries.
+        pass
+
+
+# Kept for the standalone-uvicorn path; harmless (no-op) when mounted.
 @app.middleware("http")
 async def _lazy_background_start(request, call_next):
-    """Kick the background warm-up on the first request.
-
-    Mounted sub-apps don't receive startup/lifespan events under the aggregator,
-    so the cache would otherwise stay cold and every _svc() would fall back to a
-    blocking per-module systemctl call. Fire-and-forget so this request isn't
-    delayed by the warm-up.
-    """
-    if not _bg_started:
-        asyncio.create_task(_start_background_once())
+    _ensure_bg()
     return await call_next(request)
 
 

--- a/packages/secubox-hub/www/health/health.css
+++ b/packages/secubox-hub/www/health/health.css
@@ -39,10 +39,10 @@ h2 { font-size: 16px; font-weight: 600; margin: var(--sp-xl) 0 var(--sp-m); }
 .svc-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: var(--sp-s); }
 .svc { display: flex; align-items: center; gap: var(--sp-s); background: var(--bg1); border: 1px solid var(--bd);
     border-radius: 8px; padding: 10px 12px; min-width: 0; }
-.svc .led { width: 9px; height: 9px; border-radius: 50%; flex: none; box-shadow: 0 0 6px currentColor; }
-.svc.ok .led { background: #2ecc8f; color: #2ecc8f; }
-.svc.warn .led, .svc.unknown .led { background: #f0b94c; color: #f0b94c; }
-.svc.error .led { background: #ff7a6b; color: #ff7a6b; animation: pulse 1.2s infinite; }
+/* .led now carries the status emoji (🟢🟡🔴) instead of a CSS dot. */
+.svc .led { flex: none; width: auto; height: auto; background: none; box-shadow: none;
+    font-size: 14px; line-height: 1; font-family: "Noto Color Emoji", "Apple Color Emoji", sans-serif; }
+.svc.error .led { animation: pulse 1.2s infinite; }
 @keyframes pulse { 50% { opacity: .4; } }
 .svc.error { border-left: 3px solid #803018; }
 .svc-name { font-weight: 600; font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/packages/secubox-hub/www/health/health.js
+++ b/packages/secubox-hub/www/health/health.js
@@ -25,11 +25,15 @@
         return r.json();
     }
 
+    // Status → emoji indicator (replaces the CSS LED dot).
+    const EMOJI = { ok: '🟢', warn: '🟡', error: '🔴', unknown: '⚪' };
+    const emo = (status) => EMOJI[status] || EMOJI.unknown;
+
     function chip(id, st) {
         const status = (st && st.status) || 'unknown';
         const msg = (st && st.msg) || '';
         return `<div class="svc ${status}" title="${esc(id)}: ${esc(msg)}">
-            <span class="led"></span>
+            <span class="led">${emo(status)}</span>
             <span class="svc-name">${esc(id)}</span>
             <span class="svc-msg">${esc(msg)}</span>
         </div>`;
@@ -44,10 +48,10 @@
         });
 
         $('summary').innerHTML =
-            `<div class="sum ok"><b>${ok}</b><span>healthy</span></div>` +
-            `<div class="sum warn"><b>${warn}</b><span>degraded</span></div>` +
-            `<div class="sum err"><b>${err}</b><span>down</span></div>` +
-            `<div class="sum total"><b>${ids.length}</b><span>services</span></div>`;
+            `<div class="sum ok"><b>${ok}</b><span>🟢 healthy</span></div>` +
+            `<div class="sum warn"><b>${warn}</b><span>🟡 degraded</span></div>` +
+            `<div class="sum err"><b>${err}</b><span>🔴 down</span></div>` +
+            `<div class="sum total"><b>${ids.length}</b><span>📊 services</span></div>`;
 
         const vital = ids.filter((id) => VITAL_SET.has(id));
         const common = ids.filter((id) => !VITAL_SET.has(id));

--- a/packages/secubox-hub/www/shared/sidebar.js
+++ b/packages/secubox-hub/www/shared/sidebar.js
@@ -1711,26 +1711,31 @@
             // If already ok/warn/error, keep that status until new result arrives
         });
 
-        for (var i = 0; i < modules.length; i += BATCH_SIZE) {
-            var batch = modules.slice(i, i + BATCH_SIZE);
-            var results = await Promise.allSettled(batch.map(function(mod) {
-                return checkModuleHealth(mod);
-            }));
-
-            results.forEach(function(result, idx) {
-                var mod = batch[idx];
-                if (result.status === 'fulfilled') {
-                    healthCache[mod] = result.value;
-                } else {
-                    healthCache[mod] = { status: 'error', msg: 'Check failed', timestamp: Date.now() };
-                }
-            });
-
-            // Update LEDs after each batch
-            updateAllLEDs();
-        }
-
+        // #740: ONE batch call instead of one /api/v1/<mod>/health per module.
+        // The per-module loop fired ~119 requests every cycle and hammered the
+        // aggregator's single shared event loop (board-wide 502s). The hub batch
+        // endpoint returns every module's status in a single hit.
+        await applyHealthBatch(modules);
         return healthCache;
+    }
+
+    // Populate healthCache for `modules` from the single hub batch endpoint
+    // (/api/v1/hub/public/health-batch — served by the dedicated hub process,
+    // double-buffered). Replaces the per-module health storm.
+    async function applyHealthBatch(modules) {
+        var token = localStorage.getItem('sbx_token');
+        var headers = token ? { 'Authorization': 'Bearer ' + token } : {};
+        var res = await safeFetch(BATCH_HEALTH_API, { headers: headers }, 5000);
+        if (!res.ok || !res.data || !res.data.modules) return;
+        var mods = res.data.modules;
+        modules.forEach(function(mod) {
+            var hb = mods[mod] || mods[mod.replace(/_/g, '-')] || mods[mod.replace(/-/g, '_')];
+            healthCache[mod] = hb
+                ? { status: hb.status, msg: hb.msg || '', timestamp: Date.now() }
+                : { status: 'unknown', msg: 'no health API', timestamp: Date.now() };
+        });
+        updateAllLEDs();
+        try { savePreCache(healthCache); } catch (e) {}
     }
 
     async function refreshStaleHealth() {
@@ -1744,17 +1749,9 @@
 
         if (stale.length === 0) return;
 
-        // Incremental update - update each LED as result comes in
-        for (var i = 0; i < stale.length; i += BATCH_SIZE) {
-            var batch = stale.slice(i, i + BATCH_SIZE);
-            await Promise.allSettled(batch.map(async function(mod) {
-                var result = await checkModuleHealth(mod);
-                healthCache[mod] = result;
-                // Update single LED immediately
-                var item = document.querySelector('.nav-item[data-module="' + mod + '"]');
-                if (item) updateSingleLED(item, result);
-            }));
-        }
+        // #740: refresh stale modules via the single batch endpoint, not one
+        // /health request per module.
+        await applyHealthBatch(stale);
 
         // Save cache once at end, no re-sort needed
         savePreCache(healthCache);

--- a/packages/secubox-identity/api/main.py
+++ b/packages/secubox-identity/api/main.py
@@ -706,7 +706,7 @@ async def sign_message(message: str):
 
 
 @app.post("/identity/verify", dependencies=[Depends(require_jwt)])
-async def verify_signature(message: str, signature: str, public_key: str):
+def verify_signature(message: str, signature: str, public_key: str):
     """Verify a signature."""
     valid = identity_manager.verify(message, signature, public_key)
     return {"valid": valid}

--- a/packages/secubox-iot-guard/api/main.py
+++ b/packages/secubox-iot-guard/api/main.py
@@ -999,7 +999,7 @@ async def probe_mesh_device(ip_address: str):
 
 
 @app.post("/discover/full", dependencies=[Depends(require_jwt)])
-async def full_discovery(
+def full_discovery(
     network: Optional[str] = None,
     include_mesh: bool = True,
     use_arping: bool = True,
@@ -1377,7 +1377,7 @@ async def find_cast_devices():
 
 
 @app.get("/cast/diagnose/{ip_address}", dependencies=[Depends(require_jwt)])
-async def diagnose_cast_device(ip_address: str):
+def diagnose_cast_device(ip_address: str):
     """Run full diagnostic on a Cast device.
 
     Checks:
@@ -1459,7 +1459,7 @@ async def diagnose_cast_device(ip_address: str):
 
 
 @app.post("/cast/whitelist/{ip_address}", dependencies=[Depends(require_jwt)])
-async def whitelist_cast_device(ip_address: str, apply_crowdsec: bool = True):
+def whitelist_cast_device(ip_address: str, apply_crowdsec: bool = True):
     """Whitelist a Cast device in CrowdSec.
 
     Args:
@@ -1493,7 +1493,7 @@ async def whitelist_cast_device(ip_address: str, apply_crowdsec: bool = True):
 
 
 @app.get("/cast/capture/{ip_address}", dependencies=[Depends(require_jwt)])
-async def start_cast_capture(ip_address: str, duration: int = 60):
+def start_cast_capture(ip_address: str, duration: int = 60):
     """Start a packet capture for Cast device debugging.
 
     Args:

--- a/packages/secubox-jellyfin/api/main.py
+++ b/packages/secubox-jellyfin/api/main.py
@@ -176,7 +176,7 @@ async def health():
 
 
 @router.get("/status")
-async def status():
+def status():
     """Get Jellyfin service status."""
     cfg = get_config()
     rt = detect_runtime()
@@ -315,7 +315,7 @@ async def remove_media_path(media_id: str, user=Depends(require_jwt)):
 # ============================================================================
 
 @router.post("/install")
-async def install_jellyfin(user=Depends(require_jwt)):
+def install_jellyfin(user=Depends(require_jwt)):
     """Install Jellyfin container."""
     rt = detect_runtime()
     if not rt:
@@ -435,7 +435,7 @@ async def restart_jellyfin(user=Depends(require_jwt)):
 
 
 @router.post("/uninstall")
-async def uninstall_jellyfin(user=Depends(require_jwt)):
+def uninstall_jellyfin(user=Depends(require_jwt)):
     """Uninstall Jellyfin container."""
     rt = detect_runtime()
     if not rt:
@@ -485,7 +485,7 @@ async def update_jellyfin(user=Depends(require_jwt)):
 # ============================================================================
 
 @router.post("/backup")
-async def backup_jellyfin(user=Depends(require_jwt)):
+def backup_jellyfin(user=Depends(require_jwt)):
     """Backup Jellyfin configuration."""
     cfg = get_config()
     data_path = Path(cfg.get("data_path", "/srv/jellyfin"))
@@ -542,7 +542,7 @@ async def restore_jellyfin(req: RestoreRequest, user=Depends(require_jwt)):
 
 
 @router.get("/logs")
-async def get_logs(lines: int = 50, user=Depends(require_jwt)):
+def get_logs(lines: int = 50, user=Depends(require_jwt)):
     """Get container logs."""
     rt = detect_runtime()
     if not rt:

--- a/packages/secubox-jitsi/api/main.py
+++ b/packages/secubox-jitsi/api/main.py
@@ -426,7 +426,7 @@ async def health():
 
 
 @router.get("/status")
-async def status(user=Depends(require_jwt)):
+def status(user=Depends(require_jwt)):
     """Get Jitsi Meet comprehensive status."""
     cfg = get_config()
     rt = detect_runtime()
@@ -669,7 +669,7 @@ async def set_auth_config(auth: AuthConfig, user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/prosody/status")
-async def prosody_status(user=Depends(require_jwt)):
+def prosody_status(user=Depends(require_jwt)):
     """Get Prosody XMPP server status."""
     container = get_container_status(JITSI_CONTAINERS["prosody"])
 
@@ -734,7 +734,7 @@ async def enable_jibri(user=Depends(require_jwt)):
 
 
 @router.post("/jibri/disable")
-async def disable_jibri(user=Depends(require_jwt)):
+def disable_jibri(user=Depends(require_jwt)):
     """Disable Jibri recording service."""
     cfg = get_config()
     cfg["jibri_enabled"] = False
@@ -858,7 +858,7 @@ async def restart_jitsi(user=Depends(require_jwt)):
 
 
 @router.post("/container/uninstall")
-async def uninstall_jitsi(user=Depends(require_jwt)):
+def uninstall_jitsi(user=Depends(require_jwt)):
     """Uninstall Jitsi (keeps data)."""
     log.info(f"Uninstalling Jitsi by {user.get('sub', 'unknown')}")
 
@@ -880,7 +880,7 @@ async def uninstall_jitsi(user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/logs")
-async def get_logs(
+def get_logs(
     service: str = Query("web", enum=["web", "prosody", "jicofo", "jvb", "jibri"]),
     lines: int = Query(100, ge=10, le=1000),
     user=Depends(require_jwt)

--- a/packages/secubox-localai/api/main.py
+++ b/packages/secubox-localai/api/main.py
@@ -433,7 +433,7 @@ systemctl start localai
 
 
 @app.delete("/uninstall", dependencies=[Depends(require_jwt)])
-async def uninstall_localai():
+def uninstall_localai():
     """Remove LocalAI LXC container."""
     if lxc_running():
         subprocess.run(["lxc-stop", "-n", LXC_NAME], capture_output=True, timeout=30)

--- a/packages/secubox-mac-guard/api/main.py
+++ b/packages/secubox-mac-guard/api/main.py
@@ -475,7 +475,7 @@ async def health():
 
 
 @router.get("/status")
-async def status(user=Depends(require_jwt)):
+def status(user=Depends(require_jwt)):
     """Get MAC Guard status."""
     cached = stats_cache.get("status")
     if cached:
@@ -853,7 +853,7 @@ async def get_unknown(user=Depends(require_jwt)):
 
 # Scan endpoint
 @router.post("/scan")
-async def scan_network(background_tasks: BackgroundTasks, user=Depends(require_jwt)):
+def scan_network(background_tasks: BackgroundTasks, user=Depends(require_jwt)):
     """Trigger network scan."""
     try:
         # Use arping or nmap if available

--- a/packages/secubox-matrix/api/main.py
+++ b/packages/secubox-matrix/api/main.py
@@ -316,7 +316,7 @@ async def status(user=Depends(require_jwt)):
 # ══════════════════════════════════════════════════════════════════
 
 @app.post("/install")
-async def install(
+def install(
     server_name: str = Query(..., description="Matrix server domain"),
     user=Depends(require_jwt)
 ):
@@ -457,7 +457,7 @@ async def restart(user=Depends(require_jwt)):
 
 
 @app.delete("/uninstall")
-async def uninstall(user=Depends(require_jwt)):
+def uninstall(user=Depends(require_jwt)):
     """Remove Matrix container (keeps data)."""
     if lxc_running():
         lxc_stop()
@@ -781,7 +781,7 @@ pip3 install mautrix-{bridge_id}
 # ══════════════════════════════════════════════════════════════════
 
 @app.post("/backup")
-async def create_backup(user=Depends(require_jwt)):
+def create_backup(user=Depends(require_jwt)):
     """Create Matrix data backup."""
     backup_dir = Path("/var/lib/secubox/backups/matrix")
     backup_dir.mkdir(parents=True, exist_ok=True)

--- a/packages/secubox-mediaflow/api/main.py
+++ b/packages/secubox-mediaflow/api/main.py
@@ -579,25 +579,25 @@ async def update_settings(req: SettingsRequest, user=Depends(require_jwt)):
 
 # DPI service control
 @router.post("/start_netifyd")
-async def start_netifyd(user=Depends(require_jwt)):
+def start_netifyd(user=Depends(require_jwt)):
     r = subprocess.run(["systemctl", "start", "netifyd"], capture_output=True, text=True)
     return {"success": r.returncode == 0}
 
 
 @router.post("/stop_netifyd")
-async def stop_netifyd(user=Depends(require_jwt)):
+def stop_netifyd(user=Depends(require_jwt)):
     r = subprocess.run(["systemctl", "stop", "netifyd"], capture_output=True, text=True)
     return {"success": r.returncode == 0}
 
 
 @router.post("/start_ndpid")
-async def start_ndpid(user=Depends(require_jwt)):
+def start_ndpid(user=Depends(require_jwt)):
     r = subprocess.run(["systemctl", "start", "ndpid"], capture_output=True, text=True)
     return {"success": r.returncode == 0}
 
 
 @router.post("/stop_ndpid")
-async def stop_ndpid(user=Depends(require_jwt)):
+def stop_ndpid(user=Depends(require_jwt)):
     r = subprocess.run(["systemctl", "stop", "ndpid"], capture_output=True, text=True)
     return {"success": r.returncode == 0}
 

--- a/packages/secubox-meshname/api/main.py
+++ b/packages/secubox-meshname/api/main.py
@@ -269,7 +269,7 @@ async def get_service_status():
 
 
 @app.post("/enable", dependencies=[Depends(require_jwt)])
-async def enable_meshname(enabled: bool = True):
+def enable_meshname(enabled: bool = True):
     """Enable or disable mesh DNS."""
     state = _load_state()
     state["enabled"] = enabled
@@ -468,7 +468,7 @@ async def set_config(mesh_config: MeshConfig):
 
 
 @app.get("/resolve/{hostname}", dependencies=[Depends(require_jwt)])
-async def resolve_hostname(hostname: str):
+def resolve_hostname(hostname: str):
     """Resolve a hostname through mesh DNS."""
     state = _load_state()
     mesh_domain = state.get("mesh_domain", "mesh.local")

--- a/packages/secubox-metablogizer/api/main.py
+++ b/packages/secubox-metablogizer/api/main.py
@@ -428,7 +428,7 @@ async def get_access():
 
 
 @app.get("/access/detailed")
-async def get_access_detailed():
+def get_access_detailed():
     """Get all published sites with certificate info and sizes"""
     import subprocess
     from datetime import datetime
@@ -1178,7 +1178,7 @@ async def get_site_cert(name: str):
 
 
 @app.get("/site/{name}/certificate", dependencies=[Depends(require_jwt)])
-async def get_certificate_info(name: str):
+def get_certificate_info(name: str):
     """Get certificate information for a site"""
     import subprocess
     from datetime import datetime

--- a/packages/secubox-mirror/api/main.py
+++ b/packages/secubox-mirror/api/main.py
@@ -318,7 +318,7 @@ async def cache_stats(user=Depends(require_jwt)):
 
 
 @router.post("/cache/purge")
-async def cache_purge(path: str = "", user=Depends(require_jwt)):
+def cache_purge(path: str = "", user=Depends(require_jwt)):
     """Purge cache - all or specific path."""
     if not path:
         # Purge entire cache

--- a/packages/secubox-nac/api/main.py
+++ b/packages/secubox-nac/api/main.py
@@ -723,7 +723,7 @@ async def ban_client(mac: str, user=Depends(require_jwt)):
 
 
 @router.post("/unban_client")
-async def unban_client(mac: str, user=Depends(require_jwt)):
+def unban_client(mac: str, user=Depends(require_jwt)):
     """Unban a client."""
     mac_lower = mac.lower()
 
@@ -860,7 +860,7 @@ async def get_history(limit: int = 100, mac: Optional[str] = None, user=Depends(
 
 
 @router.get("/logs")
-async def logs(lines: int = 100, user=Depends(require_jwt)):
+def logs(lines: int = 100, user=Depends(require_jwt)):
     """Get dnsmasq logs."""
     try:
         r = subprocess.run(
@@ -998,7 +998,7 @@ async def set_parental_rule_compat(req: ParentalRule, user=Depends(require_jwt))
 
 
 @router.get("/sync_zones")
-async def sync_zones(user=Depends(require_jwt)):
+def sync_zones(user=Depends(require_jwt)):
     for zone_id, info in ZONES.items():
         subprocess.run(
             ["nft", "add", "set", "inet", "secubox_nac", info["nft_set"],

--- a/packages/secubox-ndpid/api/main.py
+++ b/packages/secubox-ndpid/api/main.py
@@ -779,28 +779,28 @@ async def get_realtime_stats():
 # ============================================================================
 
 @app.post("/control/start", dependencies=[Depends(require_jwt)])
-async def start_ndpid():
+def start_ndpid():
     """Start nDPId daemon."""
     result = subprocess.run(["systemctl", "start", "ndpid"], capture_output=True, text=True)
     return {"success": result.returncode == 0, "error": result.stderr if result.returncode != 0 else None}
 
 
 @app.post("/control/stop", dependencies=[Depends(require_jwt)])
-async def stop_ndpid():
+def stop_ndpid():
     """Stop nDPId daemon."""
     result = subprocess.run(["systemctl", "stop", "ndpid"], capture_output=True, text=True)
     return {"success": result.returncode == 0}
 
 
 @app.post("/control/restart", dependencies=[Depends(require_jwt)])
-async def restart_ndpid():
+def restart_ndpid():
     """Restart nDPId daemon."""
     result = subprocess.run(["systemctl", "restart", "ndpid"], capture_output=True, text=True)
     return {"success": result.returncode == 0, "error": result.stderr if result.returncode != 0 else None}
 
 
 @app.get("/logs", dependencies=[Depends(require_jwt)])
-async def get_logs(lines: int = 100):
+def get_logs(lines: int = 100):
     """Get nDPId daemon logs."""
     result = subprocess.run(
         ["journalctl", "-u", "ndpid", "-n", str(lines), "--no-pager"],
@@ -853,7 +853,7 @@ async def save_settings(settings: NDPIdSettings):
 
 
 @app.get("/interfaces", dependencies=[Depends(require_jwt)])
-async def list_interfaces():
+def list_interfaces():
     """List available network interfaces."""
     result = subprocess.run(["ip", "-j", "link", "show"], capture_output=True, text=True)
     try:
@@ -873,7 +873,7 @@ async def list_interfaces():
 # ============================================================================
 
 @app.get("/mirred/status", dependencies=[Depends(require_jwt)])
-async def mirred_status():
+def mirred_status():
     """Get tc mirred status."""
     cfg = get_config("ndpid")
     iface = cfg.get("interface", "eth0")
@@ -890,7 +890,7 @@ async def mirred_status():
 
 
 @app.post("/mirred/setup", dependencies=[Depends(require_jwt)])
-async def setup_mirred():
+def setup_mirred():
     """Setup tc mirred for DPI."""
     cfg = get_config("ndpid")
     iface = cfg.get("interface", "eth0")
@@ -917,7 +917,7 @@ async def setup_mirred():
 
 
 @app.post("/mirred/remove", dependencies=[Depends(require_jwt)])
-async def remove_mirred():
+def remove_mirred():
     """Remove tc mirred configuration."""
     cfg = get_config("ndpid")
     iface = cfg.get("interface", "eth0")

--- a/packages/secubox-netdiag/api/main.py
+++ b/packages/secubox-netdiag/api/main.py
@@ -86,7 +86,7 @@ class PingRequest(BaseModel):
 
 
 @router.post("/ping")
-async def ping(req: PingRequest, user=Depends(require_jwt)):
+def ping(req: PingRequest, user=Depends(require_jwt)):
     """Ping a host and return results."""
     # Validate host - basic sanitization
     host = _sanitize_host(req.host)
@@ -157,7 +157,7 @@ class TracerouteRequest(BaseModel):
 
 
 @router.post("/traceroute")
-async def traceroute(req: TracerouteRequest, user=Depends(require_jwt)):
+def traceroute(req: TracerouteRequest, user=Depends(require_jwt)):
     """Traceroute to a host."""
     host = _sanitize_host(req.host)
     if not host:
@@ -217,7 +217,7 @@ class DNSRequest(BaseModel):
 
 
 @router.post("/dns")
-async def dns_lookup(req: DNSRequest, user=Depends(require_jwt)):
+def dns_lookup(req: DNSRequest, user=Depends(require_jwt)):
     """DNS lookup for a domain."""
     domain = _sanitize_host(req.domain)
     if not domain:
@@ -268,7 +268,7 @@ class WhoisRequest(BaseModel):
 
 
 @router.post("/whois")
-async def whois_lookup(req: WhoisRequest, user=Depends(require_jwt)):
+def whois_lookup(req: WhoisRequest, user=Depends(require_jwt)):
     """WHOIS lookup for a domain or IP."""
     target = _sanitize_host(req.target)
     if not target:
@@ -322,7 +322,7 @@ def _parse_whois(output: str) -> dict:
 # ══════════════════════════════════════════════════════════════════
 
 @router.get("/ports")
-async def list_ports(user=Depends(require_jwt)):
+def list_ports(user=Depends(require_jwt)):
     """List listening ports on the system."""
     try:
         result = subprocess.run(
@@ -507,7 +507,7 @@ def _is_local_network(host: str) -> bool:
 # ══════════════════════════════════════════════════════════════════
 
 @router.get("/interfaces")
-async def interfaces(user=Depends(require_jwt)):
+def interfaces(user=Depends(require_jwt)):
     """List network interfaces with details."""
     try:
         result = subprocess.run(
@@ -564,7 +564,7 @@ async def interfaces(user=Depends(require_jwt)):
 # ══════════════════════════════════════════════════════════════════
 
 @router.get("/routes")
-async def routes(user=Depends(require_jwt)):
+def routes(user=Depends(require_jwt)):
     """Show routing table."""
     try:
         result = subprocess.run(
@@ -597,7 +597,7 @@ async def routes(user=Depends(require_jwt)):
 # ══════════════════════════════════════════════════════════════════
 
 @router.get("/arp")
-async def arp_table(user=Depends(require_jwt)):
+def arp_table(user=Depends(require_jwt)):
     """Show ARP table."""
     try:
         result = subprocess.run(
@@ -632,7 +632,7 @@ async def arp_table(user=Depends(require_jwt)):
 # ══════════════════════════════════════════════════════════════════
 
 @router.get("/connections")
-async def connections(user=Depends(require_jwt)):
+def connections(user=Depends(require_jwt)):
     """Show active network connections."""
     try:
         result = subprocess.run(
@@ -684,7 +684,7 @@ class MTRRequest(BaseModel):
 
 
 @router.post("/mtr")
-async def mtr(req: MTRRequest, user=Depends(require_jwt)):
+def mtr(req: MTRRequest, user=Depends(require_jwt)):
     """Run MTR (My Traceroute) to a host."""
     host = _sanitize_host(req.host)
     if not host:
@@ -747,7 +747,7 @@ class NmapRequest(BaseModel):
 
 
 @router.post("/nmap")
-async def nmap_scan(req: NmapRequest, user=Depends(require_jwt)):
+def nmap_scan(req: NmapRequest, user=Depends(require_jwt)):
     """Run basic nmap scan on a host (local network only)."""
     host = _sanitize_host(req.host)
     if not host:
@@ -815,7 +815,7 @@ class BandwidthRequest(BaseModel):
 
 
 @router.post("/bandwidth")
-async def run_bandwidth(req: BandwidthRequest, user=Depends(require_jwt)):
+def run_bandwidth(req: BandwidthRequest, user=Depends(require_jwt)):
     """Run bandwidth test using iperf3."""
     if not _tool_available("iperf3"):
         raise HTTPException(503, "iperf3 not installed")

--- a/packages/secubox-netifyd/api/main.py
+++ b/packages/secubox-netifyd/api/main.py
@@ -388,7 +388,7 @@ async def get_status():
 # =============================================================================
 
 @app.post("/start", dependencies=[Depends(require_jwt)])
-async def start_service():
+def start_service():
     """Start netifyd daemon."""
     result = subprocess.run(
         ["systemctl", "start", "netifyd"],
@@ -402,7 +402,7 @@ async def start_service():
 
 
 @app.post("/stop", dependencies=[Depends(require_jwt)])
-async def stop_service():
+def stop_service():
     """Stop netifyd daemon."""
     result = subprocess.run(
         ["systemctl", "stop", "netifyd"],
@@ -416,7 +416,7 @@ async def stop_service():
 
 
 @app.post("/restart", dependencies=[Depends(require_jwt)])
-async def restart_service():
+def restart_service():
     """Restart netifyd daemon."""
     result = subprocess.run(
         ["systemctl", "restart", "netifyd"],
@@ -650,7 +650,7 @@ async def clear_alerts():
 # =============================================================================
 
 @app.get("/logs", dependencies=[Depends(require_jwt)])
-async def get_logs(lines: int = 100):
+def get_logs(lines: int = 100):
     """Get recent netifyd logs."""
     try:
         result = subprocess.run(
@@ -669,7 +669,7 @@ async def get_logs(lines: int = 100):
 # =============================================================================
 
 @app.get("/interfaces", dependencies=[Depends(require_jwt)])
-async def list_interfaces():
+def list_interfaces():
     """List available network interfaces."""
     result = subprocess.run(["ip", "-j", "link", "show"], capture_output=True, text=True)
     try:

--- a/packages/secubox-netmodes/api/main.py
+++ b/packages/secubox-netmodes/api/main.py
@@ -168,7 +168,7 @@ async def set_mode(req: ModeRequest, user=Depends(require_jwt)):
 
 
 @router.post("/apply_mode")
-async def apply_mode(req: ModeRequest, user=Depends(require_jwt)):
+def apply_mode(req: ModeRequest, user=Depends(require_jwt)):
     """Applique le mode réseau : backup + render template + netplan apply."""
     if req.mode not in AVAILABLE_MODES:
         raise HTTPException(400, f"Mode inconnu: {req.mode}")
@@ -222,7 +222,7 @@ async def confirm_mode(user=Depends(require_jwt)):
 
 
 @router.post("/rollback")
-async def rollback(user=Depends(require_jwt)):
+def rollback(user=Depends(require_jwt)):
     """Restaure la dernière sauvegarde netplan et réapplique."""
     backups = sorted(BACKUP_DIR.glob("00-secubox.yaml.*"))
     if not backups:
@@ -237,7 +237,7 @@ async def rollback(user=Depends(require_jwt)):
 
 
 @router.get("/validate_config")
-async def validate_config(user=Depends(require_jwt)):
+def validate_config(user=Depends(require_jwt)):
     """Valider la config netplan actuelle."""
     r = subprocess.run(["netplan", "generate"], capture_output=True, text=True, timeout=10)
     return {"valid": r.returncode == 0, "output": r.stderr[:500] if r.returncode != 0 else "OK"}
@@ -322,7 +322,7 @@ async def vpnrelay_config(user=Depends(require_jwt)):
 
 
 @router.get("/travel_scan_networks")
-async def travel_scan_networks(user=Depends(require_jwt)):
+def travel_scan_networks(user=Depends(require_jwt)):
     """Scanner les réseaux WiFi disponibles."""
     r = subprocess.run(
         ["nmcli", "-t", "-f", "SSID,SIGNAL,SECURITY", "device", "wifi", "list"],
@@ -366,7 +366,7 @@ async def generate_config(req: GenerateConfigRequest, user=Depends(require_jwt))
 
 
 @router.post("/generate_wireguard_keys")
-async def generate_wireguard_keys(user=Depends(require_jwt)):
+def generate_wireguard_keys(user=Depends(require_jwt)):
     """Générer des clés WireGuard."""
     priv = subprocess.run(["wg", "genkey"], capture_output=True, text=True)
     private_key = priv.stdout.strip()
@@ -390,7 +390,7 @@ async def apply_wireguard_config(req: WireguardConfigRequest, user=Depends(requi
 
 
 @router.post("/apply_mtu_clamping")
-async def apply_mtu_clamping(mtu: int = 1280, user=Depends(require_jwt)):
+def apply_mtu_clamping(mtu: int = 1280, user=Depends(require_jwt)):
     """Appliquer le MTU clamping."""
     r = subprocess.run(
         ["iptables", "-A", "FORWARD", "-p", "tcp", "--tcp-flags", "SYN,RST", "SYN",
@@ -401,7 +401,7 @@ async def apply_mtu_clamping(mtu: int = 1280, user=Depends(require_jwt)):
 
 
 @router.post("/enable_tcp_bbr")
-async def enable_tcp_bbr(user=Depends(require_jwt)):
+def enable_tcp_bbr(user=Depends(require_jwt)):
     """Activer TCP BBR."""
     subprocess.run(["sysctl", "-w", "net.core.default_qdisc=fq"], capture_output=True)
     subprocess.run(["sysctl", "-w", "net.ipv4.tcp_congestion_control=bbr"], capture_output=True)
@@ -482,7 +482,7 @@ class AutoApplyRequest(BaseModel):
 
 
 @router.post("/auto_apply")
-async def auto_apply(req: AutoApplyRequest, user=Depends(require_jwt)):
+def auto_apply(req: AutoApplyRequest, user=Depends(require_jwt)):
     """
     Auto-detect interfaces and apply network configuration.
     1. Run secubox-net-detect

--- a/packages/secubox-newsbin/api/main.py
+++ b/packages/secubox-newsbin/api/main.py
@@ -254,7 +254,7 @@ async def health():
 
 
 @router.get("/status")
-async def status():
+def status():
     """Get Newsbin service status."""
     cfg = get_config()
     rt = detect_runtime()
@@ -651,7 +651,7 @@ async def get_container_status_endpoint(user=Depends(require_jwt)):
 
 
 @router.post("/container/install")
-async def install_container(user=Depends(require_jwt)):
+def install_container(user=Depends(require_jwt)):
     """Install SABnzbd container."""
     rt = detect_runtime()
     if not rt:
@@ -763,7 +763,7 @@ async def restart_container(user=Depends(require_jwt)):
 
 
 @router.delete("/container")
-async def uninstall_container(user=Depends(require_jwt)):
+def uninstall_container(user=Depends(require_jwt)):
     """Uninstall SABnzbd container."""
     rt = detect_runtime()
     if not rt:
@@ -811,7 +811,7 @@ async def update_container(user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/logs")
-async def get_logs(lines: int = 50, user=Depends(require_jwt)):
+def get_logs(lines: int = 50, user=Depends(require_jwt)):
     """Get container logs."""
     rt = detect_runtime()
     if not rt:
@@ -833,7 +833,7 @@ async def get_logs(lines: int = 50, user=Depends(require_jwt)):
 # ============================================================================
 
 @router.post("/backup")
-async def create_backup(user=Depends(require_jwt)):
+def create_backup(user=Depends(require_jwt)):
     """Backup SABnzbd configuration."""
     cfg = get_config()
     data_path = Path(cfg.get("data_path", "/srv/newsbin"))

--- a/packages/secubox-nextcloud/api/main.py
+++ b/packages/secubox-nextcloud/api/main.py
@@ -184,7 +184,7 @@ async def restart_service():
 
 
 @app.post("/install", dependencies=[Depends(require_jwt)])
-async def install():
+def install():
     """Install Nextcloud (background)"""
     if lxc_installed():
         raise HTTPException(400, "Already installed")
@@ -211,7 +211,7 @@ async def uninstall():
 
 
 @app.post("/update", dependencies=[Depends(require_jwt)])
-async def update():
+def update():
     """Update Nextcloud"""
     subprocess.Popen(
         ["/usr/sbin/nextcloudctl", "update"],
@@ -374,7 +374,7 @@ async def delete_backup(name: str):
 
 
 @app.post("/restore/{name}", dependencies=[Depends(require_jwt)])
-async def restore_backup(name: str):
+def restore_backup(name: str):
     """Restore from backup"""
     subprocess.Popen(
         ["/usr/sbin/nextcloudctl", "restore", name],

--- a/packages/secubox-ollama/api/main.py
+++ b/packages/secubox-ollama/api/main.py
@@ -144,7 +144,7 @@ async def health():
 
 
 @router.get("/status")
-async def status():
+def status():
     """Get Ollama service status."""
     cfg = get_config()
     rt = detect_runtime()
@@ -227,7 +227,7 @@ async def list_models(user=Depends(require_jwt)):
 
 
 @router.get("/models/{name}")
-async def get_model_info(name: str, user=Depends(require_jwt)):
+def get_model_info(name: str, user=Depends(require_jwt)):
     """Get model details."""
     if not is_running():
         raise HTTPException(503, "Ollama not running")
@@ -261,7 +261,7 @@ async def get_model_info(name: str, user=Depends(require_jwt)):
 
 
 @router.post("/models/pull")
-async def pull_model(req: ModelPullRequest, user=Depends(require_jwt)):
+def pull_model(req: ModelPullRequest, user=Depends(require_jwt)):
     """Pull a model from Ollama registry."""
     if not is_running():
         raise HTTPException(503, "Ollama not running")
@@ -286,7 +286,7 @@ async def pull_model(req: ModelPullRequest, user=Depends(require_jwt)):
 
 
 @router.delete("/models/{name}")
-async def remove_model(name: str, user=Depends(require_jwt)):
+def remove_model(name: str, user=Depends(require_jwt)):
     """Remove a model."""
     if not is_running():
         raise HTTPException(503, "Ollama not running")
@@ -367,7 +367,7 @@ async def generate(req: GenerateRequest, user=Depends(require_jwt)):
 
 
 @router.get("/system")
-async def system_info(user=Depends(require_jwt)):
+def system_info(user=Depends(require_jwt)):
     """Get system resource info."""
     cfg = get_config()
     rt = detect_runtime()
@@ -431,7 +431,7 @@ async def system_info(user=Depends(require_jwt)):
 
 
 @router.get("/logs")
-async def get_logs(lines: int = 50, user=Depends(require_jwt)):
+def get_logs(lines: int = 50, user=Depends(require_jwt)):
     """Get recent container logs."""
     rt = detect_runtime()
     if not rt:

--- a/packages/secubox-openclaw/api/main.py
+++ b/packages/secubox-openclaw/api/main.py
@@ -796,7 +796,7 @@ async def scan_domain(target: str, background_tasks: BackgroundTasks):
 
 
 @app.post("/scan/ip", dependencies=[Depends(require_jwt)])
-async def scan_ip(target: str, background_tasks: BackgroundTasks):
+def scan_ip(target: str, background_tasks: BackgroundTasks):
     """Start an IP scan."""
     # Validate IP
     try:

--- a/packages/secubox-p2p/api/main.py
+++ b/packages/secubox-p2p/api/main.py
@@ -1006,7 +1006,7 @@ def generate_wg_keypair() -> tuple:
 
 
 @app.get("/wireguard")
-async def get_wireguard_status():
+def get_wireguard_status():
     """Get WireGuard mesh status (public read)."""
     config = get_wg_mesh_config()
 
@@ -1097,7 +1097,7 @@ async def add_wireguard_peer(
 
 
 @app.post("/wireguard/enable")
-async def enable_wireguard(user: dict = Depends(require_jwt)):
+def enable_wireguard(user: dict = Depends(require_jwt)):
     """Enable and start WireGuard mesh interface."""
     config = get_wg_mesh_config()
 
@@ -1684,7 +1684,7 @@ async def ml_cleanup_local(request: Request):
 
 
 @app.post("/master-link/join")
-async def ml_join(req: JoinRequest, request: Request):
+def ml_join(req: JoinRequest, request: Request):
     """Handle join request from new node (token validated)."""
     # Validate token
     validation = ml_token_validate(req.token)

--- a/packages/secubox-peertube/api/main.py
+++ b/packages/secubox-peertube/api/main.py
@@ -305,7 +305,7 @@ async def health():
 
 
 @router.get("/status")
-async def status():
+def status():
     """Real native-LXC status: LXC state + PeerTube HTTP reachability + disk."""
     cfg = get_config()
     state = get_lxc_state()
@@ -680,7 +680,7 @@ async def update_transcoding_settings(settings: TranscodingSettings, user=Depend
 # ============================================================================
 
 @router.get("/storage/stats")
-async def get_storage_stats(user=Depends(require_jwt)):
+def get_storage_stats(user=Depends(require_jwt)):
     cfg = get_config()
     data_path = Path(cfg.get("data_path", "/data/peertube"))
     stats = {"total": "", "videos": "", "thumbnails": "",
@@ -771,7 +771,7 @@ async def container_status():
 
 
 @router.post("/container/install")
-async def install_peertube(user=Depends(require_jwt)):
+def install_peertube(user=Depends(require_jwt)):
     """Provision the LXC + native PeerTube install. Long-running → detached."""
     if not Path(INSTALL_LIB).exists():
         return {"success": False, "error": f"install script missing at {INSTALL_LIB}"}
@@ -825,7 +825,7 @@ async def uninstall_peertube(user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/logs")
-async def get_logs(lines: int = 100, user=Depends(require_jwt)):
+def get_logs(lines: int = 100, user=Depends(require_jwt)):
     """Tail peertube.service journal inside the LXC."""
     cfg = get_config()
     try:

--- a/packages/secubox-photoprism/api/main.py
+++ b/packages/secubox-photoprism/api/main.py
@@ -381,7 +381,7 @@ async def get_library_statistics(user=Depends(require_jwt)):
 
 
 @router.post("/library/index")
-async def start_indexing(user=Depends(require_jwt)):
+def start_indexing(user=Depends(require_jwt)):
     """Start library indexing."""
     if not is_running():
         return {"success": False, "error": "PhotoPrism is not running"}
@@ -405,7 +405,7 @@ async def start_indexing(user=Depends(require_jwt)):
 
 
 @router.post("/library/import")
-async def import_photos(user=Depends(require_jwt)):
+def import_photos(user=Depends(require_jwt)):
     """Import photos from import folder."""
     if not is_running():
         return {"success": False, "error": "PhotoPrism is not running"}
@@ -515,7 +515,7 @@ async def disable_face_recognition(user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/storage")
-async def get_storage_info(user=Depends(require_jwt)):
+def get_storage_info(user=Depends(require_jwt)):
     """Get storage information."""
     cfg = get_config()
     data_path = Path(cfg.get("data_path", "/srv/photoprism"))
@@ -636,7 +636,7 @@ async def container_status(user=Depends(require_jwt)):
 
 
 @router.post("/container/install")
-async def install_photoprism(user=Depends(require_jwt)):
+def install_photoprism(user=Depends(require_jwt)):
     """Provision the LXC + podman + PhotoPrism. Long-running → detached."""
     if not Path(INSTALL_LIB).exists():
         return {"success": False, "error": f"install script missing at {INSTALL_LIB}"}
@@ -687,7 +687,7 @@ async def uninstall_photoprism(user=Depends(require_jwt)):
 
 
 @router.post("/container/update")
-async def update_photoprism(user=Depends(require_jwt)):
+def update_photoprism(user=Depends(require_jwt)):
     """Pull the latest image inside the LXC + restart."""
     cfg = get_config()
     image = cfg.get("image", "docker.io/photoprism/photoprism:latest")
@@ -707,7 +707,7 @@ async def update_photoprism(user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/logs")
-async def get_logs(lines: int = 50, user=Depends(require_jwt)):
+def get_logs(lines: int = 50, user=Depends(require_jwt)):
     """Tail photoprism.service journal inside the LXC."""
     cfg = get_config()
     try:
@@ -727,7 +727,7 @@ async def get_logs(lines: int = 50, user=Depends(require_jwt)):
 # ============================================================================
 
 @router.post("/backup")
-async def backup_photoprism(user=Depends(require_jwt)):
+def backup_photoprism(user=Depends(require_jwt)):
     """Backup PhotoPrism configuration and database."""
     cfg = get_config()
     data_path = Path(cfg.get("data_path", "/srv/photoprism"))

--- a/packages/secubox-qos/api/main.py
+++ b/packages/secubox-qos/api/main.py
@@ -352,7 +352,7 @@ async def usage(user=Depends(require_jwt)):
 
 
 @router.get("/clients")
-async def clients(user=Depends(require_jwt)):
+def clients(user=Depends(require_jwt)):
     """Statistiques par client via nftables accounting (si configuré)."""
     r = subprocess.run(
         ["nft", "-j", "list", "table", "inet", "secubox_qos"],
@@ -379,7 +379,7 @@ class QosConfig(BaseModel):
 
 
 @router.post("/apply_qos")
-async def apply_qos(req: QosConfig, user=Depends(require_jwt)):
+def apply_qos(req: QosConfig, user=Depends(require_jwt)):
     conf = _load_conf()
     conf.update(req.dict())
     _save_conf(conf)
@@ -685,7 +685,7 @@ async def delete_parental(mac: str, user=Depends(require_jwt)):
 # ── Analytics / Realtime ───────────────────────────────────────────
 
 @router.get("/realtime")
-async def realtime(user=Depends(require_jwt)):
+def realtime(user=Depends(require_jwt)):
     """Bande passante en temps réel."""
     conf = _load_conf()
     iface = conf.get("interface", "eth0")
@@ -703,7 +703,7 @@ async def realtime(user=Depends(require_jwt)):
 
 
 @router.get("/bandwidth_history")
-async def bandwidth_history(hours: int = 24, user=Depends(require_jwt)):
+def bandwidth_history(hours: int = 24, user=Depends(require_jwt)):
     """Historique de bande passante (via vnstat si disponible)."""
     r = subprocess.run(
         ["vnstat", "--json", "-h", str(hours)],
@@ -716,7 +716,7 @@ async def bandwidth_history(hours: int = 24, user=Depends(require_jwt)):
 
 
 @router.get("/top_talkers")
-async def top_talkers(user=Depends(require_jwt)):
+def top_talkers(user=Depends(require_jwt)):
     """Top consommateurs de bande passante (via nftables accounting)."""
     r = subprocess.run(
         ["nft", "-j", "list", "set", "inet", "secubox_qos", "client_bytes"],
@@ -775,7 +775,7 @@ async def reset_quota(mac: str, user=Depends(require_jwt)):
 # ── DPI Integration ────────────────────────────────────────────────
 
 @router.get("/dpi_apps")
-async def dpi_apps(user=Depends(require_jwt)):
+def dpi_apps(user=Depends(require_jwt)):
     """Applications détectées par DPI."""
     r = subprocess.run(
         ["curl", "-s", "--unix-socket", "/run/secubox/dpi.sock",
@@ -821,7 +821,7 @@ async def delete_dpi_rule(app_id: str, user=Depends(require_jwt)):
 # ── Advanced ───────────────────────────────────────────────────────
 
 @router.get("/tc_raw")
-async def tc_raw(user=Depends(require_jwt)):
+def tc_raw(user=Depends(require_jwt)):
     """Configuration tc brute."""
     conf = _load_conf()
     iface = conf.get("interface", "eth0")
@@ -839,7 +839,7 @@ async def tc_raw(user=Depends(require_jwt)):
 
 
 @router.post("/tc_command")
-async def tc_command(command: str, user=Depends(require_jwt)):
+def tc_command(command: str, user=Depends(require_jwt)):
     """Exécuter une commande tc (admin only)."""
     if not command.startswith("tc "):
         return {"error": "Must start with 'tc '"}
@@ -848,7 +848,7 @@ async def tc_command(command: str, user=Depends(require_jwt)):
 
 
 @router.get("/interface_list")
-async def interface_list(user=Depends(require_jwt)):
+def interface_list(user=Depends(require_jwt)):
     """Liste des interfaces réseau."""
     r = subprocess.run(["ip", "-j", "link", "show"], capture_output=True, text=True)
     try:
@@ -912,7 +912,7 @@ async def import_config(req: ImportRequest, user=Depends(require_jwt)):
 
 
 @router.get("/logs")
-async def logs(lines: int = 100, user=Depends(require_jwt)):
+def logs(lines: int = 100, user=Depends(require_jwt)):
     """Logs QoS."""
     r = subprocess.run(
         ["journalctl", "-u", "secubox-qos", "-n", str(lines), "--no-pager"],
@@ -1015,7 +1015,7 @@ async def set_vlan_policy(interface: str, req: VlanPolicyRequest, user=Depends(r
 
 
 @router.delete("/vlan/{interface}/policy")
-async def delete_vlan_policy(interface: str, user=Depends(require_jwt)):
+def delete_vlan_policy(interface: str, user=Depends(require_jwt)):
     """Remove QoS policy from a VLAN interface."""
     conf = _load_conf()
 
@@ -1249,7 +1249,7 @@ async def add_managed_interface(req: AddInterfaceRequest, user=Depends(require_j
 
 
 @router.delete("/interface/{interface}")
-async def remove_managed_interface(interface: str, user=Depends(require_jwt)):
+def remove_managed_interface(interface: str, user=Depends(require_jwt)):
     """Remove an interface from QoS management."""
     conf = _load_conf()
 
@@ -1270,7 +1270,7 @@ async def remove_managed_interface(interface: str, user=Depends(require_jwt)):
 
 
 @router.get("/interface/{interface}/stats")
-async def get_interface_stats(interface: str, user=Depends(require_jwt)):
+def get_interface_stats(interface: str, user=Depends(require_jwt)):
     """Get detailed stats for a specific interface."""
     if not Path(f"/sys/class/net/{interface}").exists():
         raise HTTPException(status_code=404, detail=f"Interface {interface} not found")

--- a/packages/secubox-rtty/api/main.py
+++ b/packages/secubox-rtty/api/main.py
@@ -373,7 +373,7 @@ async def update_config(req: ConfigUpdate, user=Depends(require_jwt)):
 
 
 @router.get("/logs")
-async def get_logs(lines: int = 100, user=Depends(require_jwt)):
+def get_logs(lines: int = 100, user=Depends(require_jwt)):
     """Get rtty service logs."""
     # Try rtty log file first
     if RTTY_LOG.exists():

--- a/packages/secubox-smtp-relay/api/main.py
+++ b/packages/secubox-smtp-relay/api/main.py
@@ -416,7 +416,7 @@ class TestEmail(BaseModel):
 
 
 @router.post("/test")
-async def test_email(email: TestEmail, user=Depends(require_jwt)):
+def test_email(email: TestEmail, user=Depends(require_jwt)):
     """Send a test email through the relay."""
     config = _load_config()
     if not config.get("smarthost"):

--- a/packages/secubox-soc/api/main.py
+++ b/packages/secubox-soc/api/main.py
@@ -447,7 +447,7 @@ async def get_map_threats(continent: Optional[str] = None, country: Optional[str
 
 
 @app.get("/map/attacks", dependencies=[Depends(require_jwt)])
-async def get_live_attacks():
+def get_live_attacks():
     attacks = []
     try:
         result = subprocess.run(["cscli", "decisions", "list", "-o", "json"], capture_output=True, text=True, timeout=5)

--- a/packages/secubox-streamlit/api/main.py
+++ b/packages/secubox-streamlit/api/main.py
@@ -550,7 +550,7 @@ class WakeResult(BaseModel):
 
 
 @router.post("/apps/{name}/wake", response_model=WakeResult)
-async def wake_app(name: str, user=Depends(require_jwt)) -> WakeResult:
+def wake_app(name: str, user=Depends(require_jwt)) -> WakeResult:
     """Wake an idle-stopped streamlit app.
 
     Blocks until the port comes up or 30 s elapse. Idempotent — returns

--- a/packages/secubox-system/api/main.py
+++ b/packages/secubox-system/api/main.py
@@ -375,7 +375,7 @@ async def status(user=Depends(require_jwt)):
 
 
 @router.get("/info")
-async def info():
+def info():
     """System info for dashboard (public)."""
     import platform
     import datetime
@@ -402,7 +402,7 @@ async def info():
 
 
 @router.get("/metrics")
-async def metrics():
+def metrics():
     """System metrics for Eye Remote dashboard (public).
 
     Returns metrics in format expected by Eye Remote display.
@@ -448,7 +448,7 @@ async def resources():
 
 
 @router.get("/metrics")
-async def metrics_public():
+def metrics_public():
     """
     Public metrics endpoint for Eye Remote Dashboard (no JWT required).
     Returns all metrics needed by the HyperPixel 2.1 Round display.
@@ -551,7 +551,7 @@ async def network():
 
 
 @router.get("/security")
-async def security():
+def security():
     """Security status for dashboard (public)."""
     # nftables always active on SecuBox (rules loaded at boot)
     firewall = "Active"
@@ -586,7 +586,7 @@ async def security():
 
 
 @router.get("/packages")
-async def packages():
+def packages():
     """Installed SecuBox packages (public)."""
     r = subprocess.run(
         ["dpkg-query", "-W", "-f", "${Package} ${Version}\n"],
@@ -601,7 +601,7 @@ async def packages():
 
 
 @router.post("/restart_services")
-async def restart_services(user=Depends(require_jwt)):
+def restart_services(user=Depends(require_jwt)):
     """Restart all SecuBox services."""
     for svc in SECUBOX_SERVICES[:12]:
         if svc.startswith("secubox-"):
@@ -610,21 +610,21 @@ async def restart_services(user=Depends(require_jwt)):
 
 
 @router.post("/reload_firewall")
-async def reload_firewall(user=Depends(require_jwt)):
+def reload_firewall(user=Depends(require_jwt)):
     """Reload nftables firewall."""
     r = subprocess.run(["systemctl", "reload", "nftables"], capture_output=True, text=True)
     return {"success": r.returncode == 0}
 
 
 @router.post("/sync_time")
-async def sync_time(user=Depends(require_jwt)):
+def sync_time(user=Depends(require_jwt)):
     """Sync system time with NTP."""
     r = subprocess.run(["timedatectl", "set-ntp", "true"], capture_output=True, text=True)
     return {"success": r.returncode == 0}
 
 
 @router.post("/clear_cache")
-async def clear_cache(user=Depends(require_jwt)):
+def clear_cache(user=Depends(require_jwt)):
     """Clear system caches."""
     subprocess.run(["sync"], timeout=5)
     Path("/proc/sys/vm/drop_caches").write_text("3")
@@ -632,7 +632,7 @@ async def clear_cache(user=Depends(require_jwt)):
 
 
 @router.get("/check_updates")
-async def check_updates(user=Depends(require_jwt)):
+def check_updates(user=Depends(require_jwt)):
     """Check for package updates."""
     subprocess.run(["apt-get", "update", "-qq"], capture_output=True, timeout=60)
     r = subprocess.run(["apt-get", "-s", "upgrade"], capture_output=True, text=True, timeout=30)
@@ -642,7 +642,7 @@ async def check_updates(user=Depends(require_jwt)):
 
 
 @router.post("/apply_updates")
-async def apply_updates(user=Depends(require_jwt)):
+def apply_updates(user=Depends(require_jwt)):
     """Apply package updates."""
     r = subprocess.run(
         ["apt-get", "upgrade", "-y", "-qq"],
@@ -652,7 +652,7 @@ async def apply_updates(user=Depends(require_jwt)):
 
 
 @router.post("/shutdown")
-async def shutdown(user=Depends(require_jwt)):
+def shutdown(user=Depends(require_jwt)):
     """Shutdown the system."""
     log.warning("Shutdown requested by user")
     subprocess.Popen(["shutdown", "-h", "+1"], stdout=subprocess.DEVNULL)
@@ -660,7 +660,7 @@ async def shutdown(user=Depends(require_jwt)):
 
 
 @router.post("/settings")
-async def settings(data: dict, user=Depends(require_jwt)):
+def settings(data: dict, user=Depends(require_jwt)):
     """Save system settings."""
     if "hostname" in data and data["hostname"]:
         subprocess.run(["hostnamectl", "set-hostname", data["hostname"]], timeout=10)
@@ -689,7 +689,7 @@ async def logs(unit: str = "", lines: int = 100, user=Depends(require_jwt)):
 
 
 @router.get("/secubox_logs")
-async def secubox_logs():
+def secubox_logs():
     """Get latest secubox log messages with criticality and emojis (public for dashboard).
 
     Returns 5 most recent messages from secubox-* services with:
@@ -924,7 +924,7 @@ async def get_denoise_stats(user=Depends(require_jwt)):
 
 
 @router.post("/reboot")
-async def reboot(user=Depends(require_jwt)):
+def reboot(user=Depends(require_jwt)):
     """Redémarrer le système."""
     log.warning("Reboot requested by user")
     subprocess.Popen(["shutdown", "-r", "+1"], stdout=subprocess.DEVNULL)
@@ -1014,7 +1014,7 @@ async def delete_diagnostic(name: str, user=Depends(require_jwt)):
 
 
 @router.get("/run_diagnostic_test")
-async def run_diagnostic_test(test: str, user=Depends(require_jwt)):
+def run_diagnostic_test(test: str, user=Depends(require_jwt)):
     """Exécuter un test de diagnostic."""
     tests = {
         "network": ["ping", "-c", "3", "1.1.1.1"],
@@ -1142,7 +1142,7 @@ async def board_info_endpoint():
 
 
 @router.post("/board/detect")
-async def run_board_detection(user=Depends(require_jwt)):
+def run_board_detection(user=Depends(require_jwt)):
     """
     Run secubox-net-detect script to refresh board detection.
     Requires authentication.

--- a/packages/secubox-threatmesh/api/main.py
+++ b/packages/secubox-threatmesh/api/main.py
@@ -250,7 +250,7 @@ async def mesh_ingest(request: Request):
 
 
 @router.post("/feeds/refresh", dependencies=[Depends(require_jwt)])
-async def feeds_refresh():
+def feeds_refresh():
     """Trigger the feed fetcher now (normally on a timer)."""
     try:
         subprocess.Popen(["/usr/sbin/secubox-threatfeed"])

--- a/packages/secubox-threats/api/main.py
+++ b/packages/secubox-threats/api/main.py
@@ -509,7 +509,7 @@ async def list_alerts(
 
 
 @app.get("/alerts/sources", dependencies=[Depends(require_jwt)])
-async def get_alert_sources():
+def get_alert_sources():
     """Get available alert sources and their status."""
     sources = []
 

--- a/packages/secubox-torrent/api/main.py
+++ b/packages/secubox-torrent/api/main.py
@@ -342,7 +342,7 @@ async def health():
 
 
 @router.get("/status")
-async def status():
+def status():
     """Get torrent service status."""
     cfg = get_config()
     rt = detect_runtime()
@@ -751,7 +751,7 @@ async def container_status(user=Depends(require_jwt)):
 
 
 @router.post("/container/install")
-async def install_container(user=Depends(require_jwt)):
+def install_container(user=Depends(require_jwt)):
     """Install torrent container."""
     rt = detect_runtime()
     if not rt:
@@ -862,7 +862,7 @@ async def restart_container(user=Depends(require_jwt)):
 
 
 @router.post("/container/uninstall")
-async def uninstall_container(user=Depends(require_jwt)):
+def uninstall_container(user=Depends(require_jwt)):
     """Uninstall torrent container."""
     rt = detect_runtime()
     if not rt:
@@ -883,7 +883,7 @@ async def uninstall_container(user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/logs")
-async def get_logs(lines: int = 100, user=Depends(require_jwt)):
+def get_logs(lines: int = 100, user=Depends(require_jwt)):
     """Get container logs."""
     rt = detect_runtime()
     if not rt:

--- a/packages/secubox-turn/api/main.py
+++ b/packages/secubox-turn/api/main.py
@@ -560,7 +560,7 @@ async def generate_secret(user=Depends(require_jwt)):
 
 
 @router.get("/logs")
-async def get_logs(lines: int = 100, user=Depends(require_jwt)):
+def get_logs(lines: int = 100, user=Depends(require_jwt)):
     """Get TURN server logs."""
     log_file = Path("/var/log/turnserver/turnserver.log")
 

--- a/packages/secubox-users/api/main.py
+++ b/packages/secubox-users/api/main.py
@@ -463,7 +463,7 @@ async def get_user(username: str):
     raise HTTPException(status_code=404, detail="User not found")
 
 @app.post("/user", dependencies=[Depends(require_jwt)])
-async def create_user(user: UserCreate):
+def create_user(user: UserCreate):
     """Create a new user and provision to services."""
     # Delegate identity creation to engine.
     # The legacy API role "user" maps to engine role "viewer" (least privilege).
@@ -577,7 +577,7 @@ async def enable_user(username: str):
     return {"ok": True}
 
 @app.delete("/user/{username}", dependencies=[Depends(require_jwt)])
-async def delete_user(username: str):
+def delete_user(username: str):
     """Delete user and deprovision from services."""
     # Read services before deleting (engine will remove the record)
     user_record = _engine.get_user(username)
@@ -630,7 +630,7 @@ async def sync_user(username: str):
     raise HTTPException(status_code=404, detail="User not found")
 
 @app.post("/user/{username}/password", dependencies=[Depends(require_permission("users.password", allow_self_for_param="username"))])
-async def change_password(username: str, pwd: PasswordChange):
+def change_password(username: str, pwd: PasswordChange):
     """Change user password (admin path — caller holds users.password permission).
     Sets the internal password hash via engine and propagates to external services."""
     user_record = _engine.get_user(username)
@@ -1111,7 +1111,7 @@ async def get_sessions():
 
 
 @app.delete("/session/{session_id}", dependencies=[Depends(require_jwt)])
-async def revoke_session(session_id: str):
+def revoke_session(session_id: str):
     """Revoke a specific session."""
     try:
         result = subprocess.run(
@@ -1128,7 +1128,7 @@ async def revoke_session(session_id: str):
 
 
 @app.post("/sessions/revoke-all", dependencies=[Depends(require_jwt)])
-async def revoke_all_sessions():
+def revoke_all_sessions():
     """EMERGENCY: Revoke ALL active sessions immediately.
     This is a panic button - all users will be logged out.
     """

--- a/packages/secubox-voip/api/main.py
+++ b/packages/secubox-voip/api/main.py
@@ -252,7 +252,7 @@ async def health():
 
 
 @router.get("/status")
-async def status():
+def status():
     """Get VoIP service status."""
     cfg = get_config()
     rt = detect_runtime()
@@ -676,7 +676,7 @@ async def get_container_info(user=Depends(require_jwt)):
 
 
 @router.post("/container/install")
-async def install_voip(user=Depends(require_jwt)):
+def install_voip(user=Depends(require_jwt)):
     """Install FreePBX container."""
     rt = detect_runtime()
     if not rt:
@@ -794,7 +794,7 @@ async def restart_voip(user=Depends(require_jwt)):
 
 
 @router.post("/container/uninstall")
-async def uninstall_voip(user=Depends(require_jwt)):
+def uninstall_voip(user=Depends(require_jwt)):
     """Uninstall FreePBX container."""
     rt = detect_runtime()
     if not rt:
@@ -815,7 +815,7 @@ async def uninstall_voip(user=Depends(require_jwt)):
 # ============================================================================
 
 @router.get("/logs")
-async def get_logs(
+def get_logs(
     lines: int = Query(50, ge=1, le=500),
     log_type: str = Query("all", pattern="^(all|asterisk|freepbx)$"),
     user=Depends(require_jwt)

--- a/packages/secubox-webradio/api/main.py
+++ b/packages/secubox-webradio/api/main.py
@@ -194,7 +194,7 @@ async def health():
 
 
 @router.get("/status")
-async def status():
+def status():
     """Get webradio service status."""
     cfg = get_config()
     rt = detect_runtime()
@@ -453,7 +453,7 @@ async def list_recordings(user=Depends(require_jwt)):
 
 
 @router.post("/record/start")
-async def start_recording(station_id: str, format: str = "mp3", user=Depends(require_jwt)):
+def start_recording(station_id: str, format: str = "mp3", user=Depends(require_jwt)):
     """Start recording a station."""
     stations = load_stations()
     station = None
@@ -650,7 +650,7 @@ async def container_status(user=Depends(require_jwt)):
 
 
 @router.post("/container/install")
-async def install_containers(user=Depends(require_jwt)):
+def install_containers(user=Depends(require_jwt)):
     """Pull required container images."""
     rt = detect_runtime()
     if not rt:
@@ -733,7 +733,7 @@ memory_limit = "{config.memory_limit}"
 # ============================================================================
 
 @router.get("/logs")
-async def get_logs(lines: int = 50, user=Depends(require_jwt)):
+def get_logs(lines: int = 50, user=Depends(require_jwt)):
     """Get container logs."""
     rt = detect_runtime()
     if not rt:

--- a/packages/secubox-wireguard/api/main.py
+++ b/packages/secubox-wireguard/api/main.py
@@ -484,7 +484,7 @@ async def migrate(req: MigrateRequest, user=Depends(require_jwt)):
 # === Health Check ===
 
 @app.get("/health")
-async def health():
+def health():
     """Health check endpoint."""
     try:
         result = subprocess.run(["wg", "show", "interfaces"], capture_output=True, timeout=2)

--- a/packages/secubox-yggdrasil/api/main.py
+++ b/packages/secubox-yggdrasil/api/main.py
@@ -531,7 +531,7 @@ async def probe_secubox_peer(ipv6: str, timeout: float = 3.0) -> dict:
 
 
 @app.get("/status")
-async def get_status():
+def get_status():
     """Get mesh network status (public)."""
     ygg_info = get_yggdrasil_info()
     peers = get_yggdrasil_peers()
@@ -809,7 +809,7 @@ async def remove_secubox_peer(ipv6: str, user=Depends(require_jwt)):
 
 
 @app.get("/secubox/self")
-async def get_self_info(user=Depends(require_jwt)):
+def get_self_info(user=Depends(require_jwt)):
     """Get this node's SecuBox info for mesh announcement."""
     ygg_info = get_yggdrasil_info()
 
@@ -1196,7 +1196,7 @@ async def test_webhook(webhook_id: str, user=Depends(require_jwt)):
 # ════════════════════════════════════════════════════════════════════════════
 
 @app.get("/services/health")
-async def get_services_health(user=Depends(require_jwt)):
+def get_services_health(user=Depends(require_jwt)):
     """Check health of all announced services."""
     data = load_json(SERVICES_FILE, {"services": []})
     ygg_info = get_yggdrasil_info()
@@ -1233,7 +1233,7 @@ async def get_services_health(user=Depends(require_jwt)):
 
 
 @app.post("/services/{name}/health")
-async def check_service_health(name: str, user=Depends(require_jwt)):
+def check_service_health(name: str, user=Depends(require_jwt)):
     """Check health of a specific service."""
     data = load_json(SERVICES_FILE, {"services": []})
 

--- a/packages/secubox-zkp/api/main.py
+++ b/packages/secubox-zkp/api/main.py
@@ -116,7 +116,7 @@ async def list_keys():
     return {"keys": keys}
 
 @app.post("/keygen")
-async def generate_key(req: KeygenRequest, user: dict = Depends(require_jwt)):
+def generate_key(req: KeygenRequest, user: dict = Depends(require_jwt)):
     """Generate a new ZKP key pair."""
     init_dirs()
 
@@ -164,7 +164,7 @@ async def generate_key(req: KeygenRequest, user: dict = Depends(require_jwt)):
         raise HTTPException(status_code=500, detail="Key generation failed")
 
 @app.post("/prove")
-async def generate_proof(req: KeyRequest, user: dict = Depends(require_jwt)):
+def generate_proof(req: KeyRequest, user: dict = Depends(require_jwt)):
     """Generate a ZKP proof."""
     init_dirs()
 
@@ -199,7 +199,7 @@ async def generate_proof(req: KeyRequest, user: dict = Depends(require_jwt)):
         raise HTTPException(status_code=500, detail=f"Proof failed: {result.stderr}")
 
 @app.post("/verify")
-async def verify_proof(req: KeyRequest, user: dict = Depends(require_jwt)):
+def verify_proof(req: KeyRequest, user: dict = Depends(require_jwt)):
     """Verify a ZKP proof."""
     init_dirs()
 

--- a/scripts/async-sweep.py
+++ b/scripts/async-sweep.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+"""SecuBox-Deb :: async-sweep codemod (#738)
+
+Convert blocking FastAPI route handlers declared `async def` but containing NO
+`await` into plain `def`. Mounted in the aggregator's single event loop, an
+`async def` handler that calls blocking code (subprocess, openssl, argon2,
+requests…) freezes the whole loop. A `def` handler is run by Starlette in the
+AnyIO threadpool instead, so the blocking call no longer stalls the gateway.
+
+Safety rules — a handler is converted ONLY when ALL hold:
+  * decorated with an HTTP verb (router/app .get/.post/.put/.delete/.patch/
+    .options/.head/.trace) — NOT .websocket
+  * its own body has no `await`, `async with`, `async for`, `yield`
+    (genuinely-async or streaming handlers are left untouched)
+  * its name is never used as a coroutine elsewhere in the file
+    (`await name(`, `create_task(name`, `gather(name`, `ensure_future(name`)
+
+Only the leading `async ` token on the `def` line is removed; formatting is
+otherwise preserved. Every rewritten file is re-parsed + py_compile'd.
+
+Usage:
+  async-sweep.py --check  PATH...     # report only, no writes
+  async-sweep.py --apply  PATH...     # rewrite in place
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import py_compile
+import sys
+import tempfile
+from pathlib import Path
+
+HTTP_VERBS = {"get", "post", "put", "delete", "patch", "options", "head", "trace"}
+
+# Attribute calls that block the event loop when run inline (sync I/O / CPU).
+_BLOCK_ATTR = {
+    "run", "call", "check_call", "check_output", "Popen",          # subprocess.*
+    "communicate", "wait",                                          # Popen.*
+    "system", "popen",                                             # os.*
+    "sleep",                                                        # time.sleep
+    "urlopen",                                                      # urllib
+    "check_password", "verify_password", "verify", "hash",         # argon2 / auth
+}
+# Bare/standalone names whose call blocks (sync HTTP clients, etc.).
+_BLOCK_FUNC_HINT = {"verify_password", "check_password"}
+# Module roots whose sync methods block (requests.get, httpx.get, openssl via subprocess…).
+_BLOCK_MODULE = {"requests", "subprocess", "socket"}
+
+
+class _BlockingFinder(ast.NodeVisitor):
+    """True if the direct body issues a known blocking call (excludes nested
+    function bodies)."""
+
+    def __init__(self) -> None:
+        self.found = False
+
+    def _stop(self, _node):
+        return
+
+    visit_FunctionDef = _stop
+    visit_AsyncFunctionDef = _stop
+    visit_Lambda = _stop
+
+    def visit_Call(self, node):
+        fn = node.func
+        if isinstance(fn, ast.Attribute):
+            if fn.attr in _BLOCK_ATTR:
+                self.found = True
+            root = fn.value
+            if isinstance(root, ast.Name) and root.id in _BLOCK_MODULE:
+                self.found = True
+        elif isinstance(fn, ast.Name) and fn.id in _BLOCK_FUNC_HINT:
+            self.found = True
+        self.generic_visit(node)
+
+
+def _body_blocks(node: ast.AsyncFunctionDef) -> bool:
+    f = _BlockingFinder()
+    for stmt in node.body:
+        f.visit(stmt)
+        if f.found:
+            return True
+    return False
+
+
+def _decorator_verbs(node: ast.AsyncFunctionDef) -> set[str]:
+    verbs = set()
+    for dec in node.decorator_list:
+        call = dec.func if isinstance(dec, ast.Call) else dec
+        if isinstance(call, ast.Attribute):
+            verbs.add(call.attr)
+    return verbs
+
+
+class _AwaitFinder(ast.NodeVisitor):
+    """True if the *direct* body uses await/async-context/yield — i.e. excludes
+    awaits that belong to nested (async) functions defined inside."""
+
+    def __init__(self) -> None:
+        self.found = False
+
+    def _stop(self, _node):  # don't descend into nested function bodies
+        return
+
+    visit_FunctionDef = _stop
+    visit_AsyncFunctionDef = _stop
+    visit_Lambda = _stop
+
+    def visit_Await(self, node):
+        self.found = True
+
+    def visit_AsyncWith(self, node):
+        self.found = True
+
+    def visit_AsyncFor(self, node):
+        self.found = True
+
+    def visit_Yield(self, node):
+        self.found = True
+
+    def visit_YieldFrom(self, node):
+        self.found = True
+
+
+def _body_has_await(node: ast.AsyncFunctionDef) -> bool:
+    f = _AwaitFinder()
+    for stmt in node.body:
+        f.visit(stmt)
+        if f.found:
+            return True
+    return False
+
+
+def _coroutine_referenced_names(tree: ast.Module) -> set[str]:
+    """Names used as coroutines: awaited, or passed to create_task/gather/
+    ensure_future. Such functions MUST stay async."""
+    names: set[str] = set()
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Await):
+            tgt = n.value
+            if isinstance(tgt, ast.Call):
+                fn = tgt.func
+                if isinstance(fn, ast.Name):
+                    names.add(fn.id)
+                elif isinstance(fn, ast.Attribute):
+                    names.add(fn.attr)
+        elif isinstance(n, ast.Call):
+            fn = n.func
+            sched = isinstance(fn, ast.Attribute) and fn.attr in {
+                "create_task", "ensure_future", "gather",
+            }
+            if sched:
+                for a in n.args:
+                    if isinstance(a, ast.Name):
+                        names.add(a.id)
+                    elif isinstance(a, ast.Call) and isinstance(a.func, ast.Name):
+                        names.add(a.func.id)
+    return names
+
+
+def analyze(path: Path):
+    """Return (conversions, skips). conversions = list of (lineno, col, name)."""
+    src = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(src)
+    except SyntaxError as e:
+        return None, [("<parse>", f"SyntaxError: {e}")]
+
+    coro_names = _coroutine_referenced_names(tree)
+    conversions, skips = [], []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        verbs = _decorator_verbs(node)
+        if not (verbs & HTTP_VERBS):
+            continue  # not an HTTP route handler
+        if "websocket" in verbs:
+            skips.append((node.name, "websocket"))
+            continue
+        if _body_has_await(node):
+            skips.append((node.name, "await/stream"))
+            continue
+        if node.name in coro_names:
+            skips.append((node.name, "referenced-as-coroutine"))
+            continue
+        if not _body_blocks(node):
+            skips.append((node.name, "no-blocking-call"))
+            continue
+        conversions.append((node.lineno, node.col_offset, node.name))
+
+    return conversions, skips
+
+
+def apply_file(path: Path) -> tuple[int, list]:
+    conversions, skips = analyze(path)
+    if conversions is None:
+        return 0, skips
+    if not conversions:
+        return 0, skips
+
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    for lineno, col, name in conversions:
+        line = lines[lineno - 1]
+        if line[col:col + 6] != "async ":
+            raise RuntimeError(f"{path}:{lineno}: expected 'async ' at col {col}, got {line[col:col+10]!r}")
+        lines[lineno - 1] = line[:col] + line[col + 6:]
+
+    new_src = "".join(lines)
+    # validate: must parse + compile
+    ast.parse(new_src)
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as tf:
+        tf.write(new_src)
+        tmp = tf.name
+    try:
+        py_compile.compile(tmp, doraise=True)
+    finally:
+        Path(tmp).unlink(missing_ok=True)
+
+    path.write_text(new_src, encoding="utf-8")
+    return len(conversions), skips
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--check", action="store_true")
+    g.add_argument("--apply", action="store_true")
+    ap.add_argument("paths", nargs="+", type=Path)
+    args = ap.parse_args()
+
+    files: list[Path] = []
+    for p in args.paths:
+        if p.is_dir():
+            files.extend(sorted(p.rglob("api/main.py")))
+        else:
+            files.append(p)
+
+    total_conv = total_files = 0
+    for f in files:
+        if args.check:
+            conv, skips = analyze(f)
+            if conv is None:
+                print(f"  PARSE-FAIL {f}: {skips}")
+                continue
+            if conv:
+                total_conv += len(conv)
+                total_files += 1
+                print(f"  {f.relative_to(Path.cwd()) if f.is_absolute() else f}: {len(conv)} handlers → def")
+        else:
+            n, skips = apply_file(f)
+            if n:
+                total_conv += n
+                total_files += 1
+                print(f"  {f}: {n} converted")
+    print(f"\n{'CHECK' if args.check else 'APPLY'}: {total_conv} handlers across {total_files} files")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #738

## Problème
`secubox-aggregator` monte ~110 modules FastAPI dans **une seule boucle event-loop** (`--workers 1`, consolidation volontaire pour la RAM). Un endpoint `async def` qui exécute du **synchrone bloquant** (subprocess/journalctl/openssl/argon2) **gèle toute la boucle** → `aggregator.sock: Connection refused` → **502/000 board-wide**. Cause racine de 502 récurrents + login KO + dashboards vides.

## Solution
1. **Codemod AST déterministe** (`scripts/async-sweep.py`) : convertit `async def` → `def` les handlers de route qui (a) sont décorés d'un verbe HTTP, (b) contiennent un appel bloquant connu, (c) n'ont aucun `await`/`async with`/`async for`/`yield`, (d) ne sont jamais awaités/`create_task` ailleurs. Starlette les exécute alors dans le **threadpool AnyIO** → l'appel bloquant ne gèle plus la boucle. await/stream/websocket intouchés. `py_compile` par fichier.
2. **Bump threadpool AnyIO** 40 → 80 tokens au startup de l'aggregator (best-effort).

## Périmètre
**243 handlers / 56 modules** (system 17, qos 13, netdiag/hexo 12, hub 11, haproxy 9…).

## Preuve (board gk2)
Test : 3× `/system/services` bloquants concurrents + `/hub/health`.

| | Avant (`async def`) | Après (`def` threadpool) |
|---|---|---|
| `/hub/health` sous charge | **000 — timeout 11.6s** (boucle gelée) | **200 — 2.4s** (vivante) |
| Modules montés | — | **117 / 0 échec import** |

47 modules déployés en hotpatch sur gk2 ; 9 du repo non installés (couverts en source). Build .deb via CI pour pérennité.

## Note
Conversion `async def`→`def` = exécution threadpool → possibles accès concurrents sur état module partagé (avant : sérialisé par la boucle). Handlers visés = très majoritairement read/subprocess-puis-return ; risque faible.