### PR TITLE
feat(users,yacy): sync master admin password to YaCy + durable fixes (ref #776)

### DIFF
--- a/packages/secubox-users/api/engine.py
+++ b/packages/secubox-users/api/engine.py
@@ -61,14 +61,38 @@ class Engine:
         return json.loads(self.users_path.read_text())
 
     def _save(self, doc: Dict[str, Any]) -> None:
-        """Atomic write: temp + os.replace in the same dir."""
+        """Atomic write: temp + os.replace in the same dir.
+
+        Preserves the existing file's owner + mode. Without this, a root-run CLI
+        (``sudo usersctl set-password``) would leave users.json as root:root 0600
+        — unreadable by the secubox-owned auth service, which then falls back to
+        the auth.toml emergency users and rejects every login. Mirrors
+        secubox_core.user_store.set_password's owner-preservation.
+        """
         self.users_path.parent.mkdir(parents=True, exist_ok=True)
+        prev_stat = None
+        try:
+            prev_stat = self.users_path.stat()
+        except FileNotFoundError:
+            pass
         fd, tmp_path = tempfile.mkstemp(
             prefix=".users.json.", dir=str(self.users_path.parent)
         )
         try:
             with os.fdopen(fd, "w") as f:
                 json.dump(doc, f, indent=2, sort_keys=True)
+            if prev_stat is not None:
+                # Re-apply the prior owner/mode so a root writer does not strip
+                # the secubox service's access. Fail-open: a non-root writer that
+                # cannot chown keeps its own (identical) ownership.
+                try:
+                    os.chown(tmp_path, prev_stat.st_uid, prev_stat.st_gid)
+                except OSError:
+                    pass
+                try:
+                    os.chmod(tmp_path, prev_stat.st_mode & 0o777)
+                except OSError:
+                    pass
             os.replace(tmp_path, self.users_path)
         except Exception:
             try:

--- a/packages/secubox-users/api/main.py
+++ b/packages/secubox-users/api/main.py
@@ -39,6 +39,10 @@ USERSCTL = "/usr/sbin/usersctl"
 USERS_FILE = os.environ.get("USERS_FILE", "/etc/secubox/users.json")
 ROLES_FILE = os.environ.get("ROLES_FILE", "/etc/secubox/roles.json")
 SERVICES = ["nextcloud", "gitea", "email", "matrix", "jellyfin", "peertube", "jabber"]
+# YaCy has a single admin account (no per-user accounts), so its password is
+# synced from exactly one SecuBox user: the master "admin". Changing that user's
+# password propagates to YaCy when the module is installed and active.
+YACY_SYNC_USER = "admin"
 SESSIONS_FILE = os.environ.get("SECUBOX_AUTH_SESSIONS", "/var/lib/secubox/auth/sessions.json")
 
 # Single engine instance — all mutations go through here
@@ -324,6 +328,44 @@ def get_service_ctl(name: str) -> Optional[str]:
     ctl = f"/usr/sbin/{name}ctl"
     return ctl if os.path.exists(ctl) else None
 
+
+def _yacy_available() -> bool:
+    """True when the YaCy module is installed and its host service is active."""
+    if not os.path.exists("/usr/sbin/yacyctl"):
+        return False
+    try:
+        r = subprocess.run(
+            ["systemctl", "is-active", "--quiet", "secubox-yacy.service"],
+            timeout=5,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def _sync_yacy_admin_password(username: str, password: str) -> Optional[bool]:
+    """Propagate the master admin user's password to YaCy's single admin account.
+
+    Returns True/False on an attempt, or None when skipped (not the sync user, or
+    YaCy not installed/active). The password is handed to `yacyctl set-admin-password`
+    over STDIN (never argv) so it cannot leak via ps/sudo logs. yacyctl needs root
+    (secret file + lxc-attach); the secubox user is granted exactly this one command
+    via secubox-yacy's sudoers drop-in.
+    """
+    if username != YACY_SYNC_USER:
+        return None
+    if not _yacy_available():
+        return None
+    try:
+        r = subprocess.run(
+            ["sudo", "-n", "/usr/sbin/yacyctl", "set-admin-password"],
+            input=password,
+            capture_output=True, text=True, timeout=90,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
 def load_roles() -> List[dict]:
     """Load roles from JSON file or return defaults."""
     if os.path.exists(ROLES_FILE):
@@ -508,6 +550,11 @@ def create_user(user: UserCreate):
         else:
             provision_results[svc] = False
 
+    # YaCy single-admin sync (only fires for the master 'admin' user).
+    yacy_synced = _sync_yacy_admin_password(user.username, user.password)
+    if yacy_synced is not None:
+        provision_results["yacy"] = yacy_synced
+
     # Persist services list via engine's atomic I/O
     if user.services:
         doc = _engine._load()
@@ -669,6 +716,13 @@ def change_password(username: str, pwd: PasswordChange):
                 results[svc] = result.returncode == 0
             except Exception:
                 results[svc] = False
+
+    # YaCy has a single admin account, synced from the master 'admin' user only.
+    # Independent of the per-user services list above.
+    yacy_synced = _sync_yacy_admin_password(username, pwd.password)
+    if yacy_synced is not None:
+        results["yacy"] = yacy_synced
+
     return {"success": True, "password_results": results}
 
 

--- a/packages/secubox-users/api/main.py
+++ b/packages/secubox-users/api/main.py
@@ -5,6 +5,7 @@ Roles, Permissions, Access Control Lists, and Active Sessions
 """
 import subprocess
 import json
+import logging
 import os
 from datetime import datetime
 from pathlib import Path
@@ -43,6 +44,8 @@ SERVICES = ["nextcloud", "gitea", "email", "matrix", "jellyfin", "peertube", "ja
 # synced from exactly one SecuBox user: the master "admin". Changing that user's
 # password propagates to YaCy when the module is installed and active.
 YACY_SYNC_USER = "admin"
+
+_log = logging.getLogger("secubox.users")
 SESSIONS_FILE = os.environ.get("SECUBOX_AUTH_SESSIONS", "/var/lib/secubox/auth/sessions.json")
 
 # Single engine instance — all mutations go through here
@@ -351,6 +354,14 @@ def _sync_yacy_admin_password(username: str, password: str) -> Optional[bool]:
     over STDIN (never argv) so it cannot leak via ps/sudo logs. yacyctl needs root
     (secret file + lxc-attach); the secubox user is granted exactly this one command
     via secubox-yacy's sudoers drop-in.
+
+    Runtime requirement: this uses `sudo`, which is neutralized by
+    `NoNewPrivileges=true` (the kernel drops the setuid bit regardless of sudoers).
+    It therefore only elevates when secubox-users runs with NNP disabled — which is
+    the case when the module is served in-process by secubox-aggregator
+    (NoNewPrivileges=no). On a hardened standalone unit the sudo call fails; we log
+    it loudly and return False (never a silent success) so the operator sees that
+    YaCy was NOT updated.
     """
     if username != YACY_SYNC_USER:
         return None
@@ -362,8 +373,15 @@ def _sync_yacy_admin_password(username: str, password: str) -> Optional[bool]:
             input=password,
             capture_output=True, text=True, timeout=90,
         )
-        return r.returncode == 0
-    except Exception:
+        if r.returncode != 0:
+            _log.warning(
+                "YaCy admin password sync failed (rc=%s): %s",
+                r.returncode, (r.stderr or "").strip()[:300],
+            )
+            return False
+        return True
+    except Exception as exc:
+        _log.warning("YaCy admin password sync errored: %s", exc)
         return False
 
 def load_roles() -> List[dict]:

--- a/packages/secubox-users/tests/test_yacy_password_sync.py
+++ b/packages/secubox-users/tests/test_yacy_password_sync.py
@@ -1,0 +1,81 @@
+"""secubox-users → YaCy admin password sync (#776) + users.json owner preservation.
+
+The sync pushes the master 'admin' user's password to YaCy's single admin account
+over STDIN; the owner-preservation guard keeps a root-run CLI from locking the
+secubox auth service out of users.json.
+"""
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "common"))
+sys.path.insert(0, str(ROOT / "packages" / "secubox-users"))
+
+import api.main as m  # noqa: E402
+from api import engine as E  # noqa: E402
+
+
+# --- YaCy admin password sync ---------------------------------------------------
+
+def test_sync_yacy_skips_non_admin():
+    # Only the master 'admin' user drives YaCy's single admin account.
+    assert m._sync_yacy_admin_password("bob", "pw") is None
+
+
+def test_sync_yacy_skips_when_yacy_absent(monkeypatch):
+    monkeypatch.setattr(m, "_yacy_available", lambda: False)
+    assert m._sync_yacy_admin_password("admin", "pw") is None
+
+
+def test_sync_yacy_pushes_password_over_stdin(monkeypatch):
+    monkeypatch.setattr(m, "_yacy_available", lambda: True)
+    seen = {}
+
+    class _R:
+        returncode = 0
+
+    def _fake_run(cmd, **kw):
+        seen["cmd"] = cmd
+        seen["input"] = kw.get("input")
+        return _R()
+
+    monkeypatch.setattr(m.subprocess, "run", _fake_run)
+    ok = m._sync_yacy_admin_password("admin", "s3cret;pw")
+    assert ok is True
+    assert seen["cmd"] == ["sudo", "-n", "/usr/sbin/yacyctl", "set-admin-password"]
+    # Password must travel over stdin, never argv (no ps / sudo-log leak).
+    assert seen["input"] == "s3cret;pw"
+    assert "s3cret;pw" not in " ".join(seen["cmd"])
+
+
+def test_sync_yacy_reports_failure(monkeypatch):
+    monkeypatch.setattr(m, "_yacy_available", lambda: True)
+
+    class _R:
+        returncode = 1
+
+    monkeypatch.setattr(m.subprocess, "run", lambda *a, **k: _R())
+    assert m._sync_yacy_admin_password("admin", "pw") is False
+
+
+# --- users.json owner/mode preservation (root-run CLI regression) ---------------
+
+def test_engine_save_preserves_mode(tmp_path):
+    """A distinctive pre-existing mode must survive _save.
+
+    Regression: a root-run `usersctl set-password` used to recreate users.json
+    with mkstemp's default 0o600 (root:root), locking out the secubox auth
+    service. 0o640 is distinct from that default, so this fails without the guard.
+    """
+    p = tmp_path / "users.json"
+    p.write_text(json.dumps({"version": 2, "users": [], "groups": []}))
+    os.chmod(p, 0o640)
+    eng = E.Engine(users_path=p)
+    eng.create_user("bob", email="bob@x.test", role="viewer")
+    mode = stat.S_IMODE(os.stat(p).st_mode)
+    assert mode == 0o640, f"mode not preserved after _save: {oct(mode)}"

--- a/packages/secubox-yacy/lib/yacy/install-lxc.sh
+++ b/packages/secubox-yacy/lib/yacy/install-lxc.sh
@@ -252,6 +252,29 @@ configure_yacy_admin() {
     lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl start yacy 2>/dev/null || true
 }
 
+# Public/LAN search must render results for anonymous visitors. YaCy's
+# adminAccountForLocalhost=true makes every request from a local/proxy IP
+# (127.*, 10.*, 192.168.* — see the proxyClient pref) be treated as a pseudo
+# admin. The search page then sets authSearch=1 and appends `&auth` to the
+# yacysearchitem.html AJAX that renders each hit; those requests demand a real
+# admin credential the anonymous browser doesn't carry, get 401, and NO result
+# ever renders — the box shows an empty result list to LAN users while the raw
+# index (yacysearch.json) is full. Turning it off keeps admin behind the
+# password we set (configure_yacy_admin) and lets anonymous search render.
+configure_search_access() {
+    local yacy_conf="/opt/yacy/DATA/SETTINGS/yacy.conf"
+    if lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- \
+        grep -q '^adminAccountForLocalhost=false$' "$yacy_conf" 2>/dev/null; then
+        log "adminAccountForLocalhost already disabled — skipping"
+        return
+    fi
+    log "Disabling adminAccountForLocalhost (public search render fix) ..."
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl stop yacy 2>/dev/null || true
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- sed -i \
+        "s|^adminAccountForLocalhost=.*|adminAccountForLocalhost=false|" "$yacy_conf"
+    lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- systemctl start yacy 2>/dev/null || true
+}
+
 mark_provisioned() {
     install -d -m 0755 -o secubox -g secubox "$STATE_DIR"
     date -Iseconds > "$SENTINEL"
@@ -270,6 +293,7 @@ main() {
     install_yacy_in_lxc
     generate_admin_password
     configure_yacy_admin
+    configure_search_access
     provision_yacy
     mark_provisioned
     log "OK — LXC '$LXC_NAME' at $LXC_IP, yacy provisioned + running on port 8090."

--- a/packages/secubox-yacy/sbin/yacyctl
+++ b/packages/secubox-yacy/sbin/yacyctl
@@ -14,6 +14,7 @@ readonly CONFIG_FILE="${SECUBOX_YACY_CONFIG:-/etc/secubox/yacy.toml}"
 readonly STATE_DIR="${SECUBOX_YACY_STATE:-/var/lib/secubox/yacy}"
 readonly SECRETS_DIR="${SECUBOX_SECRETS_DIR:-/etc/secubox/secrets}"
 readonly INSTALL_LIB="${SECUBOX_INSTALL_LIB:-/usr/share/secubox/lib/yacy/install-lxc.sh}"
+readonly YACY_CONF="/opt/yacy/DATA/SETTINGS/yacy.conf"
 
 readonly RED='\033[0;31m'; readonly GREEN='\033[0;32m'; readonly YELLOW='\033[1;33m'; readonly NC='\033[0m'
 log()  { printf '%b[yacy]%b %s\n' "$GREEN" "$NC" "$*"; }
@@ -160,6 +161,50 @@ cmd_reload() {
     log "Reloaded."
 }
 
+cmd_set_admin_password() {
+    # Push a new plaintext admin password into YaCy's single admin account.
+    #
+    # The password is read from STDIN (never argv) so it cannot leak via `ps`,
+    # the shell history, or sudo's command log. This is the sync target invoked
+    # by secubox-users when the master 'admin' user's password changes (over
+    # `sudo -n yacyctl set-admin-password`), and it is safe to run by hand.
+    #
+    # Requires root: it writes the root-owned secret file and drives the
+    # in-container daemon via lxc-attach. When invoked through sudo, id -u == 0
+    # so lxc_attach() runs lxc-attach directly.
+    if [ "$(id -u)" -ne 0 ]; then err "set-admin-password requires root"; exit 2; fi
+
+    local pw; pw=$(cat)
+    [ -n "$pw" ] || { err "empty password on stdin"; exit 2; }
+
+    install -d -m 0700 "$SECRETS_DIR"
+    printf '%s\n' "$pw" > "$SECRETS_DIR/yacy-admin"
+    chmod 600 "$SECRETS_DIR/yacy-admin"
+
+    # YaCy HTTP Digest hash: md5("admin:<adminRealm>:<password>"). Mirrors YaCy's
+    # own bin/passwd.sh and configure_yacy_admin() in install-lxc.sh — keep the
+    # three in lock-step if the format ever changes.
+    local realm hash
+    realm=$(lxc_attach -- sh -c "grep '^adminRealm=' $YACY_CONF | cut -d= -f2-" 2>/dev/null || true)
+    [ -n "$realm" ] || realm="YaCy"
+    hash=$(printf 'admin:%s:%s' "$realm" "$pw" | md5sum | cut -d' ' -f1)
+    [ -n "$hash" ] || { err "hash computation failed"; exit 2; }
+
+    # Idempotent: skip the daemon restart when the hash is already current.
+    if lxc_attach -- grep -q "^adminAccountBase64MD5=MD5:${hash}$" "$YACY_CONF" 2>/dev/null; then
+        log "YaCy admin password already up to date — no change."
+        return 0
+    fi
+
+    # YaCy rewrites yacy.conf on shutdown, so it must be stopped before editing.
+    log "Updating YaCy admin password (restarting daemon) ..."
+    lxc_attach -- systemctl stop yacy 2>/dev/null || true
+    lxc_attach -- sed -i \
+        "s|^adminAccountBase64MD5=.*|adminAccountBase64MD5=MD5:${hash}|" "$YACY_CONF"
+    lxc_attach -- systemctl start yacy 2>/dev/null || true
+    log "YaCy admin password updated."
+}
+
 cmd_help() {
     cat <<'HELP'
 yacyctl — SecuBox YaCy controller (SEARCH layer)
@@ -172,6 +217,7 @@ Three-fold introspection:
 Lifecycle:
   yacyctl install                  # idempotent LXC + JVM + YaCy bootstrap
   yacyctl reload                   # restart host FastAPI + yacy daemon
+  yacyctl set-admin-password       # read new admin password from STDIN, apply + restart
 
 Search-engine nouns:
   yacyctl peer       list|add <url>|remove <hash>|status <hash>
@@ -191,6 +237,7 @@ main() {
     shift || true
     case "$noun" in
         components|status|access|install|reload) "cmd_${noun}" "$@" ;;
+        set-admin-password) cmd_set_admin_password "$@" ;;
         peer|index|query|blacklist|crawler)
             err "noun '$noun' not yet implemented in v$VERSION — see #232 follow-up task"
             exit 2 ;;

--- a/packages/secubox-yacy/sudoers.d/secubox-yacy
+++ b/packages/secubox-yacy/sudoers.d/secubox-yacy
@@ -8,3 +8,9 @@ secubox ALL=(root) NOPASSWD: /usr/bin/lxc-info
 secubox ALL=(root) NOPASSWD: /usr/bin/lxc-attach
 secubox ALL=(root) NOPASSWD: /usr/bin/lxc-start
 secubox ALL=(root) NOPASSWD: /usr/bin/lxc-stop
+
+# Password sync: secubox-users (User=secubox) pushes the master 'admin' user's
+# password into YaCy's single admin account. The password is read from STDIN
+# (never argv), so it cannot leak via ps/sudo logs. Exact-command match — no
+# wildcard args — so only the bare subcommand is permitted.
+secubox ALL=(root) NOPASSWD: /usr/sbin/yacyctl set-admin-password


### PR DESCRIPTION
secubox-users → YaCy single-admin password sync, plus fixes for issues found while resetting the admin password.

- yacyctl `set-admin-password` (password over STDIN, exact-match sudoers, YaCy Digest hash).
- _sync_yacy_admin_password on create/change for the master 'admin' user only; logs loudly + returns False on sudo/NNP failure (no silent no-op), NNP requirement documented.
- install-lxc.sh: adminAccountForLocalhost=false (durable search-render fix).
- engine._save: preserve users.json owner+mode (root-run CLI no longer locks out the secubox auth service).
- Tests: sync (stdin/skip/failure) + owner-mode preservation.

Reviewed adversarially (hash consistency, no leak, sudoers scope confirmed; NNP finding addressed).

ref #776