### PR TITLE
PDF report: rich Netrunner character sheet + persona/dpi/media route parity + real Quêtes (#790, #792)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-pdf-character-sheet.md
+++ b/docs/superpowers/plans/2026-07-04-pdf-character-sheet.md
@@ -1,0 +1,479 @@
+# Rich PDF Character Sheet + Route Parity — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the PDF report's Netrunner character sheet as rich as the HTML `.nr` card (pip attributes + notes, on/off inventory, bestiary, active-threats section), and make all three PDF routes emit the same enriched content.
+
+**Architecture:** Part A enriches the existing `reports._persona_block` (full-fpdf, no matplotlib) plus a small `_attr_row` helper. Part B extracts `report_me`'s inline data-enrichment into `api._enrich_report_data(mac_hash, data, ua="")` and calls it from `report_me`, `report` (token), and `admin_client_report`.
+
+**Tech Stack:** Python 3.11, fpdf2 (no matplotlib added), FastAPI, pytest.
+
+## Global Constraints
+
+- New test file(s) MUST carry the full 4-line SPDX header block: `# SPDX-License-Identifier: LicenseRef-CMSD-1.0` + `# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>` + `# Source-Disclosed License — All rights reserved except as expressly granted.` + `# See LICENCE-CMSD-1.0.md for terms.`
+- The character sheet is **full-fpdf** — do NOT add any matplotlib render (keeps `render_pdf` light; the #785 incident was matplotlib-driven).
+- Every text string drawn in the PDF goes through the existing `_safe(...)` helper (emoji-safe).
+- The Quêtes/menaces section MUST fail-safe on missing keys: `alerts = ((report.get("dpi_exfil") or {}).get("me") or {}).get("alerts") or []`.
+- Pip count clamped to 0..6 before string multiplication.
+- Reuse existing helpers (`_safe`, `_persona_bar`, `_bullet`, `_page_w`) and the existing palette. No new drawing engine.
+- Only `packages/secubox-toolbox/secubox_toolbox/reports.py`, `.../api.py`, and test files may change.
+- Tests run from the package dir: `cd packages/secubox-toolbox && PYTHONPATH=<worktree>/common <venv>/bin/python3 -m pytest tests/<f> -q`. Venv: `/home/reepost/CyberMindStudio/secubox-deb/secubox-deb/.venv/bin/python3` (has fpdf2 + matplotlib).
+
+---
+
+## File Structure
+
+- `packages/secubox-toolbox/secubox_toolbox/reports.py` — **modify**: add `_attr_row`; rewrite `_persona_block` body (lines 568-603) to the rich layout.
+- `packages/secubox-toolbox/tests/test_persona_pdf.py` — **new**: tests for the enriched persona block.
+- `packages/secubox-toolbox/secubox_toolbox/api.py` — **modify**: add `_enrich_report_data`; replace `report_me`'s inline block (2882-2904); add the call to `report` and `admin_client_report`.
+- `packages/secubox-toolbox/tests/test_enrich_report_data.py` — **new**: hermetic test of the enrichment helper.
+
+---
+
+## Task 1: Enrich `_persona_block` (Part A)
+
+**Files:**
+- Modify: `packages/secubox-toolbox/secubox_toolbox/reports.py` (add `_attr_row` before `_persona_block` at line 568; replace `_persona_block` body 568-603)
+- Test: `packages/secubox-toolbox/tests/test_persona_pdf.py`
+
+**Interfaces:**
+- Consumes: `report["persona"]` = `{emoji, tag, klass, level, align, hp, exposure, xp, attrs:[{icon,name,v,pips,note}], inventory:[{icon,name,on}]}`; `report["bestiary"]` = `[{label,count,emoji?}]`; `report["dpi_exfil"]["me"]["alerts"]` = `[{kind,label?,service?,dst?,detail?}]`. Existing module helpers `_safe`, `_persona_bar`, `_bullet`, `_page_w`.
+- Produces: `_attr_row(pdf, family, a)` (renders one attribute line); the enriched `_persona_block(pdf, family, report)` (same signature).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/secubox-toolbox/tests/test_persona_pdf.py`:
+
+```python
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+"""Rich PDF character sheet (#790): pips, on/off inventory, quests section."""
+from secubox_toolbox import reports
+
+
+def _base(**extra):
+    d = {"mac_hash": "deadbeef", "device_type": "phone", "generated_at": "2026-07-04",
+         "indicators": [], "recommendations": [], "pinned_apps": []}
+    d.update(extra)
+    return d
+
+
+_PERSONA = {
+    "emoji": "🧑‍💻", "tag": "VILLAGE3B·#A1B2", "klass": "Runner", "level": "R3",
+    "align": "🛡️ Protégé", "hp": 85, "exposure": 15, "xp": 12480,
+    "attrs": [
+        {"icon": "🛡️", "name": "DÉFENSE", "v": 14, "pips": 5, "note": ""},
+        {"icon": "⚔️", "name": "RIPOSTE", "v": 6, "pips": 2, "note": "312 pubs tuées"},
+    ],
+    "inventory": [
+        {"icon": "🧅", "name": "Tunnel Tor", "on": True},
+        {"icon": "🚫", "name": "Ad-blocker", "on": False},
+    ],
+}
+
+
+def _spy_safe(monkeypatch):
+    """Capture every string drawn (everything is wrapped in reports._safe)."""
+    seen = []
+    orig = reports._safe
+    monkeypatch.setattr(reports, "_safe", lambda t: (seen.append(str(t)), orig(t))[1])
+    return seen
+
+
+def test_persona_rich_sections_and_pips(monkeypatch):
+    seen = _spy_safe(monkeypatch)
+    data = _base(persona=_PERSONA,
+                 bestiary=[{"label": "doubleclick.net", "count": 42, "emoji": "👹"}],
+                 dpi_exfil={"me": {"alerts": [
+                     {"kind": "exfil_volume", "label": "exfil", "service": "drive.google", "detail": "up 4.2Mo"}]}})
+    blob = reports.render_pdf(data)
+    assert isinstance(blob, (bytes, bytearray)) and len(blob) > 1000
+    joined = " ".join(seen)
+    assert "CARACTERISTIQUES" in joined           # attributes section header
+    assert "QUETES EN COURS" in joined            # quests section header
+    assert "●" in joined and "○" in joined         # pip glyphs rendered
+    assert any("✓" in s for s in seen) and any("✗" in s for s in seen)  # on/off inventory
+    assert any("EXFIL" in s for s in seen)         # the alert surfaced in Quêtes
+    assert any("doubleclick" in s for s in seen)   # bestiary
+
+
+def test_persona_no_alerts_shows_safe_zone(monkeypatch):
+    seen = _spy_safe(monkeypatch)
+    data = _base(persona=_PERSONA, dpi_exfil={"me": {"alerts": []}})
+    reports.render_pdf(data)
+    assert any("zone sure" in s for s in seen)     # empty-threats message
+
+
+def test_persona_missing_dpi_exfil_no_raise(monkeypatch):
+    # dpi_exfil absent entirely (legacy/token path before enrichment) must not raise
+    data = _base(persona=_PERSONA)
+    blob = reports.render_pdf(data)
+    assert isinstance(blob, (bytes, bytearray)) and len(blob) > 500
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=/home/reepost/CyberMindStudio/secubox-deb-worktrees/790-pdf-report-rich-netrunner-character-shee/common /home/reepost/CyberMindStudio/secubox-deb/secubox-deb/.venv/bin/python3 -m pytest tests/test_persona_pdf.py -v`
+Expected: `test_persona_rich_sections_and_pips` FAILS (`"CARACTERISTIQUES" in joined` is false — current block draws widgets, not this header; no pips; no Quêtes section). The other two may pass or fail; all three must pass after Step 3.
+
+- [ ] **Step 3: Add `_attr_row` and rewrite `_persona_block`**
+
+In `packages/secubox-toolbox/secubox_toolbox/reports.py`, insert `_attr_row` immediately BEFORE `def _persona_block` (line 568):
+
+```python
+def _attr_row(pdf, family: str, a: dict) -> None:
+    """#790 — one character-sheet attribute line: icon+name · pips · value · note."""
+    pips = max(0, min(6, int(a.get("pips", 0) or 0)))
+    pdf.set_x(pdf.l_margin)
+    pdf.set_font(family, "", 9)
+    pdf.set_text_color(40, 40, 40)
+    pdf.cell(42, 5, _safe(f"{a.get('icon', '')} {a.get('name', '')[:12]}"), ln=False)
+    pdf.set_text_color(0, 200, 80)
+    pdf.cell(26, 5, _safe("●" * pips + "○" * (6 - pips)), ln=False)
+    pdf.set_font(family, "B", 9)
+    pdf.set_text_color(0, 120, 255)
+    pdf.cell(12, 5, _safe(str(a.get("v", 0))), ln=False)
+    note = a.get("note") or ""
+    if note:
+        pdf.set_font(family, "I", 7)
+        pdf.set_text_color(140, 140, 140)
+        pdf.cell(0, 5, _safe(str(note)[:48]), ln=True)
+    else:
+        pdf.ln()
+    pdf.set_text_color(0)
+```
+
+Then REPLACE the entire body of `_persona_block` (currently lines 568-603, from `def _persona_block` through its final `pdf.ln(2)`) with:
+
+```python
+def _persona_block(pdf, family: str, report: dict) -> None:
+    """#707/#790 — Cyberpunk-Netrunner character sheet for the PDF, faithful to
+    the HTML .nr card: pip attributes + notes, on/off inventory, bestiary, and
+    the active-threats (Quêtes) section from dpi_exfil alerts."""
+    p = report.get("persona") or {}
+    pdf.set_font(family, "B", 12)
+    pdf.set_text_color(0, 212, 255)
+    pdf.cell(0, 6, _safe("🎮 FICHE NETRUNNER"), ln=True)
+    pdf.set_font(family, "B", 11)
+    pdf.set_text_color(0, 212, 255)
+    pdf.cell(0, 6, _safe(f"{p.get('emoji','')} {p.get('tag','?')}"), ln=True)
+    pdf.set_font(family, "", 9)
+    pdf.set_text_color(150, 120, 230)
+    pdf.cell(0, 5, _safe(f"Classe {p.get('klass','?')}  ·  Niveau {p.get('level','?')}  ·  {p.get('align','')}"), ln=True)
+    pdf.ln(1)
+    _persona_bar(pdf, family, "ICE / integrite", p.get("hp", 0), (0, 255, 65))
+    _persona_bar(pdf, family, "Exposition", p.get("exposure", 0), (255, 179, 71))
+    pdf.set_font(family, "", 8)
+    pdf.set_text_color(120, 120, 120)
+    pdf.cell(0, 4, _safe(f"XP {p.get('xp',0):,} Ko echanges (7j)"), ln=True)
+    pdf.ln(1)
+
+    # ⚡ Caracteristiques — pip rows (mirror of the HTML .nr attributes)
+    pdf.set_x(pdf.l_margin)
+    pdf.set_font(family, "B", 9)
+    pdf.set_text_color(0, 212, 255)
+    pdf.cell(0, 5, _safe("⚡ CARACTERISTIQUES"), ln=True)
+    for a in (p.get("attrs") or [])[:4]:
+        _attr_row(pdf, family, a)
+
+    # 🎒 Inventaire · protections — on/off checks
+    inv = p.get("inventory") or []
+    if inv:
+        pdf.set_x(pdf.l_margin)
+        pdf.set_font(family, "B", 9)
+        pdf.set_text_color(0, 212, 255)
+        pdf.cell(0, 5, _safe("🎒 INVENTAIRE · PROTECTIONS"), ln=True)
+        pdf.set_x(pdf.l_margin)
+        pdf.set_font(family, "", 8)
+        for it in inv:
+            seg = _safe(f"{it.get('icon','')} {it.get('name','')}  ")
+            pdf.set_text_color(40, 40, 40)
+            pdf.cell(pdf.get_string_width(seg) + 1, 5, seg, ln=False)
+            if it.get("on"):
+                pdf.set_text_color(0, 180, 70)
+                mark = _safe("✓   ")
+            else:
+                pdf.set_text_color(170, 170, 170)
+                mark = _safe("✗   ")
+            pdf.cell(pdf.get_string_width(mark) + 2, 5, mark, ln=False)
+        pdf.ln(6)
+
+    # 🐉 Bestiaire · qui te traque — top trackers
+    best = report.get("bestiary") or []
+    if best:
+        pdf.set_x(pdf.l_margin)
+        pdf.set_font(family, "B", 9)
+        pdf.set_text_color(0, 212, 255)
+        pdf.cell(0, 5, _safe("🐉 BESTIAIRE · QUI TE TRAQUE"), ln=True)
+        for b in best[:5]:
+            _bullet(pdf, f"{b.get('emoji', '👾')} {b.get('label', '?')[:24]}  x{b.get('count', 0)}", font_size=8)
+
+    # ⚔️ Quetes en cours · menaces — from dpi_exfil alerts (#790)
+    alerts = ((report.get("dpi_exfil") or {}).get("me") or {}).get("alerts") or []
+    pdf.set_x(pdf.l_margin)
+    pdf.set_font(family, "B", 9)
+    pdf.set_text_color(0, 212, 255)
+    pdf.cell(0, 5, _safe("⚔️ QUETES EN COURS · MENACES"), ln=True)
+    if alerts:
+        for q in alerts[:5]:
+            label = q.get("label") or q.get("kind") or "?"
+            dest = q.get("service") or q.get("dst") or ""
+            detail = q.get("detail") or ""
+            _bullet(pdf, f"🗡️ {str(label).upper()} — {dest} {detail}".strip(), font_size=8)
+    else:
+        pdf.set_x(pdf.l_margin)
+        pdf.set_font(family, "", 8)
+        pdf.set_text_color(0, 150, 60)
+        pdf.cell(0, 5, _safe("✓ Aucune menace active — zone sure, runner."), ln=True)
+    pdf.set_text_color(0)
+    pdf.ln(2)
+```
+
+Note: the old `_persona_block` used the `_widget` helper for 4 attribute boxes; that call is removed. `_widget` stays in the file (still used by `_dashboard_hero`), so do not delete it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=/home/reepost/CyberMindStudio/secubox-deb-worktrees/790-pdf-report-rich-netrunner-character-shee/common /home/reepost/CyberMindStudio/secubox-deb/secubox-deb/.venv/bin/python3 -m pytest tests/test_persona_pdf.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: No-regression on existing report tests**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=/home/reepost/CyberMindStudio/secubox-deb-worktrees/790-pdf-report-rich-netrunner-character-shee/common /home/reepost/CyberMindStudio/secubox-deb/secubox-deb/.venv/bin/python3 -m pytest tests/ -k "report or pdf or bundle or persona" -q`
+Expected: PASS (no regression)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/secubox-toolbox/secubox_toolbox/reports.py packages/secubox-toolbox/tests/test_persona_pdf.py
+git commit -m "feat(toolbox): rich PDF character sheet — pips, on/off inventory, quests (ref #790)"
+```
+
+---
+
+## Task 2: Extract `_enrich_report_data` + wire all PDF routes (Part B)
+
+**Files:**
+- Modify: `packages/secubox-toolbox/secubox_toolbox/api.py` (add `_enrich_report_data` near the report routes; replace `report_me` inline block 2882-2904; add call in `report` ~2923 and `admin_client_report` ~3989)
+- Test: `packages/secubox-toolbox/tests/test_enrich_report_data.py`
+
+**Interfaces:**
+- Consumes (all already in `api.py`): `_dpi_stats`, `_media_stats`, `_build_pdf_donuts`, `_persona_sheet`, `_build_report_charts`, `store.get_client_level`, `social.fetch_graph`.
+- Produces: `_enrich_report_data(mac_hash: str, data: dict, ua: str = "") -> dict` — mutates+returns `data` with keys `dpi_exfil, media_exfil, pdf_donuts, persona, charts, graph_stats, bestiary, carto_nodes, carto_country`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/secubox-toolbox/tests/test_enrich_report_data.py`:
+
+```python
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+"""_enrich_report_data populates every report enrichment key (#790 parity)."""
+from secubox_toolbox import api, store
+
+
+def test_enrich_populates_all_keys(monkeypatch):
+    monkeypatch.setattr(api, "_dpi_stats", lambda mh: {"me": {"present": False}, "all": {}})
+    monkeypatch.setattr(api, "_media_stats", lambda mh: {"me": {"present": False}, "all": {"present": False}})
+    monkeypatch.setattr(api, "_build_pdf_donuts", lambda mh, d: [])
+    monkeypatch.setattr(api, "_build_report_charts", lambda g: {"trackers": [{"label": "x", "count": 3}]})
+    monkeypatch.setattr(api, "_persona_sheet", lambda *a, **k: {"tag": "T", "ua_seen": a[-1]})
+    monkeypatch.setattr(store, "get_client_level", lambda mh: "r1")
+    # social.fetch_graph is imported inside the helper via `from . import social`
+    import secubox_toolbox.social as social
+    monkeypatch.setattr(social, "fetch_graph",
+                        lambda mh, since_seconds=0: {"stats": {"total_trackers": 4}, "nodes": [{"n": 1}], "by_country": [{"c": "FR"}]})
+
+    data = {"device_type": "phone"}
+    out = api._enrich_report_data("aabbccdd", data, ua="Mozilla/5.0")
+
+    assert out is data  # mutates in place
+    for k in ("dpi_exfil", "media_exfil", "pdf_donuts", "persona", "charts",
+              "graph_stats", "bestiary", "carto_nodes", "carto_country"):
+        assert k in out, f"missing {k}"
+    assert out["persona"]["tag"] == "T"
+    assert out["persona"]["ua_seen"] == "Mozilla/5.0"   # ua threaded through
+    assert out["bestiary"] == [{"label": "x", "count": 3}]
+    assert out["graph_stats"] == {"total_trackers": 4}
+    assert out["carto_nodes"] == [{"n": 1}]
+
+
+def test_enrich_survives_graph_failure(monkeypatch):
+    monkeypatch.setattr(api, "_dpi_stats", lambda mh: {"me": {}, "all": {}})
+    monkeypatch.setattr(api, "_media_stats", lambda mh: {"me": {}, "all": {}})
+    monkeypatch.setattr(api, "_build_pdf_donuts", lambda mh, d: [])
+    monkeypatch.setattr(api, "_build_report_charts", lambda g: {"trackers": []})
+    monkeypatch.setattr(api, "_persona_sheet", lambda *a, **k: {"tag": "T"})
+    monkeypatch.setattr(store, "get_client_level", lambda mh: "r1")
+    import secubox_toolbox.social as social
+
+    def _boom(*a, **k):
+        raise RuntimeError("graph down")
+    monkeypatch.setattr(social, "fetch_graph", _boom)
+
+    out = api._enrich_report_data("aabbccdd", {"device_type": "pc"})
+    assert out["graph_stats"] == {}          # fell back to empty graph
+    assert out["bestiary"] == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=/home/reepost/CyberMindStudio/secubox-deb-worktrees/790-pdf-report-rich-netrunner-character-shee/common /home/reepost/CyberMindStudio/secubox-deb/secubox-deb/.venv/bin/python3 -m pytest tests/test_enrich_report_data.py -v`
+Expected: FAIL — `AttributeError: module 'secubox_toolbox.api' has no attribute '_enrich_report_data'`
+
+- [ ] **Step 3: Add `_enrich_report_data`**
+
+In `packages/secubox-toolbox/secubox_toolbox/api.py`, add this function immediately BEFORE `@router.get("/report/me")` (line 2863):
+
+```python
+def _enrich_report_data(mac_hash: str, data: dict, ua: str = "") -> dict:
+    """#790 — attach the live enrichment (DPI, media, persona, charts, carto) to
+    a report `data` dict. Factored out of report_me so /report/{token} and the
+    admin route produce the SAME rich PDF. `ua` drives the persona device class;
+    "" is fine for non-HTTP callers (falls back to a generic Runner class)."""
+    data["dpi_exfil"] = _dpi_stats(mac_hash)          # #701 DPI parity
+    data["media_exfil"] = _media_stats(mac_hash)      # #785 media-type donuts
+    data["pdf_donuts"] = _build_pdf_donuts(mac_hash, data)  # #703 visual donuts
+    try:
+        from . import social as _social
+        _graph = _social.fetch_graph(mac_hash, since_seconds=7 * 86400)
+    except Exception:
+        _graph = {"stats": {}, "nodes": [], "by_country": []}
+    _gs = _graph.get("stats") or {}
+    _exp = min(100, int((_gs.get("total_trackers", 0) or 0) * 1.5
+                        + (_gs.get("opgrade_sites", 0) or 0) * 12
+                        + (_gs.get("antibot_sites", 0) or 0) * 8))
+    _lvl = store.get_client_level(mac_hash) if mac_hash else "r1"
+    data["persona"] = _persona_sheet(mac_hash, _lvl, _gs, _exp, data["dpi_exfil"],
+                                     data.get("device_type", ""), ua)
+    _charts = _build_report_charts(_graph)
+    data["charts"] = _charts                          # #711 "En un coup d'œil"
+    data["graph_stats"] = _gs
+    data["bestiary"] = (_charts.get("trackers") or [])[:5]
+    data["carto_nodes"] = _graph.get("nodes") or []   # #709 carto + tables
+    data["carto_country"] = _graph.get("by_country") or []
+    return data
+```
+
+- [ ] **Step 4: Replace the inline block in `report_me`**
+
+In `report_me`, DELETE the inline enrichment (lines 2882-2904 — from `data["dpi_exfil"] = _dpi_stats(mac_hash)` through `data["carto_country"] = _graph.get("by_country") or []`) and replace with a single call. The surrounding lines stay:
+
+Find:
+```python
+    session = _aggregate_session(mac_hash)
+    data = reports.build_report_data(mac_hash, session)
+    data["dpi_exfil"] = _dpi_stats(mac_hash)  # #701 — DPI parity with the HTML report
+    data["media_exfil"] = _media_stats(mac_hash)  # #785 — media-type (MIME) donuts
+    data["pdf_donuts"] = _build_pdf_donuts(mac_hash, data)  # #703 — visual donuts
+    # #707 — Netrunner persona sheet (live graph + DPI + ads + request UA)
+    try:
+        from . import social as _social
+        _graph = _social.fetch_graph(mac_hash, since_seconds=7 * 86400)
+    except Exception:
+        _graph = {"stats": {}, "nodes": [], "by_country": []}
+    _gs = _graph.get("stats") or {}
+    _exp = min(100, int((_gs.get("total_trackers", 0) or 0) * 1.5
+                        + (_gs.get("opgrade_sites", 0) or 0) * 12
+                        + (_gs.get("antibot_sites", 0) or 0) * 8))
+    _lvl = store.get_client_level(mac_hash) if mac_hash else "r1"
+    data["persona"] = _persona_sheet(mac_hash, _lvl, _gs, _exp, data["dpi_exfil"],
+                                     data.get("device_type", ""),
+                                     request.headers.get("user-agent", ""))
+    _charts = _build_report_charts(_graph)
+    data["charts"] = _charts                              # #711 "En un coup d'œil"
+    data["graph_stats"] = _gs
+    data["bestiary"] = (_charts.get("trackers") or [])[:5]
+    data["carto_nodes"] = _graph.get("nodes") or []      # #709 carto + tables
+    data["carto_country"] = _graph.get("by_country") or []
+    pdf_bytes = await _render_pdf_offloaded(reports.render_pdf, data, cache_key=f"me:{mac_hash}")
+```
+Replace with:
+```python
+    session = _aggregate_session(mac_hash)
+    data = reports.build_report_data(mac_hash, session)
+    _enrich_report_data(mac_hash, data, ua=request.headers.get("user-agent", ""))
+    pdf_bytes = await _render_pdf_offloaded(reports.render_pdf, data, cache_key=f"me:{mac_hash}")
+```
+
+- [ ] **Step 5: Wire `report` (token) and `admin_client_report`**
+
+In `report` (the `/report/{token}` handler), find:
+```python
+    session = _aggregate_session(mac_hash)
+    data = reports.build_report_data(mac_hash, session)
+    pdf_bytes = await _render_pdf_offloaded(reports.render_pdf, data, cache_key=f"tok:{mac_hash}")
+```
+Replace with:
+```python
+    session = _aggregate_session(mac_hash)
+    data = reports.build_report_data(mac_hash, session)
+    _enrich_report_data(mac_hash, data)  # #790 — same rich content as /report/me
+    pdf_bytes = await _render_pdf_offloaded(reports.render_pdf, data, cache_key=f"tok:{mac_hash}")
+```
+
+In `admin_client_report`, find:
+```python
+    session = _aggregate_session(mac_hash)
+    data = reports.build_report_data(mac_hash, session)
+    pdf_bytes = await _render_pdf_offloaded(reports.render_pdf, data, cache_key=f"adm:{mac_hash}")
+```
+Replace with:
+```python
+    session = _aggregate_session(mac_hash)
+    data = reports.build_report_data(mac_hash, session)
+    _enrich_report_data(mac_hash, data)  # #790 — same rich content as /report/me
+    pdf_bytes = await _render_pdf_offloaded(reports.render_pdf, data, cache_key=f"adm:{mac_hash}")
+```
+
+- [ ] **Step 6: Run test + syntax check**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=/home/reepost/CyberMindStudio/secubox-deb-worktrees/790-pdf-report-rich-netrunner-character-shee/common /home/reepost/CyberMindStudio/secubox-deb/secubox-deb/.venv/bin/python3 -m pytest tests/test_enrich_report_data.py -v && /home/reepost/CyberMindStudio/secubox-deb/secubox-deb/.venv/bin/python3 -c "import ast; ast.parse(open('secubox_toolbox/api.py').read()); print('api.py parses OK')"`
+Expected: PASS (2 tests) + "api.py parses OK"
+
+- [ ] **Step 7: Confirm all three routes call the helper**
+
+Run: `grep -n "_enrich_report_data(mac_hash, data" secubox_toolbox/api.py`
+Expected: 3 lines (report_me with `ua=`, report token, admin) — plus the `def _enrich_report_data` definition line.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/secubox-toolbox/secubox_toolbox/api.py packages/secubox-toolbox/tests/test_enrich_report_data.py
+git commit -m "feat(toolbox): factor _enrich_report_data + apply to token/admin PDF routes (ref #790)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full toolbox suite (no regression):**
+
+```bash
+cd packages/secubox-toolbox && PYTHONPATH=/home/reepost/CyberMindStudio/secubox-deb-worktrees/790-pdf-report-rich-netrunner-character-shee/common /home/reepost/CyberMindStudio/secubox-deb/secubox-deb/.venv/bin/python3 -m pytest tests/ -q
+```
+Expected: all green (the two new files add 5 tests).
+
+- [ ] **Deploy note (not a code step):** only `secubox-toolbox` changed (pure Python). To validate live: deploy `reports.py` + `api.py` to `/usr/lib/secubox/toolbox/secubox_toolbox/` on gk2, restart `secubox-toolbox`, then render `/report/me?mh=<real-hash>` and confirm the character sheet shows pips/inventory/quests, and that `/report/{token}` now carries persona too. Watch for pip/check glyph rendering (`●○✓✗`) — DejaVu should cover them.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Part A pips + notes → Task 1 `_attr_row` ✅
+- Part A inventory ✓/✗ → Task 1 ✅
+- Part A bestiary → Task 1 ✅
+- Part A Quêtes/menaces + empty-safe message → Task 1 (+ test) ✅
+- Part A fail-safe on missing `dpi_exfil` → Task 1 `test_persona_missing_dpi_exfil_no_raise` ✅
+- Part B `_enrich_report_data` helper → Task 2 ✅
+- Part B wire 3 routes → Task 2 Steps 4-5 + Step 7 check ✅
+- full-fpdf / no matplotlib → no matplotlib call added in Task 1 ✅
+- pip clamp 0..6 → `_attr_row` `max(0, min(6, ...))` ✅
+
+**Placeholder scan:** none — every step has concrete code/commands.
+
+**Type consistency:** `_enrich_report_data(mac_hash, data, ua="")` signature identical across definition, tests, and all 3 call sites; `_attr_row(pdf, family, a)` consistent between definition and `_persona_block` usage; persona/bestiary/alerts key names match the shapes read from `api._persona_sheet` and `_dpi_stats`.

--- a/docs/superpowers/specs/2026-07-04-pdf-character-sheet-design.md
+++ b/docs/superpowers/specs/2026-07-04-pdf-character-sheet-design.md
@@ -1,0 +1,133 @@
+# Design — Rich Netrunner character sheet in the PDF + persona/dpi/media parity across all PDF routes
+
+- **Issue** : [#790](https://github.com/CyberMind-FR/secubox-deb/issues/790)
+- **Date** : 2026-07-04
+- **Follows** : #785 (PDF ↔ web parity, media types)
+- **Licence** : LicenseRef-CMSD-1.0
+
+## 1. Problème
+
+Le PDF du rapport rend déjà une fiche de personnage (`reports._persona_block`, #707) mais **appauvrie** par rapport à la carte `.nr` de la page web (`report-live.html.j2`), que l'utilisateur juge excellente. Écarts constatés (PDF live sur gk2) :
+
+- **Caractéristiques** : le PDF affiche 4 widgets « icône + chiffre » ; le HTML affiche des **pips `●●●○○○`** + une **note** par attribut (« 312 pubs tuées », « 4 cat · 27 flux »).
+- **Inventaire · protections** : le PDF affiche une ligne texte « nom OK/x » ; le HTML affiche des **puces ✓/✗** distinguées on/off.
+- **⚔️ Quêtes en cours · menaces** : **absente** du PDF ; le HTML la rend depuis `dpi_exfil.me.alerts`.
+
+Second problème : seule la route `/report/me` enrichit le `data` du rapport (persona + dpi_exfil + media_exfil + pdf_donuts + charts + bestiary + carto). Les routes **`/report/{token}`** et **`/admin/clients/{mac_hash}/report`** rendent un PDF **nu** (fallback `_dashboard_hero`, sans DPI/média/persona).
+
+## 2. Objectif
+
+1. Rendre la fiche de personnage du PDF fidèle à la carte `.nr` HTML.
+2. Faire que **les trois routes PDF** produisent le même contenu riche, en factorisant l'enrichissement.
+
+Toutes les données nécessaires existent déjà (`report["persona"]` via `_persona_sheet`, `report["bestiary"]`, `report["dpi_exfil"]["me"]["alerts"]`) — c'est du **rendu** et de la **factorisation**, aucune nouvelle capture.
+
+## 3. Périmètre
+
+| Partie | Fichier | Livrable |
+|---|---|---|
+| A | `packages/secubox-toolbox/secubox_toolbox/reports.py` | `_persona_block` enrichi (pips + notes, inventaire ✓/✗, bestiaire, section Quêtes/menaces) |
+| B | `packages/secubox-toolbox/secubox_toolbox/api.py` | helper `_enrich_report_data(mac_hash, data, ua="")` factorisé + appelé par les 3 routes PDF |
+| — | `packages/secubox-toolbox/tests/` | tests persona enrichi + helper + parité route |
+
+Hors périmètre : aucune nouvelle donnée collectée ; **pas** de nouveau rendu matplotlib (la fiche est full-fpdf, donc légère — ne réalourdit pas `render_pdf` ni le risque d'incident #785) ; la page web `.nr` reste inchangée (elle est déjà la référence).
+
+## 4. Architecture
+
+### 4.1 Partie A — `_persona_block` enrichi (`reports.py:568-603`)
+
+Structure conservée en tête : titre « 🎮 FICHE NETRUNNER », `{emoji} {tag}`, `Classe … · Niveau … · Alignement`, barres ICE / Exposition (via `_persona_bar`), ligne XP.
+
+Remplacements / ajouts (single-column, fpdf, réutilisant `_safe`, `_section`/`_kv`, `_page_w`, palette existante) :
+
+1. **⚡ Caractéristiques** — remplacer la boucle des 4 `_widget` par une **ligne à pips** par attribut, via un helper interne `_attr_row(pdf, family, a)` :
+   - colonne 1 (fixe ~42 mm) : `{icon} {name}` (gris foncé) ;
+   - colonne 2 : `'●' * pips + '○' * (6 - pips)` en vert (`pips = clamp(a["pips"], 0, 6)`) — `●` U+25CF / `○` U+25CB sont dans DejaVuSans, rendus monochromes fiables ;
+   - colonne 3 : la valeur `a["v"]` (bleu) ;
+   - si `a["note"]` : suffixe en italique gris clair, même ligne (`ln=True`), sinon `pdf.ln()`.
+
+2. **🎒 Inventaire · protections** — remplacer la ligne « nom OK/x » par une ligne de **segments ✓/✗** : pour chaque item, `{icon} {name}` (gris foncé) suivi de `✓` (vert `(0,180,70)`) si `it["on"]` sinon `✗` (gris `(170,170,170)`). `✓` U+2713 / `✗` U+2717 sont dans DejaVu. Largeur des cellules calée sur `pdf.get_string_width`.
+
+3. **🐉 Bestiaire · qui te traque** — conservé, depuis `report["bestiary"]` (`[{label, count, emoji?}]`), rendu en liste condensée (jusqu'à 4-5 entrées : `{emoji} {label} ×{count}`).
+
+4. **⚔️ Quêtes en cours · menaces** *(nouveau)* — depuis `report["dpi_exfil"]["me"]["alerts"]` :
+   - si des alertes : jusqu'à 5 lignes `{(label or kind)|upper} — {service or dst} {detail}` (via `_bullet`, épée 🗡️) ;
+   - sinon : une ligne verte « ✓ Aucune menace active — zone sûre, runner. »
+   - fail-safe : `alerts = ((report.get("dpi_exfil") or {}).get("me") or {}).get("alerts") or []` → jamais d'exception si la clé manque (routes sans DPI, cas hérités).
+
+`_persona_block` continue de recevoir `report` complet (déjà le cas) — il a accès à `persona`, `bestiary`, `dpi_exfil`.
+
+### 4.2 Partie B — `_enrich_report_data` factorisé (`api.py`)
+
+Extraire le bloc inline de `report_me` (`api.py:2882-2904`) dans un helper module-level :
+
+```
+def _enrich_report_data(mac_hash: str, data: dict, ua: str = "") -> dict:
+    data["dpi_exfil"]  = _dpi_stats(mac_hash)
+    data["media_exfil"] = _media_stats(mac_hash)
+    data["pdf_donuts"] = _build_pdf_donuts(mac_hash, data)
+    try:
+        from . import social as _social
+        _graph = _social.fetch_graph(mac_hash, since_seconds=7 * 86400)
+    except Exception:
+        _graph = {"stats": {}, "nodes": [], "by_country": []}
+    _gs = _graph.get("stats") or {}
+    _exp = min(100, int((_gs.get("total_trackers", 0) or 0) * 1.5
+                        + (_gs.get("opgrade_sites", 0) or 0) * 12
+                        + (_gs.get("antibot_sites", 0) or 0) * 8))
+    _lvl = store.get_client_level(mac_hash) if mac_hash else "r1"
+    data["persona"] = _persona_sheet(mac_hash, _lvl, _gs, _exp, data["dpi_exfil"],
+                                     data.get("device_type", ""), ua)
+    _charts = _build_report_charts(_graph)
+    data["charts"] = _charts
+    data["graph_stats"] = _gs
+    data["bestiary"] = (_charts.get("trackers") or [])[:5]
+    data["carto_nodes"] = _graph.get("nodes") or []
+    data["carto_country"] = _graph.get("by_country") or []
+    return data
+```
+
+Câblage :
+- `report_me` : remplacer les lignes 2882-2904 par `_enrich_report_data(mac_hash, data, ua=request.headers.get("user-agent", ""))`.
+- `report` (`/report/{token}`) : insérer `_enrich_report_data(mac_hash, data)` après `data = reports.build_report_data(...)` (avant le render).
+- `admin_client_report` : idem, `_enrich_report_data(mac_hash, data)` avant le render.
+
+Comportement inchangé pour `report_me` (même logique, juste factorisée). `token`/`admin` gagnent le contenu riche. `ua=""` → `_persona_sheet` retombe sur la classe device générique (« Runner ») — acceptable hors requête HTTP.
+
+Les `cache_key` restent distincts (`me:` / `tok:` / `adm:`), donc pas de collision ; le contenu identique n'est simplement pas partagé entre routes (acceptable).
+
+## 5. Flux de données
+
+```
+report["persona"]     ← _persona_sheet(...)  (attrs[].pips/.note, inventory[].on)
+report["bestiary"]    ← _build_report_charts(...).trackers[:5]
+report["dpi_exfil"]   ← _dpi_stats(...)       (.me.alerts)
+        │
+        ▼
+_persona_block(pdf, family, report)  →  fiche riche (pips, ✓/✗, quêtes)
+        ▲
+_enrich_report_data(mac_hash, data, ua)  ← report_me | report/{token} | admin_client_report
+```
+
+## 6. Gestion d'erreurs / dégradation
+
+- **`dpi_exfil` absent** (ne devrait plus arriver après B, mais l'ancien fallback existe) : la section Quêtes utilise `((… or {}).get("me") or {}).get("alerts") or []` → liste vide → message « zone sûre », pas d'exception.
+- **`persona` absent** : `render_pdf` garde son `if report.get("persona"): _persona_block(...) else: _dashboard_hero(...)` — inchangé.
+- **pips hors bornes** : `clamp(0, 6)` avant multiplication de chaîne.
+- **fetch_graph / store indisponible** : déjà try/except dans le helper (fail-empty), comme aujourd'hui dans `report_me`.
+- Le rendu reste **off-loop + verrouillé + caché** (`_render_pdf_offloaded`, #785) — inchangé.
+
+## 7. Tests
+
+- **`_persona_block` enrichi** (`reports.py`) : `render_pdf` sur un `data` synthétique avec `persona.attrs` (pips + note), `persona.inventory` (mix on/off), `bestiary`, et `dpi_exfil.me.alerts` peuplé → PDF non vide ; spy sur `_section` pour vérifier l'émission des titres « CARACTÉRISTIQUES » et « QUÊTES … » ; cas `alerts=[]` → le rendu contient le message « zone sûre » (spy/`_bullet` ou rendu sans crash).
+- **`alerts` vide + dpi_exfil absent** : `render_pdf` ne lève pas.
+- **`_enrich_report_data`** (`api.py`) : après appel, `data` contient les clés `dpi_exfil`, `media_exfil`, `persona`, `charts`, `bestiary` (monkeypatch des sources live pour un test hermétique).
+- **Parité route** : `report`/`admin_client_report` — vérifier (unitaire sur le helper, ou via TestClient si praticable) que la route token enrichit `data` (persona présent) avant render.
+- Non-régression : suite report/bundle existante verte.
+
+## 8. Risques / points d'attention
+
+- **Glyphes pips/checks** : `●○✓✗` doivent être dans la police PDF. DejaVuSans les contient (fallback Noto/Symbola au besoin) — vérifier au rendu live qu'ils ne tombent pas en « missing glyph ». Repli acceptable : `[###...]` ASCII si absents (peu probable).
+- **Largeur colonnes** : calage via `get_string_width` pour l'inventaire ; garder des largeurs fixes pour les pips afin d'éviter le « Not enough horizontal space » de fpdf sur de longs noms (tronquer `name[:12]`).
+- **Perf** : full-fpdf, négligeable ; n'ajoute aucun appel matplotlib → ne touche pas au budget de rendu de l'incident #785.
+- **Parité routes** : `token`/`admin` font désormais un `fetch_graph` + `_dpi_stats` + `_media_stats` par requête (comme `report_me`). Rendu déjà caché (`tok:`/`adm:`), donc coût borné par le cache #785.

--- a/packages/secubox-toolbox/conf/report-live.html.j2
+++ b/packages/secubox-toolbox/conf/report-live.html.j2
@@ -193,9 +193,11 @@ ul{list-style:none;padding-left:.2rem}li{padding:.12rem 0;font-size:.82rem}li::b
   {% set dme = (dpi_exfil or {}).me or {} %}
   <div class="nr-box" style="margin-top:.8rem">
     <h3>⚔️ Quêtes en cours · menaces</h3>
-    {% if dme.alerts %}
-      {% for q in dme.alerts[:5] %}
-      <div style="font-size:.8rem">🗡️ <b style="color:var(--amber)">{{ (q.label or q.kind or '?')|upper }}</b> — {{ q.service or q.dst or '' }} <span style="color:var(--dim)">{{ q.detail or '' }}</span></div>
+    {% set _quests = dme.alerts_raw or dme.alerts %}
+    {% if _quests %}
+      {% for q in _quests[:5] %}
+      {% set _dest = q.service or q.dst or '' %}
+      <div style="font-size:.8rem">🗡️ <b style="color:var(--amber)">{{ (q.label or q.kind or '?')|replace('_',' ')|upper }}</b>{% if _dest or q.detail %} — {{ _dest }} <span style="color:var(--dim)">{{ q.detail or '' }}</span>{% endif %}</div>
       {% endfor %}
     {% else %}<div class="empty" style="color:var(--phos)">✓ Aucune menace active — zone sûre, runner.</div>{% endif %}
   </div>

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -2600,6 +2600,9 @@ def _dpi_stats(mac_hash: str | None) -> dict:
         "categories": cats(me.get("by_category")),
         "protocols": _dpi_donut([{"label": k, "emoji": "📡", "count": v} for k, v in me_protos.items()]),
         "alerts": alerts(me.get("alerts")),
+        # #792 — donut 'alerts' loses the per-alert fields; keep the RAW collector
+        # alerts (kind/service/dst/detail) for the persona Quêtes section.
+        "alerts_raw": me.get("alerts") or [],
         "destinations": _dpi_donut(me_dests),
     }
 

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -2860,6 +2860,35 @@ async def report_me_html(request: Request) -> HTMLResponse:
     })
 
 
+def _enrich_report_data(mac_hash: str, data: dict, ua: str = "") -> dict:
+    """#790 — attach the live enrichment (DPI, media, persona, charts, carto) to
+    a report `data` dict. Factored out of report_me so /report/{token} and the
+    admin route produce the SAME rich PDF. `ua` drives the persona device class;
+    "" is fine for non-HTTP callers (falls back to a generic Runner class)."""
+    data["dpi_exfil"] = _dpi_stats(mac_hash)          # #701 DPI parity
+    data["media_exfil"] = _media_stats(mac_hash)      # #785 media-type donuts
+    data["pdf_donuts"] = _build_pdf_donuts(mac_hash, data)  # #703 visual donuts
+    try:
+        from . import social as _social
+        _graph = _social.fetch_graph(mac_hash, since_seconds=7 * 86400)
+    except Exception:
+        _graph = {"stats": {}, "nodes": [], "by_country": []}
+    _gs = _graph.get("stats") or {}
+    _exp = min(100, int((_gs.get("total_trackers", 0) or 0) * 1.5
+                        + (_gs.get("opgrade_sites", 0) or 0) * 12
+                        + (_gs.get("antibot_sites", 0) or 0) * 8))
+    _lvl = store.get_client_level(mac_hash) if mac_hash else "r1"
+    data["persona"] = _persona_sheet(mac_hash, _lvl, _gs, _exp, data["dpi_exfil"],
+                                     data.get("device_type", ""), ua)
+    _charts = _build_report_charts(_graph)
+    data["charts"] = _charts                          # #711 "En un coup d'œil"
+    data["graph_stats"] = _gs
+    data["bestiary"] = (_charts.get("trackers") or [])[:5]
+    data["carto_nodes"] = _graph.get("nodes") or []   # #709 carto + tables
+    data["carto_country"] = _graph.get("by_country") or []
+    return data
+
+
 @router.get("/report/me")
 async def report_me(request: Request) -> Response:
     """Generate + serve PDF report for the CURRENT requesting client.
@@ -2879,29 +2908,7 @@ async def report_me(request: Request) -> Response:
         mac_hash = macmod.hash_mac(mac, salt)
     session = _aggregate_session(mac_hash)
     data = reports.build_report_data(mac_hash, session)
-    data["dpi_exfil"] = _dpi_stats(mac_hash)  # #701 — DPI parity with the HTML report
-    data["media_exfil"] = _media_stats(mac_hash)  # #785 — media-type (MIME) donuts
-    data["pdf_donuts"] = _build_pdf_donuts(mac_hash, data)  # #703 — visual donuts
-    # #707 — Netrunner persona sheet (live graph + DPI + ads + request UA)
-    try:
-        from . import social as _social
-        _graph = _social.fetch_graph(mac_hash, since_seconds=7 * 86400)
-    except Exception:
-        _graph = {"stats": {}, "nodes": [], "by_country": []}
-    _gs = _graph.get("stats") or {}
-    _exp = min(100, int((_gs.get("total_trackers", 0) or 0) * 1.5
-                        + (_gs.get("opgrade_sites", 0) or 0) * 12
-                        + (_gs.get("antibot_sites", 0) or 0) * 8))
-    _lvl = store.get_client_level(mac_hash) if mac_hash else "r1"
-    data["persona"] = _persona_sheet(mac_hash, _lvl, _gs, _exp, data["dpi_exfil"],
-                                     data.get("device_type", ""),
-                                     request.headers.get("user-agent", ""))
-    _charts = _build_report_charts(_graph)
-    data["charts"] = _charts                              # #711 "En un coup d'œil"
-    data["graph_stats"] = _gs
-    data["bestiary"] = (_charts.get("trackers") or [])[:5]
-    data["carto_nodes"] = _graph.get("nodes") or []      # #709 carto + tables
-    data["carto_country"] = _graph.get("by_country") or []
+    _enrich_report_data(mac_hash, data, ua=request.headers.get("user-agent", ""))
     pdf_bytes = await _render_pdf_offloaded(reports.render_pdf, data, cache_key=f"me:{mac_hash}")
     fname = f"gondwana-toolbox-{mac_hash[:8]}.pdf"
     return Response(
@@ -2921,6 +2928,7 @@ async def report(token: str) -> Response:
         raise HTTPException(404, "report not found or expired")
     session = _aggregate_session(mac_hash)
     data = reports.build_report_data(mac_hash, session)
+    _enrich_report_data(mac_hash, data)  # #790 — same rich content as /report/me
     pdf_bytes = await _render_pdf_offloaded(reports.render_pdf, data, cache_key=f"tok:{mac_hash}")
     fname = f"gondwana-toolbox-{mac_hash[:8]}-{int(time.time())}.pdf"
     return Response(
@@ -3987,6 +3995,7 @@ async def admin_client_report(mac_hash: str) -> Response:
     """Admin endpoint : download PDF for a specific client by mac_hash."""
     session = _aggregate_session(mac_hash)
     data = reports.build_report_data(mac_hash, session)
+    _enrich_report_data(mac_hash, data)  # #790 — same rich content as /report/me
     pdf_bytes = await _render_pdf_offloaded(reports.render_pdf, data, cache_key=f"adm:{mac_hash}")
     fname = f"gondwana-toolbox-{mac_hash[:8]}-admin.pdf"
     return Response(

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -565,8 +565,35 @@ def _persona_bar(pdf, family: str, label: str, pct: int, col: tuple) -> None:
     pdf.set_y(y + 4)
 
 
+def _attr_row(pdf, family: str, a: dict) -> None:
+    """#790 — one character-sheet attribute line: icon+name · pips · value · note."""
+    pips = max(0, min(6, int(a.get("pips", 0) or 0)))
+    pdf.set_x(pdf.l_margin)
+    pdf.set_font(family, "", 9)
+    pdf.set_text_color(40, 40, 40)
+    pdf.cell(42, 5, _safe(f"{a.get('icon', '')} {a.get('name', '')[:12]}"), ln=False)
+    pdf.set_text_color(0, 200, 80)
+    pdf.cell(26, 5, _safe("●" * pips + "○" * (6 - pips)), ln=False)
+    pdf.set_font(family, "B", 9)
+    pdf.set_text_color(0, 120, 255)
+    pdf.cell(12, 5, _safe(str(a.get("v", 0))), ln=False)
+    note = a.get("note") or ""
+    if note:
+        # Guard against fonts-dejavu-core shipping Regular+Bold only (no Oblique) —
+        # same pre-existing hazard already handled for the footer (see _setup_fonts).
+        note_style = "I" if (family != "DejaVu" or getattr(pdf, "_secubox_italic_ok", False)) else ""
+        pdf.set_font(family, note_style, 7)
+        pdf.set_text_color(140, 140, 140)
+        pdf.cell(0, 5, _safe(str(note)[:48]), ln=True)
+    else:
+        pdf.ln()
+    pdf.set_text_color(0)
+
+
 def _persona_block(pdf, family: str, report: dict) -> None:
-    """#707 — Cyberpunk-Netrunner character sheet header for the PDF."""
+    """#707/#790 — Cyberpunk-Netrunner character sheet for the PDF, faithful to
+    the HTML .nr card: pip attributes + notes, on/off inventory, bestiary, and
+    the active-threats (Quêtes) section from dpi_exfil alerts."""
     p = report.get("persona") or {}
     pdf.set_font(family, "B", 12)
     pdf.set_text_color(0, 212, 255)
@@ -584,22 +611,65 @@ def _persona_block(pdf, family: str, report: dict) -> None:
     pdf.set_text_color(120, 120, 120)
     pdf.cell(0, 4, _safe(f"XP {p.get('xp',0):,} Ko echanges (7j)"), ln=True)
     pdf.ln(1)
-    # 4 attribute widgets
-    y = pdf.get_y()
-    bw = (_page_w(pdf) - 6) / 4
-    bh = 17
-    for i, a in enumerate((p.get("attrs") or [])[:4]):
-        x = pdf.l_margin + i * (bw + 2)
-        _widget(pdf, family, x, y, bw, bh, a.get("icon", "?"),
-                str(a.get("v", 0)), a.get("name", "")[:10], (15, 30, 40), fg=(0, 212, 255))
-    pdf.set_y(y + bh + 2)
-    # inventory + bestiary
-    _kv(pdf, "Inventaire",
-        "  ".join(f"{it.get('name','')} {'OK' if it.get('on') else 'x'}" for it in (p.get("inventory") or [])))
+
+    # ⚡ Caracteristiques — pip rows (mirror of the HTML .nr attributes)
+    pdf.set_x(pdf.l_margin)
+    pdf.set_font(family, "B", 9)
+    pdf.set_text_color(0, 212, 255)
+    pdf.cell(0, 5, _safe("⚡ CARACTERISTIQUES"), ln=True)
+    for a in (p.get("attrs") or [])[:4]:
+        _attr_row(pdf, family, a)
+
+    # 🎒 Inventaire · protections — on/off checks
+    inv = p.get("inventory") or []
+    if inv:
+        pdf.set_x(pdf.l_margin)
+        pdf.set_font(family, "B", 9)
+        pdf.set_text_color(0, 212, 255)
+        pdf.cell(0, 5, _safe("🎒 INVENTAIRE · PROTECTIONS"), ln=True)
+        pdf.set_x(pdf.l_margin)
+        pdf.set_font(family, "", 8)
+        for it in inv:
+            seg = _safe(f"{it.get('icon','')} {it.get('name','')}  ")
+            pdf.set_text_color(40, 40, 40)
+            pdf.cell(pdf.get_string_width(seg) + 1, 5, seg, ln=False)
+            if it.get("on"):
+                pdf.set_text_color(0, 180, 70)
+                mark = _safe("✓   ")
+            else:
+                pdf.set_text_color(170, 170, 170)
+                mark = _safe("✗   ")
+            pdf.cell(pdf.get_string_width(mark) + 2, 5, mark, ln=False)
+        pdf.ln(6)
+
+    # 🐉 Bestiaire · qui te traque — top trackers
     best = report.get("bestiary") or []
     if best:
-        _kv(pdf, "Bestiaire",
-            "  ·  ".join(f"{b.get('label','?')[:14]} x{b.get('count',0)}" for b in best[:4]))
+        pdf.set_x(pdf.l_margin)
+        pdf.set_font(family, "B", 9)
+        pdf.set_text_color(0, 212, 255)
+        pdf.cell(0, 5, _safe("🐉 BESTIAIRE · QUI TE TRAQUE"), ln=True)
+        for b in best[:5]:
+            _bullet(pdf, f"{b.get('emoji', '👾')} {b.get('label', '?')[:24]}  x{b.get('count', 0)}", font_size=8)
+
+    # ⚔️ Quetes en cours · menaces — from dpi_exfil alerts (#790)
+    alerts = ((report.get("dpi_exfil") or {}).get("me") or {}).get("alerts") or []
+    pdf.set_x(pdf.l_margin)
+    pdf.set_font(family, "B", 9)
+    pdf.set_text_color(0, 212, 255)
+    pdf.cell(0, 5, _safe("⚔️ QUETES EN COURS · MENACES"), ln=True)
+    if alerts:
+        for q in alerts[:5]:
+            label = q.get("label") or q.get("kind") or "?"
+            dest = q.get("service") or q.get("dst") or ""
+            detail = q.get("detail") or ""
+            _bullet(pdf, f"🗡️ {str(label).upper()} — {dest} {detail}".strip(), font_size=8)
+    else:
+        pdf.set_x(pdf.l_margin)
+        pdf.set_font(family, "", 8)
+        pdf.set_text_color(0, 150, 60)
+        pdf.cell(0, 5, _safe("✓ Aucune menace active — zone sure, runner."), ln=True)
+    pdf.set_text_color(0)
     pdf.ln(2)
 
 

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -653,17 +653,21 @@ def _persona_block(pdf, family: str, report: dict) -> None:
             _bullet(pdf, f"{b.get('emoji', '👾')} {b.get('label', '?')[:24]}  x{b.get('count', 0)}", font_size=8)
 
     # ⚔️ Quetes en cours · menaces — from dpi_exfil alerts (#790)
-    alerts = ((report.get("dpi_exfil") or {}).get("me") or {}).get("alerts") or []
+    # #792 — prefer the RAW collector alerts (kind/service/dst/detail); the donut
+    # 'alerts' only carries {label,count} so it can't fill the dest/detail line.
+    _me_dpi = (report.get("dpi_exfil") or {}).get("me") or {}
+    alerts = _me_dpi.get("alerts_raw") or _me_dpi.get("alerts") or []
     pdf.set_x(pdf.l_margin)
     pdf.set_font(family, "B", 9)
     pdf.set_text_color(0, 212, 255)
     pdf.cell(0, 5, _safe("⚔️ QUETES EN COURS · MENACES"), ln=True)
     if alerts:
         for q in alerts[:5]:
-            label = q.get("label") or q.get("kind") or "?"
+            label = str(q.get("label") or q.get("kind") or "?").replace("_", " ")
             dest = q.get("service") or q.get("dst") or ""
             detail = q.get("detail") or ""
-            _bullet(pdf, f"🗡️ {str(label).upper()} — {dest} {detail}".strip(), font_size=8)
+            tail = " ".join(x for x in (dest, detail) if x)
+            _bullet(pdf, f"🗡️ {label.upper()} — {tail}" if tail else f"🗡️ {label.upper()}", font_size=8)
     else:
         pdf.set_x(pdf.l_margin)
         pdf.set_font(family, "", 8)

--- a/packages/secubox-toolbox/tests/test_enrich_report_data.py
+++ b/packages/secubox-toolbox/tests/test_enrich_report_data.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+"""_enrich_report_data populates every report enrichment key (#790 parity)."""
+from secubox_toolbox import api, store
+
+
+def test_enrich_populates_all_keys(monkeypatch):
+    monkeypatch.setattr(api, "_dpi_stats", lambda mh: {"me": {"present": False}, "all": {}})
+    monkeypatch.setattr(api, "_media_stats", lambda mh: {"me": {"present": False}, "all": {"present": False}})
+    monkeypatch.setattr(api, "_build_pdf_donuts", lambda mh, d: [])
+    monkeypatch.setattr(api, "_build_report_charts", lambda g: {"trackers": [{"label": "x", "count": 3}]})
+    monkeypatch.setattr(api, "_persona_sheet", lambda *a, **k: {"tag": "T", "ua_seen": a[-1]})
+    monkeypatch.setattr(store, "get_client_level", lambda mh: "r1")
+    # social.fetch_graph is imported inside the helper via `from . import social`
+    import secubox_toolbox.social as social
+    monkeypatch.setattr(social, "fetch_graph",
+                        lambda mh, since_seconds=0: {"stats": {"total_trackers": 4}, "nodes": [{"n": 1}], "by_country": [{"c": "FR"}]})
+
+    data = {"device_type": "phone"}
+    out = api._enrich_report_data("aabbccdd", data, ua="Mozilla/5.0")
+
+    assert out is data  # mutates in place
+    for k in ("dpi_exfil", "media_exfil", "pdf_donuts", "persona", "charts",
+              "graph_stats", "bestiary", "carto_nodes", "carto_country"):
+        assert k in out, f"missing {k}"
+    assert out["persona"]["tag"] == "T"
+    assert out["persona"]["ua_seen"] == "Mozilla/5.0"   # ua threaded through
+    assert out["bestiary"] == [{"label": "x", "count": 3}]
+    assert out["graph_stats"] == {"total_trackers": 4}
+    assert out["carto_nodes"] == [{"n": 1}]
+
+
+def test_enrich_survives_graph_failure(monkeypatch):
+    monkeypatch.setattr(api, "_dpi_stats", lambda mh: {"me": {}, "all": {}})
+    monkeypatch.setattr(api, "_media_stats", lambda mh: {"me": {}, "all": {}})
+    monkeypatch.setattr(api, "_build_pdf_donuts", lambda mh, d: [])
+    monkeypatch.setattr(api, "_build_report_charts", lambda g: {"trackers": []})
+    monkeypatch.setattr(api, "_persona_sheet", lambda *a, **k: {"tag": "T"})
+    monkeypatch.setattr(store, "get_client_level", lambda mh: "r1")
+    import secubox_toolbox.social as social
+
+    def _boom(*a, **k):
+        raise RuntimeError("graph down")
+    monkeypatch.setattr(social, "fetch_graph", _boom)
+
+    out = api._enrich_report_data("aabbccdd", {"device_type": "pc"})
+    assert out["graph_stats"] == {}          # fell back to empty graph
+    assert out["bestiary"] == []

--- a/packages/secubox-toolbox/tests/test_persona_pdf.py
+++ b/packages/secubox-toolbox/tests/test_persona_pdf.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+"""Rich PDF character sheet (#790): pips, on/off inventory, quests section."""
+from secubox_toolbox import reports
+
+
+def _base(**extra):
+    d = {"mac_hash": "deadbeef", "device_type": "phone", "generated_at": "2026-07-04",
+         "indicators": [], "recommendations": [], "pinned_apps": []}
+    d.update(extra)
+    return d
+
+
+_PERSONA = {
+    "emoji": "🧑‍💻", "tag": "VILLAGE3B·#A1B2", "klass": "Runner", "level": "R3",
+    "align": "🛡️ Protégé", "hp": 85, "exposure": 15, "xp": 12480,
+    "attrs": [
+        {"icon": "🛡️", "name": "DÉFENSE", "v": 14, "pips": 5, "note": ""},
+        {"icon": "⚔️", "name": "RIPOSTE", "v": 6, "pips": 2, "note": "312 pubs tuées"},
+    ],
+    "inventory": [
+        {"icon": "🧅", "name": "Tunnel Tor", "on": True},
+        {"icon": "🚫", "name": "Ad-blocker", "on": False},
+    ],
+}
+
+
+def _spy_safe(monkeypatch):
+    """Capture every string drawn (everything is wrapped in reports._safe)."""
+    seen = []
+    orig = reports._safe
+    monkeypatch.setattr(reports, "_safe", lambda t: (seen.append(str(t)), orig(t))[1])
+    return seen
+
+
+def test_persona_rich_sections_and_pips(monkeypatch):
+    seen = _spy_safe(monkeypatch)
+    data = _base(persona=_PERSONA,
+                 bestiary=[{"label": "doubleclick.net", "count": 42, "emoji": "👹"}],
+                 dpi_exfil={"me": {"alerts": [
+                     {"kind": "exfil_volume", "label": "exfil", "service": "drive.google", "detail": "up 4.2Mo"}]}})
+    blob = reports.render_pdf(data)
+    assert isinstance(blob, (bytes, bytearray)) and len(blob) > 1000
+    joined = " ".join(seen)
+    assert "CARACTERISTIQUES" in joined           # attributes section header
+    assert "QUETES EN COURS" in joined            # quests section header
+    assert "●" in joined and "○" in joined         # pip glyphs rendered
+    assert any("✓" in s for s in seen) and any("✗" in s for s in seen)  # on/off inventory
+    assert any("EXFIL" in s for s in seen)         # the alert surfaced in Quêtes
+    assert any("doubleclick" in s for s in seen)   # bestiary
+
+
+def test_persona_no_alerts_shows_safe_zone(monkeypatch):
+    seen = _spy_safe(monkeypatch)
+    data = _base(persona=_PERSONA, dpi_exfil={"me": {"alerts": []}})
+    reports.render_pdf(data)
+    assert any("zone sure" in s for s in seen)     # empty-threats message
+
+
+def test_persona_missing_dpi_exfil_no_raise(monkeypatch):
+    # dpi_exfil absent entirely (legacy/token path before enrichment) must not raise
+    data = _base(persona=_PERSONA)
+    blob = reports.render_pdf(data)
+    assert isinstance(blob, (bytes, bytearray)) and len(blob) > 500

--- a/packages/secubox-toolbox/tests/test_persona_pdf.py
+++ b/packages/secubox-toolbox/tests/test_persona_pdf.py
@@ -37,10 +37,13 @@ def _spy_safe(monkeypatch):
 
 def test_persona_rich_sections_and_pips(monkeypatch):
     seen = _spy_safe(monkeypatch)
+    # #792 — real _dpi_stats shape: raw collector alerts under "alerts_raw"
+    # (kind/service/dst/detail); the donut "alerts" only carries {label,count}.
     data = _base(persona=_PERSONA,
                  bestiary=[{"label": "doubleclick.net", "count": 42, "emoji": "👹"}],
-                 dpi_exfil={"me": {"alerts": [
-                     {"kind": "exfil_volume", "label": "exfil", "service": "drive.google", "detail": "up 4.2Mo"}]}})
+                 dpi_exfil={"me": {"alerts": [{"label": "exfil volume", "count": 3}],
+                                   "alerts_raw": [
+                     {"kind": "exfil_volume", "dst": "1.2.3.4", "service": "drive.google", "detail": "up 4.2Mo"}]}})
     blob = reports.render_pdf(data)
     assert isinstance(blob, (bytes, bytearray)) and len(blob) > 1000
     joined = " ".join(seen)
@@ -48,7 +51,9 @@ def test_persona_rich_sections_and_pips(monkeypatch):
     assert "QUETES EN COURS" in joined            # quests section header
     assert "●" in joined and "○" in joined         # pip glyphs rendered
     assert any("✓" in s for s in seen) and any("✗" in s for s in seen)  # on/off inventory
-    assert any("EXFIL" in s for s in seen)         # the alert surfaced in Quêtes
+    assert any("EXFIL VOLUME" in s for s in seen)  # kind humanized + surfaced in Quêtes
+    assert any("drive.google" in s for s in seen)  # dest from raw alert now populated
+    assert any("up 4.2Mo" in s for s in seen)      # detail from raw alert
     assert any("doubleclick" in s for s in seen)   # bestiary
 
 
@@ -64,3 +69,13 @@ def test_persona_missing_dpi_exfil_no_raise(monkeypatch):
     data = _base(persona=_PERSONA)
     blob = reports.render_pdf(data)
     assert isinstance(blob, (bytes, bytearray)) and len(blob) > 500
+
+
+def test_persona_alerts_donut_fallback(monkeypatch):
+    # #792 — when only the donut 'alerts' exist (no alerts_raw), fall back to the
+    # label and render it with no dangling em-dash (no dest/detail available).
+    seen = _spy_safe(monkeypatch)
+    data = _base(persona=_PERSONA, dpi_exfil={"me": {"alerts": [{"label": "beaconing", "count": 2}]}})
+    reports.render_pdf(data)
+    assert any("BEACONING" in s for s in seen)
+    assert not any(s.strip().endswith("—") for s in seen)   # no dangling dash


### PR DESCRIPTION
Closes #790. Closes #792.

## Résumé

Rend la fiche de personnage du PDF fidèle à la carte `.nr` de la page web (que l'utilisateur trouve très bien), fait que **toutes** les routes PDF produisent le même contenu riche, et peuple enfin la section Quêtes/menaces avec de vraies données (HTML + PDF).

## Changements

**A — Fiche riche** (`reports.py` `_persona_block` + `_attr_row`) : ⚡ Caractéristiques avec pips `●●●○○○` + notes, 🎒 Inventaire en puces ✓/✗ on/off, 🐉 Bestiaire, et section ⚔️ Quêtes en cours · menaces (message « zone sûre » si vide). Full-fpdf (aucun matplotlib → ne touche pas au risque incident #785). Note italique gérée via le guard `_secubox_italic_ok` existant (DejaVu sans Oblique).

**B — Parité routes** (`api.py`) : `_enrich_report_data(mac_hash, data, ua="")` factorisé depuis `report_me`, appelé par les 3 routes PDF (`report_me`, `/report/{token}`, `/admin/clients/{mac_hash}/report`). token/admin passaient un PDF nu → maintenant identiques à `/report/me`.

**#792 (replié) — Quêtes réelles** (`api.py` + `reports.py` + `report-live.html.j2`) : `_dpi_stats` expose `alerts_raw` (kind/service/dst/detail) à côté du donut `alerts` ({label,count}). La section Quêtes lit `alerts_raw` → chaque menace montre destination + détail au lieu d'un « — » orphelin ; le donut Alertes de l'onglet DPI-Exfil reste sur `alerts` ; repli gracieux sur le label (sans tiret orphelin) si `alerts_raw` absent.

## Validé en live (gk2)

PDF `/report/me` : fiche avec pips `●●●●●○`/`●●●●○○`/…, inventaire ✓/✗, et Quêtes réelles : `🗡️ BEACONING — Google LLC · 15 flux périodiques (~26.9 s)`, `🗡️ NEW CLOUD — AWS S3/Supabase/Mistral`. HTML : 5 quêtes rendues. Route token enrichie. Aucune erreur. Rendu toujours derrière l'offload+lock+cache #785.

## Tests

TDD, revue par tâche + revue whole-branch (opus). 202 tests toolbox verts (7 nouveaux). Suivi restant (cosmétique non bloquant) : double-espace HTML quand dest vide mais detail présent.