### PR TITLE
feat(auth): configurable forced admin TOTP enrollment (ref #778)

### DIFF
--- a/packages/secubox-auth/api/main.py
+++ b/packages/secubox-auth/api/main.py
@@ -246,8 +246,15 @@ def _login_v2(req: _LoginIn, request: _Request, response: _Response):
         _append_audit("mfa_challenge_issued", req.username, {"ip": ip})
         return {"mfa_required": True, "mfa_token": mfa_tok}
 
-    # Admin without TOTP → force enrollment
-    if user.get("role") == "admin":
+    # Admin without TOTP → force enrollment, unless disabled by config.
+    # [auth] require_admin_totp defaults to true (secure/CSPN default); set it to
+    # false in /etc/secubox/secubox.conf to allow password-only admin login on a
+    # given node. Fail-secure: any config error keeps enrollment mandatory.
+    try:
+        _require_admin_totp = bool((get_config("auth") or {}).get("require_admin_totp", True))
+    except Exception:
+        _require_admin_totp = True
+    if user.get("role") == "admin" and _require_admin_totp:
         enroll_tok = create_token(req.username, scope="totp-enroll", expires_in=900)
         _append_audit("totp_enrollment_required", req.username, {"ip": ip})
         return {"enrollment_required": True, "enrollment_token": enroll_tok}

--- a/packages/secubox-auth/tests/test_auth_flows.py
+++ b/packages/secubox-auth/tests/test_auth_flows.py
@@ -66,6 +66,35 @@ def test_admin_password_login_returns_enrollment_token(client):
     assert "enrollment_token" in body
 
 
+def test_admin_login_session_when_totp_not_required(client, monkeypatch):
+    """require_admin_totp=false → admin logs in with password only (no enrollment)."""
+    c, _users_path, _ = client
+    from api import main as auth_main
+    monkeypatch.setattr(
+        auth_main, "get_config",
+        lambda section="": {"require_admin_totp": False} if section == "auth" else {},
+    )
+    r = c.post("/auth/login", json={"username": "admin", "password": "GoodPass!42xyz"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("access_token"), body
+    assert not body.get("enrollment_required")
+
+
+def test_admin_totp_forced_when_config_errors(client, monkeypatch):
+    """Fail-secure: a get_config error keeps admin enrollment mandatory."""
+    c, _users_path, _ = client
+    from api import main as auth_main
+
+    def _boom(section=""):
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr(auth_main, "get_config", _boom)
+    r = c.post("/auth/login", json={"username": "admin", "password": "GoodPass!42xyz"})
+    assert r.status_code == 200
+    assert r.json().get("enrollment_required") is True
+
+
 def test_wrong_password_returns_401(client):
     c, *_ = client
     r = c.post("/auth/login", json={"username": "admin", "password": "wrong"})

--- a/secubox.conf.example
+++ b/secubox.conf.example
@@ -21,6 +21,9 @@ sso_cookie_domain = ""
 
 # Utilisateurs locaux (fallback si pas d'OAuth)
 [auth]
+# Force TOTP (2FA) enrollment for admin accounts on login. Default: true
+# (secure/CSPN). Set to false to allow password-only admin login on this node.
+require_admin_totp = true
 
 [auth.users.admin]
 password = "secubox"            # À changer impérativement !


### PR DESCRIPTION
Gate the forced admin TOTP enrollment on `[auth] require_admin_totp` (default true = secure/CSPN). Set false for password-only admin login on a node. Fail-secure: any config error keeps enrollment mandatory.

- packages/secubox-auth/api/main.py + secubox.conf.example + tests (session-when-disabled, fail-secure).

Review verdict: CLEAN.

ref #778