### PR TITLE
fix(sbxwaf): preserve Content-Encoding in media cache (ref #777)

### DIFF
--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/main.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/main.go
@@ -429,7 +429,7 @@ func (s *Server) handler() http.Handler {
 		// mirrors Python media_cache.py r.pretty_url which includes the host).
 		if s.mediaCache != nil && r.Method == http.MethodGet {
 			vhostCacheURL := "https://" + r.Host + r.URL.RequestURI()
-			if cachedBody, cachedHdr, hit := s.mediaCache.Get(vhostCacheURL); hit {
+			if cachedBody, cachedHdr, hit := s.mediaCache.Get(vhostCacheURL, r.Header.Get("Accept-Encoding")); hit {
 				for k, vs := range cachedHdr {
 					for _, v := range vs {
 						w.Header().Set(k, v)

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/mediacache.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/mediacache.go
@@ -35,6 +35,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 )
 
 // Cache constants — mirror media_cache.py.
@@ -199,11 +200,28 @@ func isCacheable(ct string) bool {
 }
 
 // hasGzipMagic reports whether b begins with the gzip magic number (0x1F 0x8B).
-// Used as a defensive self-heal signal: a stored body carrying this magic while
-// the entry records no Content-Encoding is a corrupt/legacy entry that must not
-// be served as identity (that is the U+001F corruption bug this cache had).
 func hasGzipMagic(b []byte) bool {
 	return len(b) >= 2 && b[0] == 0x1f && b[1] == 0x8b
+}
+
+// isCorruptIdentity reports whether a body recorded as identity (ce=="") is in
+// fact compressed — a pre-fix legacy entry whose Content-Encoding was dropped.
+// gzip is caught by magic. brotli/deflate/zstd have no reliable magic, so they
+// are caught for text/script content-types: an identity JS/CSS body must be
+// valid UTF-8, and a compressed one is (almost) never valid UTF-8. Binary media
+// (images/video/fonts) is left alone — its identity form is legitimately
+// non-UTF-8. Serving any such corrupt body as identity is the U+001F-class bug.
+func isCorruptIdentity(ct string, data []byte) bool {
+	if hasGzipMagic(data) {
+		return true
+	}
+	ct = strings.ToLower(ct)
+	if strings.Contains(ct, "javascript") ||
+		strings.Contains(ct, "ecmascript") ||
+		strings.Contains(ct, "css") {
+		return !utf8.Valid(data)
+	}
+	return false
 }
 
 // encodingAccepted reports whether the client's Accept-Encoding header permits
@@ -221,7 +239,12 @@ func encodingAccepted(acceptEncoding, coding string) bool {
 		if i := strings.IndexByte(tok, ';'); i >= 0 {
 			base = strings.TrimSpace(tok[:i])
 			if j := strings.Index(tok[i+1:], "q="); j >= 0 {
-				if v, err := strconv.ParseFloat(strings.TrimSpace(tok[i+1+j+2:]), 64); err == nil {
+				qstr := tok[i+1+j+2:]
+				// stop at any further parameter (e.g. "q=0;x=y" → "0")
+				if k := strings.IndexByte(qstr, ';'); k >= 0 {
+					qstr = qstr[:k]
+				}
+				if v, err := strconv.ParseFloat(strings.TrimSpace(qstr), 64); err == nil {
 					q = v
 				}
 			}
@@ -278,11 +301,11 @@ func (m *MediaCache) Get(url, acceptEncoding string) (body []byte, hdr http.Head
 		return nil, nil, false
 	}
 
-	// Defensive self-heal: an entry with no recorded Content-Encoding whose body
-	// carries the gzip magic is a corrupt legacy entry (stored by the pre-fix
-	// cache that dropped Content-Encoding). Serving it as identity is exactly the
-	// U+001F bug — evict it and miss instead.
-	if e.ce == "" && hasGzipMagic(data) {
+	// Defensive self-heal: an entry recorded as identity (ce=="") whose body is
+	// actually compressed is a corrupt legacy entry (stored by the pre-fix cache
+	// that dropped Content-Encoding — gzip, brotli, deflate or zstd). Serving it
+	// as identity is exactly the U+001F bug — evict it and miss instead.
+	if e.ce == "" && isCorruptIdentity(e.ct, data) {
 		metaPath := bodyPath + ".m"
 		m.mu.Lock()
 		if ex, ok := m.index[key]; ok {

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/mediacache.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/mediacache.go
@@ -65,6 +65,7 @@ type cacheEntry struct {
 	exp   int64 // unix timestamp; 0 = never expire
 	atime int64 // unix timestamp of last access (for LRU eviction)
 	ct    string
+	ce    string // Content-Encoding of the stored body ("" = identity)
 }
 
 // CacheStats is a snapshot of MediaCache counters.
@@ -157,6 +158,7 @@ func (m *MediaCache) loadIndex() {
 			metaPath := bodyPath + ".m"
 			var meta struct {
 				CT  string `json:"ct"`
+				CE  string `json:"ce"`
 				Exp int64  `json:"exp"`
 			}
 			if raw, err := os.ReadFile(metaPath); err == nil {
@@ -172,6 +174,7 @@ func (m *MediaCache) loadIndex() {
 				// cache Get() hit — a reliable in-band atime surrogate.
 				atime: info.ModTime().Unix(),
 				ct:    meta.CT,
+				ce:    meta.CE,
 			}
 			m.index[key] = e
 			m.total += info.Size()
@@ -195,9 +198,46 @@ func isCacheable(ct string) bool {
 	return false
 }
 
+// hasGzipMagic reports whether b begins with the gzip magic number (0x1F 0x8B).
+// Used as a defensive self-heal signal: a stored body carrying this magic while
+// the entry records no Content-Encoding is a corrupt/legacy entry that must not
+// be served as identity (that is the U+001F corruption bug this cache had).
+func hasGzipMagic(b []byte) bool {
+	return len(b) >= 2 && b[0] == 0x1f && b[1] == 0x8b
+}
+
+// encodingAccepted reports whether the client's Accept-Encoding header permits
+// the given content coding. Identity (empty coding) is always acceptable. A
+// token with an explicit q=0 is treated as "not acceptable" per RFC 7231.
+func encodingAccepted(acceptEncoding, coding string) bool {
+	coding = strings.TrimSpace(strings.ToLower(coding))
+	if coding == "" || coding == "identity" {
+		return true
+	}
+	for _, part := range strings.Split(strings.ToLower(acceptEncoding), ",") {
+		tok := strings.TrimSpace(part)
+		base := tok
+		q := 1.0
+		if i := strings.IndexByte(tok, ';'); i >= 0 {
+			base = strings.TrimSpace(tok[:i])
+			if j := strings.Index(tok[i+1:], "q="); j >= 0 {
+				if v, err := strconv.ParseFloat(strings.TrimSpace(tok[i+1+j+2:]), 64); err == nil {
+					q = v
+				}
+			}
+		}
+		if (base == coding || base == "*") && q > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // Get returns the cached body + headers for url if a valid (non-expired) entry
-// exists. ok=false means cache miss (or expired). Fail-open: I/O errors → miss.
-func (m *MediaCache) Get(url string) (body []byte, hdr http.Header, ok bool) {
+// exists that the client can decode. ok=false means cache miss (or expired, or
+// the stored representation is encoded in a way the client did not advertise via
+// acceptEncoding). Fail-open: I/O errors → miss.
+func (m *MediaCache) Get(url, acceptEncoding string) (body []byte, hdr http.Header, ok bool) {
 	key := cacheKey(url)
 	now := m.nowFn().Unix()
 
@@ -211,6 +251,15 @@ func (m *MediaCache) Get(url string) (body []byte, hdr http.Header, ok bool) {
 	}
 	if e.exp != 0 && e.exp < now {
 		// Expired: treat as miss (evict lazily on next store).
+		m.misses.Add(1)
+		return nil, nil, false
+	}
+
+	// If the stored representation is content-encoded, only serve it to a client
+	// that advertised that coding — otherwise the browser would receive bytes it
+	// cannot decode. Treat as a miss so the caller proxies upstream and negotiates
+	// an acceptable encoding.
+	if e.ce != "" && !encodingAccepted(acceptEncoding, e.ce) {
 		m.misses.Add(1)
 		return nil, nil, false
 	}
@@ -229,6 +278,24 @@ func (m *MediaCache) Get(url string) (body []byte, hdr http.Header, ok bool) {
 		return nil, nil, false
 	}
 
+	// Defensive self-heal: an entry with no recorded Content-Encoding whose body
+	// carries the gzip magic is a corrupt legacy entry (stored by the pre-fix
+	// cache that dropped Content-Encoding). Serving it as identity is exactly the
+	// U+001F bug — evict it and miss instead.
+	if e.ce == "" && hasGzipMagic(data) {
+		metaPath := bodyPath + ".m"
+		m.mu.Lock()
+		if ex, ok := m.index[key]; ok {
+			m.total -= ex.size
+			delete(m.index, key)
+		}
+		m.mu.Unlock()
+		_ = os.Remove(bodyPath)
+		_ = os.Remove(metaPath)
+		m.misses.Add(1)
+		return nil, nil, false
+	}
+
 	// Update atime in index and on-disk (mirrors Python e["atime"] = time.time()).
 	m.mu.Lock()
 	if ex, ok := m.index[key]; ok {
@@ -240,6 +307,9 @@ func (m *MediaCache) Get(url string) (body []byte, hdr http.Header, ok bool) {
 	h := http.Header{}
 	if e.ct != "" {
 		h.Set("Content-Type", e.ct)
+	}
+	if e.ce != "" {
+		h.Set("Content-Encoding", e.ce)
 	}
 
 	m.hits.Add(1)
@@ -307,6 +377,10 @@ func (m *MediaCache) MaybeStore(req *http.Request, resp *http.Response, body []b
 
 	// Strip params from ct for storage.
 	ctClean := strings.TrimSpace(strings.SplitN(ct, ";", 2)[0])
+	// Preserve the body's Content-Encoding so a HIT can replay it. Without this,
+	// a gzip body would be served as identity → the client reads 0x1F as text and
+	// the asset is corrupted (dead JS/CSS).
+	ceClean := strings.TrimSpace(resp.Header.Get("Content-Encoding"))
 
 	now := m.nowFn().Unix()
 	exp := now + ttl
@@ -326,10 +400,12 @@ func (m *MediaCache) MaybeStore(req *http.Request, resp *http.Response, body []b
 	}
 	meta := struct {
 		CT  string `json:"ct"`
+		CE  string `json:"ce"`
 		Exp int64  `json:"exp"`
 		URL string `json:"url"`
 	}{
 		CT:  ctClean,
+		CE:  ceClean,
 		Exp: exp,
 		URL: func() string {
 			if len(rawURL) > 300 {
@@ -356,6 +432,7 @@ func (m *MediaCache) MaybeStore(req *http.Request, resp *http.Response, body []b
 		exp:   exp,
 		atime: now,
 		ct:    ctClean,
+		ce:    ceClean,
 	}
 	m.evictIfNeeded()
 	m.mu.Unlock()

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/mediacache_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/mediacache_test.go
@@ -58,7 +58,7 @@ func TestMediaCacheStoreAndGet(t *testing.T) {
 
 	mc.MaybeStore(req, resp, body, testURL)
 
-	got, hdr, ok := mc.Get(testURL)
+	got, hdr, ok := mc.Get(testURL, "")
 	if !ok {
 		t.Fatal("expected cache hit, got miss")
 	}
@@ -84,7 +84,7 @@ func TestMediaCacheRejectsNonMedia(t *testing.T) {
 
 	mc.MaybeStore(req, resp, body, testURL)
 
-	_, _, ok := mc.Get(testURL)
+	_, _, ok := mc.Get(testURL, "")
 	if ok {
 		t.Fatal("text/html must not be cached")
 	}
@@ -105,7 +105,7 @@ func TestMediaCacheRejectsOversize(t *testing.T) {
 
 	mc.MaybeStore(req, resp, bigBody, testURL)
 
-	_, _, ok := mc.Get(testURL)
+	_, _, ok := mc.Get(testURL, "")
 	if ok {
 		t.Fatal("oversized object must not be cached")
 	}
@@ -132,14 +132,14 @@ func TestMediaCacheExpiry(t *testing.T) {
 	mc.MaybeStore(req, resp, body, testURL)
 
 	// Before expiry: should hit.
-	if _, _, ok := mc.Get(testURL); !ok {
+	if _, _, ok := mc.Get(testURL, ""); !ok {
 		t.Fatal("expected hit before TTL expires")
 	}
 
 	// Advance clock past TTL.
 	mc.nowFn = func() time.Time { return epoch.Add(2 * time.Second) }
 
-	if _, _, ok := mc.Get(testURL); ok {
+	if _, _, ok := mc.Get(testURL, ""); ok {
 		t.Fatal("expected miss after TTL expires")
 	}
 }
@@ -220,7 +220,7 @@ func TestMediaCacheNoStoreSkipped(t *testing.T) {
 
 	mc.MaybeStore(req, resp, body, testURL)
 
-	if _, _, ok := mc.Get(testURL); ok {
+	if _, _, ok := mc.Get(testURL, ""); ok {
 		t.Fatal("no-store response must not be cached")
 	}
 }
@@ -244,14 +244,14 @@ func TestMediaCacheStatsIncrement(t *testing.T) {
 	}
 
 	// Hit
-	mc.Get(testURL)
+	mc.Get(testURL, "")
 	s2 := mc.Stats()
 	if s2.Hits != 1 {
 		t.Fatalf("expected Hits=1, got %d", s2.Hits)
 	}
 
 	// Miss
-	mc.Get("http://example.com/notfound.mp3")
+	mc.Get("http://example.com/notfound.mp3", "")
 	s3 := mc.Stats()
 	if s3.Misses != 1 {
 		t.Fatalf("expected Misses=1, got %d", s3.Misses)
@@ -301,7 +301,7 @@ func TestMediaCacheNonGETNotCached(t *testing.T) {
 	resp := makeResp(200, "image/png", 3600, body)
 	mc.MaybeStore(req, resp, body, testURL)
 
-	if _, _, ok := mc.Get(testURL); ok {
+	if _, _, ok := mc.Get(testURL, ""); ok {
 		t.Fatal("POST response must not be cached")
 	}
 }
@@ -322,7 +322,7 @@ func TestMediaCachePersistenceAcrossRestart(t *testing.T) {
 	// "Restart": new cache instance pointing at same dir.
 	mc2 := NewMediaCache(dir)
 
-	got, _, ok := mc2.Get(testURL)
+	got, _, ok := mc2.Get(testURL, "")
 	if !ok {
 		t.Fatal("expected cache hit after restart (on-disk persistence)")
 	}
@@ -481,7 +481,7 @@ func TestMediaCacheHandlerOversizeStreamsFullBody(t *testing.T) {
 	}
 
 	// Verify the oversize object was NOT cached.
-	_, _, cached := mc.Get(testURL)
+	_, _, cached := mc.Get(testURL, "")
 	if cached {
 		t.Fatal("oversize object must NOT be cached (exceeds 16 MiB per-object cap)")
 	}
@@ -516,7 +516,7 @@ func TestMediaCacheVhostIsolation(t *testing.T) {
 	mc.MaybeStore(reqA, respA, bodyA, keyA)
 
 	// Host A should hit with its own content.
-	got, _, ok := mc.Get(keyA)
+	got, _, ok := mc.Get(keyA, "")
 	if !ok {
 		t.Fatal("expected cache HIT for host A")
 	}
@@ -525,7 +525,7 @@ func TestMediaCacheVhostIsolation(t *testing.T) {
 	}
 
 	// Host B — same path, different vhost — must be a MISS (vhost isolation).
-	_, _, ok = mc.Get(keyB)
+	_, _, ok = mc.Get(keyB, "")
 	if ok {
 		t.Fatal("expected cache MISS for host B (vhost isolation violated — cross-tenant bleed)")
 	}
@@ -536,7 +536,7 @@ func TestMediaCacheVhostIsolation(t *testing.T) {
 	mc.MaybeStore(reqB, respB, bodyB, keyB)
 
 	// Now host B hits with its own content, not host A's.
-	got, _, ok = mc.Get(keyB)
+	got, _, ok = mc.Get(keyB, "")
 	if !ok {
 		t.Fatal("expected cache HIT for host B after store")
 	}
@@ -545,7 +545,7 @@ func TestMediaCacheVhostIsolation(t *testing.T) {
 	}
 
 	// Host A must still serve its own content unchanged.
-	got, _, ok = mc.Get(keyA)
+	got, _, ok = mc.Get(keyA, "")
 	if !ok {
 		t.Fatal("expected cache HIT for host A to persist after host B was stored")
 	}
@@ -556,3 +556,83 @@ func TestMediaCacheVhostIsolation(t *testing.T) {
 
 // Ensure os is used (for t.TempDir reference to filesystem).
 var _ = os.DevNull
+
+// --- Content-Encoding preservation (issue #777) ---------------------------------
+
+// respWithCE builds a cacheable response carrying a Content-Encoding header.
+func respWithCE(ct, ce string, maxAge int, body []byte) *http.Response {
+	r := makeResp(200, ct, maxAge, body)
+	if ce != "" {
+		r.Header.Set("Content-Encoding", ce)
+	}
+	return r
+}
+
+// A gzip body must round-trip WITH its Content-Encoding so a gzip-capable client
+// can decode it. This is the core fix: without the replayed header the browser
+// reads 0x1F as text (U+001F) and the asset is dead.
+func TestMediaCachePreservesContentEncoding(t *testing.T) {
+	dir := t.TempDir()
+	mc := NewMediaCache(dir)
+
+	const testURL = "https://yacy.example/js/app.js"
+	// The cache is byte-opaque; a gzip-magic prefix is enough to exercise it.
+	gzBody := []byte{0x1f, 0x8b, 0x08, 0x00, 0x01, 0x02, 0x03}
+
+	mc.MaybeStore(makeGET(testURL),
+		respWithCE("application/javascript", "gzip", 3600, gzBody), gzBody, testURL)
+
+	got, hdr, ok := mc.Get(testURL, "gzip, deflate, br")
+	if !ok {
+		t.Fatal("expected hit for gzip-capable client")
+	}
+	if !bytes.Equal(got, gzBody) {
+		t.Fatalf("body mismatch")
+	}
+	if ce := hdr.Get("Content-Encoding"); ce != "gzip" {
+		t.Fatalf("Content-Encoding not replayed: got %q want gzip", ce)
+	}
+}
+
+// An encoded entry must MISS when the client cannot decode that coding, so the
+// caller proxies upstream instead of handing over undecodable bytes.
+func TestMediaCacheEncodedMissesWhenClientCannotDecode(t *testing.T) {
+	dir := t.TempDir()
+	mc := NewMediaCache(dir)
+
+	const testURL = "https://yacy.example/js/app2.js"
+	gzBody := []byte{0x1f, 0x8b, 0x08, 0x00}
+	mc.MaybeStore(makeGET(testURL),
+		respWithCE("application/javascript", "gzip", 3600, gzBody), gzBody, testURL)
+
+	if _, _, ok := mc.Get(testURL, "identity"); ok {
+		t.Fatal("expected miss for client not accepting gzip")
+	}
+	if _, _, ok := mc.Get(testURL, ""); ok {
+		t.Fatal("expected miss for client with empty Accept-Encoding")
+	}
+	if _, _, ok := mc.Get(testURL, "gzip;q=0, identity"); ok {
+		t.Fatal("expected miss when gzip is refused via q=0")
+	}
+}
+
+// A legacy entry (gzip body stored by the pre-fix cache with no recorded
+// Content-Encoding) must be evicted and treated as a miss — serving it as
+// identity is exactly the corruption bug.
+func TestMediaCacheEvictsCorruptLegacyGzip(t *testing.T) {
+	dir := t.TempDir()
+	mc := NewMediaCache(dir)
+
+	const testURL = "https://yacy.example/js/legacy.js"
+	gzBody := []byte{0x1f, 0x8b, 0x08, 0x00, 0xde, 0xad}
+	// makeResp sets no Content-Encoding → ce="" is persisted, mimicking the old binary.
+	mc.MaybeStore(makeGET(testURL),
+		makeResp(200, "application/javascript", 3600, gzBody), gzBody, testURL)
+
+	if _, _, ok := mc.Get(testURL, "gzip"); ok {
+		t.Fatal("expected corrupt legacy gzip entry to be evicted, got hit")
+	}
+	if _, _, ok := mc.Get(testURL, "gzip"); ok {
+		t.Fatal("entry should remain evicted on the second lookup")
+	}
+}

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/mediacache_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/mediacache_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 // makeResp builds a minimal *http.Response suitable for MaybeStore.
@@ -634,5 +635,77 @@ func TestMediaCacheEvictsCorruptLegacyGzip(t *testing.T) {
 	}
 	if _, _, ok := mc.Get(testURL, "gzip"); ok {
 		t.Fatal("entry should remain evicted on the second lookup")
+	}
+}
+
+// --- encodingAccepted table (M1: trailing-param q-value) ------------------------
+
+func TestEncodingAcceptedTable(t *testing.T) {
+	cases := []struct {
+		ae, coding string
+		want       bool
+	}{
+		{"gzip, deflate, br", "gzip", true},
+		{"gzip, deflate, br", "br", true},
+		{"gzip, deflate", "zstd", false},
+		{"*", "gzip", true},
+		{"*;q=0", "gzip", false},
+		{"gzip;q=0, identity", "gzip", false},
+		{"gzip;q=0;x=y, identity", "gzip", false}, // trailing param after q= must still reject
+		{"gzip;q=1.0", "gzip", true},
+		{"  GZIP ;q=0.5 ", "gzip", true},          // case + whitespace
+		{"", "gzip", false},
+		{"anything", "", true},        // identity coding always ok
+		{"", "identity", true},        // identity coding always ok
+	}
+	for _, c := range cases {
+		if got := encodingAccepted(c.ae, c.coding); got != c.want {
+			t.Errorf("encodingAccepted(%q, %q) = %v, want %v", c.ae, c.coding, got, c.want)
+		}
+	}
+}
+
+// --- I1: legacy non-gzip (brotli/deflate/zstd) text entry must self-heal --------
+
+func TestMediaCacheEvictsCorruptLegacyNonGzipText(t *testing.T) {
+	dir := t.TempDir()
+	mc := NewMediaCache(dir)
+
+	const testURL = "https://yacy.example/js/legacy-br.js"
+	// A brotli/zstd body has no gzip magic but is not valid UTF-8 — simulate with
+	// raw bytes that are invalid UTF-8 and don't start 0x1f8b.
+	brBody := []byte{0x8b, 0x02, 0x80, 0xff, 0xfe, 0x00, 0x41}
+	if utf8.Valid(brBody) {
+		t.Fatal("test body must be invalid UTF-8")
+	}
+	mc.MaybeStore(makeGET(testURL),
+		makeResp(200, "application/javascript", 3600, brBody), brBody, testURL)
+
+	// Recorded ce="" (makeResp sets none) + non-UTF-8 JS body → corrupt legacy →
+	// must be evicted, not served as identity.
+	if _, _, ok := mc.Get(testURL, "br"); ok {
+		t.Fatal("expected corrupt legacy non-gzip text entry to be evicted, got hit")
+	}
+}
+
+// A legitimate identity JS body (valid UTF-8, ce="") must still be served.
+func TestMediaCacheServesValidIdentityText(t *testing.T) {
+	dir := t.TempDir()
+	mc := NewMediaCache(dir)
+
+	const testURL = "https://yacy.example/js/plain.js"
+	body := []byte("/* hello */ console.log('héllo');") // valid UTF-8
+	mc.MaybeStore(makeGET(testURL),
+		makeResp(200, "application/javascript", 3600, body), body, testURL)
+
+	got, hdr, ok := mc.Get(testURL, "gzip")
+	if !ok {
+		t.Fatal("expected hit for valid identity JS body")
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatal("body mismatch")
+	}
+	if ce := hdr.Get("Content-Encoding"); ce != "" {
+		t.Fatalf("identity body must have no Content-Encoding, got %q", ce)
 	}
 }


### PR DESCRIPTION
Fixes the media cache serving compressed JS/CSS without `Content-Encoding` (U+001F → dead scripts → blank pages, e.g. empty YaCy search).

- MaybeStore persists Content-Encoding; Get(url, acceptEncoding) replays it and only serves an encoded entry the client can decode (q=0 honored).
- Self-heal evicts corrupt legacy entries: gzip magic, plus non-UTF-8 text/js/css bodies recorded as identity (catches br/deflate/zstd).
- Tests: CE round-trip, non-decodable miss, legacy gzip + non-gzip eviction, encodingAccepted table.

Reviewed adversarially (I1 legacy-brotli + M1 q-value fixed post-review). Live mitigation (cache disabled via drop-in) in place until this ships.

ref #777