### PR TITLE
fix(threats): populate SOC dashboard — sudo cscli + correct sbxwaf log path (ref #782)

### DIFF
--- a/packages/secubox-threats/api/main.py
+++ b/packages/secubox-threats/api/main.py
@@ -207,11 +207,18 @@ def _generate_id() -> str:
 # ══════════════════════════════════════════════════════════════
 
 def _fetch_crowdsec_alerts() -> List[Dict]:
-    """Fetch alerts from CrowdSec."""
+    """Fetch alerts from CrowdSec.
+
+    The module runs as the `secubox` user, which cannot read CrowdSec's LAPI
+    socket directly, so cscli is invoked through sudo (exact-command sudoers grant
+    in secubox-threats' drop-in). This elevates only under the aggregator
+    (NoNewPrivileges=no); on a hardened standalone unit sudo is neutralized and the
+    fetch simply returns [] (fail-open — the endpoint still serves stored alerts).
+    """
     alerts = []
     try:
         result = subprocess.run(
-            ["cscli", "alerts", "list", "-o", "json"],
+            ["sudo", "-n", "/usr/bin/cscli", "alerts", "list", "-o", "json"],
             capture_output=True, text=True, timeout=5
         )
         if result.returncode == 0 and result.stdout:
@@ -269,9 +276,13 @@ def _fetch_suricata_alerts() -> List[Dict]:
 
 
 def _fetch_waf_alerts() -> List[Dict]:
-    """Fetch alerts from HAProxy/mitmproxy WAF logs."""
+    """Fetch alerts from the sbxwaf threat log.
+
+    Reads /var/log/secubox/waf/waf-threats.log (JSON-per-line), whose schema is
+    {timestamp, client_ip, host, method, path, category, severity, rule_id, action}.
+    """
     alerts = []
-    waf_log = Path("/var/log/secubox/waf.json")
+    waf_log = Path("/var/log/secubox/waf/waf-threats.log")
     if waf_log.exists():
         try:
             result = subprocess.run(
@@ -284,13 +295,19 @@ def _fetch_waf_alerts() -> List[Dict]:
                         continue
                     try:
                         event = json.loads(line)
+                        ts = event.get("timestamp", "")
+                        ip = event.get("client_ip", "")
+                        cat = event.get("category", "waf")
+                        # sbxwaf lines carry no unique id; a stable per-event id
+                        # (ts+ip+path) lets /alerts dedupe on re-scan.
+                        eid = event.get("rule_id") or f"{ts}-{ip}-{event.get('path','')}"
                         alerts.append({
-                            "id": f"waf-{event.get('id', _generate_id())}",
+                            "id": f"waf-{eid}",
                             "source": "waf",
                             "severity": event.get("severity", "medium"),
-                            "message": event.get("rule", event.get("message", "Unknown")),
-                            "value": event.get("client_ip", ""),
-                            "timestamp": event.get("timestamp", ""),
+                            "message": f"{cat}: {event.get('method','')} {event.get('path','')}".strip(),
+                            "value": ip,
+                            "timestamp": ts,
                             "raw": event
                         })
                     except Exception:

--- a/packages/secubox-threats/debian/rules
+++ b/packages/secubox-threats/debian/rules
@@ -15,3 +15,7 @@ override_dh_auto_install:
 	# Systemd service
 	install -d debian/secubox-threats/usr/lib/systemd/system
 	[ -f systemd/secubox-threats.service ] && cp systemd/secubox-threats.service debian/secubox-threats/usr/lib/systemd/system/ || true
+
+	# sudoers: let the secubox-run FastAPI read CrowdSec alerts (cscli via sudo)
+	install -d debian/secubox-threats/etc/sudoers.d
+	[ -f sudoers.d/secubox-threats ] && install -m 440 sudoers.d/secubox-threats debian/secubox-threats/etc/sudoers.d/ || true

--- a/packages/secubox-threats/sudoers.d/secubox-threats
+++ b/packages/secubox-threats/sudoers.d/secubox-threats
@@ -1,0 +1,5 @@
+# SecuBox Threats — allow the secubox user (the module runs as User=secubox) to
+# read CrowdSec alerts for the SOC dashboard ingestion. cscli talks to the LAPI
+# socket which is not group-readable by secubox, so it is invoked via sudo.
+# Read-only listing only; exact command prefix, no write/decision subcommands.
+secubox ALL=(root) NOPASSWD: /usr/bin/cscli alerts list -o json


### PR DESCRIPTION
`/threats/` showed all-zero because both live sources failed:
- `_fetch_crowdsec_alerts` ran bare `cscli` as the secubox user (no LAPI access) → now `sudo -n /usr/bin/cscli alerts list -o json` with an exact-command sudoers drop-in (works under aggregator NNP=no, fail-open otherwise).
- `_fetch_waf_alerts` read a nonexistent path → now reads `/var/log/secubox/waf/waf-threats.log` and maps the sbxwaf schema with a stable per-event id.
- debian/rules installs the 0440 sudoers drop-in.

Verified live on gk2: cscli via sudo returns 50 alerts, WAF log ingested → `unacknowledged_alerts: 98` (was 0).

ref #782