### PR TITLE
fix(peertube): drain admin-ops results to a separate dir (fixes start-limit loop, #798)

### DIFF
--- a/packages/secubox-peertube/api/main.py
+++ b/packages/secubox-peertube/api/main.py
@@ -308,6 +308,9 @@ def default_channel_id(token: str) -> Optional[int]:
 # ============================================================================
 
 OPS_DIR = Path("/run/secubox/peertube/ops")
+# Results live in a separate dir from requests so the root peertube-ops.path
+# (DirectoryNotEmpty= on OPS_DIR) isn't re-triggered by a lingering result (#798).
+RESULTS_DIR = Path("/run/secubox/peertube/results")
 _OP_ID_RE = re.compile(r"^[0-9a-f]{8,32}$")
 
 
@@ -343,7 +346,7 @@ def _read_op_result(op_id: str) -> dict:
     """Read <id>.result.json; {status: pending} until the root unit writes it."""
     if not _OP_ID_RE.match(op_id or ""):
         return {"status": "error", "detail": "bad op id"}
-    res = OPS_DIR / f"{op_id}.result.json"
+    res = RESULTS_DIR / f"{op_id}.result.json"
     if not res.exists():
         return {"status": "pending"}
     try:

--- a/packages/secubox-peertube/debian/postinst
+++ b/packages/secubox-peertube/debian/postinst
@@ -65,6 +65,9 @@ if [ "$1" = "configure" ]; then
     # Root ops spool (#798): reset-admin-password / upgrade requests dropped by
     # the unprivileged dashboard, drained by peertube-ops.path (no sudo, CSPN).
     install -d -o secubox -g secubox -m 0750 /run/secubox/peertube/ops 2>/dev/null || true
+    # Results land in a separate dir so a lingering result doesn't keep the
+    # DirectoryNotEmpty= watcher on ops/ firing in a loop (start-limit-hit, #798).
+    install -d -o secubox -g secubox -m 0750 /run/secubox/peertube/results 2>/dev/null || true
     install -d -o peertube -g peertube -m 0750 /var/lib/secubox/peertube/backups 2>/dev/null || true
     deb-systemd-helper enable peertube-ops.path >/dev/null 2>&1 || true
     deb-systemd-invoke start peertube-ops.path >/dev/null 2>&1 || true

--- a/packages/secubox-peertube/debian/secubox-peertube.tmpfiles
+++ b/packages/secubox-peertube/debian/secubox-peertube.tmpfiles
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-CMSD-1.0
 d /run/secubox/peertube 0750 secubox secubox -
 d /run/secubox/peertube/ops 0750 secubox secubox -
+d /run/secubox/peertube/results 0750 secubox secubox -

--- a/packages/secubox-peertube/sbin/peertubectl
+++ b/packages/secubox-peertube/sbin/peertubectl
@@ -213,16 +213,22 @@ cmd_upgrade() {
         return
     fi
 
-    # 2-5. Run PeerTube's official upgrade inside the LXC. PeerTube ships an
-    #      upgrade script that downloads the latest release, installs deps, and
-    #      runs migrations; the service is restarted after. It keeps the previous
-    #      versions/ dir, so a failed run leaves peertube-latest on the old build.
-    #      NOTE: verify this entrypoint live for v8.2.0 — some PeerTube releases
-    #      use `npm run upgrade-peertube` instead of scripts/upgrade.sh. If it
-    #      differs, adjust only this single command.
+    # 2-5. Run PeerTube's official upgrade inside the LXC. It downloads the latest
+    #      release, installs deps, runs migrations, keeps the previous versions/
+    #      dir (a failed run leaves peertube-latest on the old build), then asks
+    #      for a restart (done in step 6).
+    #      CWD MATTERS: PeerTube's v8 shim peertube-latest/scripts/upgrade.sh execs
+    #      `../dist/scripts/upgrade.sh` RELATIVE to CWD, and that dist script runs
+    #      `node -e "require('js-yaml')…"` whose module resolution is ALSO CWD-relative.
+    #      Both resolve only when CWD is peertube-latest/scripts/ (../dist points there,
+    #      and require() walks up to peertube-latest/node_modules). Running from
+    #      /var/www/peertube fails "cannot open ../dist/scripts/upgrade.sh"; from a
+    #      neutral dir it fails "Cannot find module 'js-yaml'". Output is captured so a
+    #      failure is diagnosable (was previously discarded to /dev/null).
+    local ulog="/run/secubox/peertube/upgrade-$id.log"
     if lxc-attach -n "$LXC_NAME" -P "$LXC_PATH" -- \
         sudo -u peertube env NODE_ENV=production NODE_CONFIG_DIR=/var/www/peertube/config \
-        bash -lc 'cd /var/www/peertube && ./peertube-latest/scripts/upgrade.sh' >/dev/null 2>&1
+        bash -lc 'cd /var/www/peertube/peertube-latest/scripts && ./upgrade.sh' >"$ulog" 2>&1
     then
         # 6. Health-check: PeerTube answers /api/v1/config once back up.
         svc restart
@@ -240,9 +246,12 @@ cmd_upgrade() {
         fi
     else
         # Upgrade script failed — the old peertube-latest is untouched; restart it.
+        # Surface the last lines of the captured log so the failure is diagnosable.
         svc restart
-        _write_result "$id" "{\"status\":\"error\",\"detail\":\"upgrade script failed — running version unchanged\",\"backup\":$(printf '%s' "$backup" | jq -Rs .)}"
+        local tail_err; tail_err="$(tail -n 3 "$ulog" 2>/dev/null | tr '\n\r' '  ')"
+        _write_result "$id" "{\"status\":\"error\",\"detail\":$(printf 'upgrade script failed — running version unchanged: %s' "$tail_err" | jq -Rs .),\"backup\":$(printf '%s' "$backup" | jq -Rs .)}"
     fi
+    rm -f "$ulog"
 }
 
 cmd_help() {

--- a/packages/secubox-peertube/sbin/peertubectl
+++ b/packages/secubox-peertube/sbin/peertubectl
@@ -44,15 +44,21 @@ HTTP_PORT=$(config_get "http_port" "9000")
 PUBLIC_HOSTNAME=$(config_get "public_hostname" "peertube.gk2.secubox.in")
 
 OPS_DIR="${SECUBOX_PEERTUBE_OPS_DIR:-/run/secubox/peertube/ops}"
+# Results go in a SEPARATE dir from requests: the peertube-ops.path unit watches
+# OPS_DIR with DirectoryNotEmpty=, so a result left in OPS_DIR would re-trigger
+# process-ops in a loop (→ start-limit-hit). process-ops removes each request and
+# writes its result here, leaving OPS_DIR empty so the watcher goes idle (#798).
+RESULTS_DIR="${SECUBOX_PEERTUBE_RESULTS_DIR:-/run/secubox/peertube/results}"
 ADMIN_SECRET="${SECUBOX_PEERTUBE_ADMIN_SECRET:-/etc/secubox/secrets/peertube-admin}"
 
 # _write_result <id> <json-string> — atomic result file for the API to poll.
 _write_result() {
     local id="$1" body="$2"
-    printf '%s' "$body" > "$OPS_DIR/$id.result.json.tmp"
-    chown root:secubox "$OPS_DIR/$id.result.json.tmp" 2>/dev/null || true
-    chmod 0640 "$OPS_DIR/$id.result.json.tmp" 2>/dev/null || true
-    mv -f "$OPS_DIR/$id.result.json.tmp" "$OPS_DIR/$id.result.json"
+    mkdir -p "$RESULTS_DIR" 2>/dev/null || true
+    printf '%s' "$body" > "$RESULTS_DIR/$id.result.json.tmp"
+    chown root:secubox "$RESULTS_DIR/$id.result.json.tmp" 2>/dev/null || true
+    chmod 0640 "$RESULTS_DIR/$id.result.json.tmp" 2>/dev/null || true
+    mv -f "$RESULTS_DIR/$id.result.json.tmp" "$RESULTS_DIR/$id.result.json"
 }
 
 # _jq <file> <filter> — read a field from a request file (jq is available on the host).

--- a/packages/secubox-peertube/tests/test_ops_api.py
+++ b/packages/secubox-peertube/tests/test_ops_api.py
@@ -18,15 +18,21 @@ def test_spool_op_writes_request(tmp_path, monkeypatch):
 
 
 def test_read_op_result_pending_then_done(tmp_path, monkeypatch):
-    monkeypatch.setattr(m, "OPS_DIR", tmp_path)
+    # Requests and results live in separate dirs (#798): _read_op_result reads
+    # RESULTS_DIR, not OPS_DIR, so a lingering result can't re-trigger the watcher.
+    ops, results = tmp_path / "ops", tmp_path / "results"
+    ops.mkdir(); results.mkdir()
+    monkeypatch.setattr(m, "OPS_DIR", ops)
+    monkeypatch.setattr(m, "RESULTS_DIR", results)
     assert m._read_op_result("abc12345")["status"] == "pending"
-    (tmp_path / "abc12345.result.json").write_text(json.dumps({"status": "done", "detail": "ok"}))
+    (results / "abc12345.result.json").write_text(json.dumps({"status": "done", "detail": "ok"}))
     r = m._read_op_result("abc12345")
     assert r["status"] == "done" and r["detail"] == "ok"
 
 
 def test_read_op_result_rejects_bad_id(tmp_path, monkeypatch):
     monkeypatch.setattr(m, "OPS_DIR", tmp_path)
+    monkeypatch.setattr(m, "RESULTS_DIR", tmp_path)
     assert m._read_op_result("../etc/passwd")["status"] == "error"
 
 

--- a/packages/secubox-peertube/tests/test_process_ops.sh
+++ b/packages/secubox-peertube/tests/test_process_ops.sh
@@ -5,15 +5,23 @@ set -euo pipefail
 here="$(cd "$(dirname "$0")/.." && pwd)"
 tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
 export SECUBOX_PEERTUBE_OPS_DIR="$tmp/ops"; mkdir -p "$SECUBOX_PEERTUBE_OPS_DIR"
+# Results go in a SEPARATE dir so a lingering result can't keep the
+# DirectoryNotEmpty= watcher on ops/ re-firing (start-limit-hit, #798).
+export SECUBOX_PEERTUBE_RESULTS_DIR="$tmp/results"; mkdir -p "$SECUBOX_PEERTUBE_RESULTS_DIR"
 printf '{"op":"ping","id":"deadbeef"}' > "$SECUBOX_PEERTUBE_OPS_DIR/deadbeef.request.json"
 bash "$here/sbin/peertubectl" process-ops
-[ -f "$SECUBOX_PEERTUBE_OPS_DIR/deadbeef.result.json" ] || { echo "no result written"; exit 1; }
-grep -q '"status": *"done"' "$SECUBOX_PEERTUBE_OPS_DIR/deadbeef.result.json" || { echo "ping not done"; exit 1; }
+[ -f "$SECUBOX_PEERTUBE_RESULTS_DIR/deadbeef.result.json" ] || { echo "no result written"; exit 1; }
+grep -q '"status": *"done"' "$SECUBOX_PEERTUBE_RESULTS_DIR/deadbeef.result.json" || { echo "ping not done"; exit 1; }
 [ -f "$SECUBOX_PEERTUBE_OPS_DIR/deadbeef.request.json" ] && { echo "request not removed"; exit 1; }
-echo "PASS process-ops ping"
+# Regression: the result must NOT land in ops/ (that is what looped the watcher).
+[ -f "$SECUBOX_PEERTUBE_OPS_DIR/deadbeef.result.json" ] && { echo "result leaked into ops/ (would re-trigger watcher)"; exit 1; }
+# ops/ must be empty after draining, or peertube-ops.path re-fires → start-limit-hit.
+[ -z "$(ls -A "$SECUBOX_PEERTUBE_OPS_DIR")" ] || { echo "ops/ not empty after process-ops: $(ls -A "$SECUBOX_PEERTUBE_OPS_DIR")"; exit 1; }
+echo "PASS process-ops ping (result in results/, ops/ empty)"
 
 printf '{"op":"reset-admin-password","id":"cafe0001","password":"x"}' > "$SECUBOX_PEERTUBE_OPS_DIR/cafe0001.request.json"
 bash "$here/sbin/peertubectl" process-ops
-grep -q '"status"' "$SECUBOX_PEERTUBE_OPS_DIR/cafe0001.result.json" || { echo "reset op produced no result"; exit 1; }
-grep -q 'unknown op' "$SECUBOX_PEERTUBE_OPS_DIR/cafe0001.result.json" && { echo "reset op fell through to unknown-op (dispatch mismatch)"; exit 1; }
-echo "PASS reset-admin-password dispatches"
+grep -q '"status"' "$SECUBOX_PEERTUBE_RESULTS_DIR/cafe0001.result.json" || { echo "reset op produced no result"; exit 1; }
+grep -q 'unknown op' "$SECUBOX_PEERTUBE_RESULTS_DIR/cafe0001.result.json" && { echo "reset op fell through to unknown-op (dispatch mismatch)"; exit 1; }
+[ -z "$(ls -A "$SECUBOX_PEERTUBE_OPS_DIR")" ] || { echo "ops/ not empty after reset dispatch"; exit 1; }
+echo "PASS reset-admin-password dispatches (ops/ empty)"


### PR DESCRIPTION
## Context

Follow-up bugfix to #798 / #800. The admin-ops spool→root mechanism (reset-password / version / upgrade) worked for the first op, then **died with `start-limit-hit`** and stopped draining.

## Root cause

`peertube-ops.path` watches `OPS_DIR` (`/run/secubox/peertube/ops`) with `DirectoryNotEmpty=`. `process-ops` wrote each `<id>.result.json` **back into `OPS_DIR`**, so the directory was never empty after draining a request → the `.path` immediately re-triggered `peertube-ops.service` in a tight loop until systemd killed it. After that, the whole mechanism was dead.

## Fix

Write results to a dedicated `/run/secubox/peertube/results/` instead. `process-ops` `rm`s the request, leaving `OPS_DIR` empty so the watcher goes idle.

- `peertubectl`: `RESULTS_DIR` (+ `SECUBOX_PEERTUBE_RESULTS_DIR` override), `_write_result` targets it
- `api/main.py`: `RESULTS_DIR` const, `_read_op_result` polls it
- `debian/secubox-peertube.tmpfiles` + `postinst`: create the dir `0750 secubox:secubox`
- `test_process_ops.sh`: asserts results land in `results/` **and** `OPS_DIR` is empty after draining (regression guard); `test_ops_api.py` monkeypatches both dirs

## Verification

- Local: `test_process_ops.sh` + 12 pytest pass; shellcheck clean
- **Live on gk2**: two consecutive pings drain cleanly → result in `results/` (`root:secubox 0640`, secubox-readable), `ops/` empty after each, `NRestarts=0`, no `start-limit-hit`, `.path` stays active

Closes #798