### PR TITLE
fix(sbxwaf): forward WebSocket upgrades (Zigbee dashboard wss:// broke, #796)

### DIFF
--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/main.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/main.go
@@ -48,7 +48,18 @@ import (
 	"time"
 
 	"github.com/CyberMind-FR/secubox-deb/secubox-toolbox-ng/internal/forge"
+	"golang.org/x/net/http/httpguts"
 )
+
+// isWebSocketUpgrade reports whether r is a WebSocket handshake, using the same
+// header semantics as net/http/httputil.ReverseProxy: the Connection header must
+// contain the "Upgrade" token (comma list, case-insensitive) AND Upgrade must be
+// "websocket". #796 — we must NOT rewrite Connection on these requests, or the
+// ReverseProxy stops tunnelling the WebSocket.
+func isWebSocketUpgrade(h http.Header) bool {
+	return httpguts.HeaderValuesContainsToken(h["Connection"], "Upgrade") &&
+		strings.EqualFold(h.Get("Upgrade"), "websocket")
+}
 
 // upstreamErrorCode maps a round-trip error to the appropriate HTTP error code,
 // mirroring the Python error() hook logic (~line 1106):
@@ -288,8 +299,13 @@ func (s *Server) handler() http.Handler {
 		// Task 2.2 — Request inspection.
 		// Only when rules are loaded; otherwise pass through unconditionally.
 		if s.rules != nil {
-			// Add Connection: close to upstream requests (#496, mirrors Python).
-			r.Header.Set("Connection", "close")
+			// Add Connection: close to upstream requests (#496, mirrors Python) —
+			// but NEVER on a WebSocket upgrade: that would clobber Connection:
+			// Upgrade and stop httputil.ReverseProxy from tunnelling the WS,
+			// turning wss:// vhosts into a plain GET → 404/1006 (#796).
+			if !isWebSocketUpgrade(r.Header) {
+				r.Header.Set("Connection", "close")
+			}
 
 			ip := clientIP(r)
 			// Determine the path for skip-list checks. Use RawPath when available

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/mediacache.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/mediacache.go
@@ -22,9 +22,11 @@
 package main
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -558,6 +560,18 @@ func (c *cachingResponseWriter) Flush() {
 	if f, ok := c.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
+}
+
+// Hijack forwards to the underlying ResponseWriter so httputil.ReverseProxy can
+// tunnel WebSocket upgrades through this cache wrapper (#796). Without it, the
+// media-cache tee shadows the underlying Hijacker and WS upgrades return 503
+// ("can't switch protocols using non-Hijacker ResponseWriter"). A hijacked
+// connection is raw-tunnelled, so nothing is cached — correct for a WS.
+func (c *cachingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := c.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, fmt.Errorf("cachingResponseWriter: underlying ResponseWriter does not support Hijack")
 }
 
 // Stats returns a point-in-time snapshot of cache counters.

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/routes.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/routes.go
@@ -193,6 +193,7 @@ func (r *Routes) buildEntries(parsed map[string][2]string) map[string]routeEntry
 				if bare, _, e := net.SplitHostPort(reqHost); e == nil {
 					reqHost = bare
 				}
+				log.Printf("sbxwaf: upstream error host=%s path=%s -> %d: %v", reqHost, req.URL.Path, code, err)
 				writeErrorPage(w, code, reqHost)
 			}
 			r.proxyCache.Store(key, p)

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/visitstats.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/visitstats.go
@@ -20,7 +20,10 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -46,6 +49,17 @@ func (s *statusRecorder) Flush() {
 	if f, ok := s.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
+}
+
+// Hijack forwards to the underlying ResponseWriter so that httputil.ReverseProxy
+// can tunnel WebSocket upgrades through this wrapper (#796). Without it, the
+// embedded http.ResponseWriter interface does not expose Hijack, so a wrapped
+// writer fails the http.Hijacker type assertion and WS upgrades return 503.
+func (s *statusRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := s.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, errors.New("statusRecorder: underlying ResponseWriter does not support Hijack")
 }
 
 // visitMapCap bounds each per-key map so a flood of distinct vhosts/IPs cannot

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/websocket_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/websocket_test.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: LicenseRef-CMSD-1.0
+// Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+// Source-Disclosed License — All rights reserved except as expressly granted.
+// See LICENCE-CMSD-1.0.md for terms.
+
+// #796 — sbxwaf must forward WebSocket upgrades (it used to force Connection:
+// close on every upstream request, clobbering Connection: Upgrade and breaking
+// httputil.ReverseProxy's WS tunnel → wss:// vhosts got a 404/1006).
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIsWebSocketUpgrade(t *testing.T) {
+	cases := []struct {
+		conn, upg string
+		want      bool
+	}{
+		{"Upgrade", "websocket", true},
+		{"upgrade", "WebSocket", true},             // case-insensitive
+		{"keep-alive, Upgrade", "websocket", true}, // Upgrade token in a list
+		{"keep-alive", "websocket", false},         // no Upgrade token in Connection
+		{"Upgrade", "", false},                     // no Upgrade header
+		{"close", "websocket", false},              // close, not upgrade
+		{"", "", false},                            // plain request
+	}
+	for _, c := range cases {
+		h := http.Header{}
+		if c.conn != "" {
+			h.Set("Connection", c.conn)
+		}
+		if c.upg != "" {
+			h.Set("Upgrade", c.upg)
+		}
+		if got := isWebSocketUpgrade(h); got != c.want {
+			t.Errorf("isWebSocketUpgrade(Connection=%q Upgrade=%q) = %v, want %v",
+				c.conn, c.upg, got, c.want)
+		}
+	}
+}
+
+// wsBackend upgrades a WebSocket handshake (records the Connection header it
+// received on connCh) and echoes back "hello". Non-WS requests get 200 with the
+// Connection header sent to connCh too.
+func wsBackend(connCh chan<- string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case connCh <- r.Header.Get("Connection"):
+		default:
+		}
+		if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, "plain-ok")
+			return
+		}
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "backend: no hijack", http.StatusInternalServerError)
+			return
+		}
+		conn, brw, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		io.WriteString(brw, "HTTP/1.1 101 Switching Protocols\r\n"+
+			"Upgrade: websocket\r\nConnection: Upgrade\r\n\r\nhello")
+		brw.Flush()
+	}
+}
+
+func splitHostPortInt(t *testing.T, url string) (string, int) {
+	t.Helper()
+	addr := strings.TrimPrefix(url, "http://")
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", addr, err)
+	}
+	var port int
+	for _, b := range []byte(portStr) {
+		port = port*10 + int(b-'0')
+	}
+	return host, port
+}
+
+// TestHandlerPreservesWebSocketUpgrade drives a real WS handshake through the
+// sbxwaf handler (rules loaded → the Connection-rewrite path is active) and
+// asserts it reaches the backend as an upgrade (101), not a clobbered plain GET.
+func TestHandlerPreservesWebSocketUpgrade(t *testing.T) {
+	connCh := make(chan string, 1)
+	backend := httptest.NewServer(wsBackend(connCh))
+	defer backend.Close()
+	bHost, bPort := splitHostPortInt(t, backend.URL)
+
+	srv := &Server{
+		rules: LoadRules("/tmp/nonexistent-waf-rules-796.json"), // non-nil, matches nothing → clobber path active
+		routeLookup: func(host string) (string, int, bool) {
+			return bHost, bPort, true
+		},
+	}
+	front := httptest.NewServer(srv.handler())
+	defer front.Close()
+
+	c, err := net.Dial("tcp", strings.TrimPrefix(front.URL, "http://"))
+	if err != nil {
+		t.Fatalf("dial front: %v", err)
+	}
+	defer c.Close()
+	c.SetDeadline(time.Now().Add(5 * time.Second))
+
+	fmt.Fprintf(c, "GET /api HTTP/1.1\r\nHost: zigbee.example.com\r\n"+
+		"Upgrade: websocket\r\nConnection: Upgrade\r\n"+
+		"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n")
+
+	br := bufio.NewReader(c)
+	status, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read status line: %v", err)
+	}
+	if !strings.Contains(status, "101") {
+		t.Fatalf("WebSocket upgrade not tunnelled: status = %q (want 101 Switching Protocols)", strings.TrimSpace(status))
+	}
+
+	// The backend must have seen the upgrade, NOT a clobbered Connection: close.
+	select {
+	case got := <-connCh:
+		if strings.EqualFold(strings.TrimSpace(got), "close") {
+			t.Fatalf("backend received Connection: close on a WebSocket upgrade (clobbered)")
+		}
+		if !strings.Contains(strings.ToLower(got), "upgrade") {
+			t.Fatalf("backend Connection header lost the upgrade token: %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("backend never received the request")
+	}
+}
+
+// TestHandlerProxiesNonWebSocket is the regression guard: the WS carve-out must
+// not break ordinary (non-WS) requests — they still proxy normally. (The #496
+// Connection: close set on the upstream request is a hop-by-hop header that
+// ReverseProxy consumes to disable keep-alive; it is not forwarded to the
+// backend, so we assert the response, not the backend's Connection header.)
+func TestHandlerProxiesNonWebSocket(t *testing.T) {
+	connCh := make(chan string, 1)
+	backend := httptest.NewServer(wsBackend(connCh))
+	defer backend.Close()
+	bHost, bPort := splitHostPortInt(t, backend.URL)
+
+	srv := &Server{
+		rules: LoadRules("/tmp/nonexistent-waf-rules-796.json"),
+		routeLookup: func(host string) (string, int, bool) {
+			return bHost, bPort, true
+		},
+	}
+	front := httptest.NewServer(srv.handler())
+	defer front.Close()
+
+	resp, err := http.Get(front.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("non-WS request: status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "plain-ok") {
+		t.Fatalf("non-WS request: body = %q, want plain-ok", string(body))
+	}
+}

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/websocket_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/websocket_test.go
@@ -102,7 +102,8 @@ func TestHandlerPreservesWebSocketUpgrade(t *testing.T) {
 	bHost, bPort := splitHostPortInt(t, backend.URL)
 
 	srv := &Server{
-		rules: LoadRules("/tmp/nonexistent-waf-rules-796.json"), // non-nil, matches nothing → clobber path active
+		rules:  LoadRules("/tmp/nonexistent-waf-rules-796.json"), // non-nil, matches nothing → clobber path active
+		visits: NewVisitStats(t.TempDir() + "/visits.json"),      // non-nil → statusRecorder wraps w (board path; must still Hijack)
 		routeLookup: func(host string) (string, int, bool) {
 			return bHost, bPort, true
 		},

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/websocket_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/websocket_test.go
@@ -20,6 +20,44 @@ import (
 	"time"
 )
 
+// hijackableRW is a ResponseWriter that records whether Hijack was called on it.
+type hijackableRW struct {
+	http.ResponseWriter
+	hijacked bool
+}
+
+func (h *hijackableRW) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h.hijacked = true
+	return nil, nil, nil
+}
+
+// TestResponseWrappersForwardHijack guards #796: every ResponseWriter wrapper in
+// the sbxwaf handler chain (visit-stats + media-cache) must forward Hijack, or
+// httputil.ReverseProxy can't tunnel WebSocket upgrades ("can't switch protocols
+// using non-Hijacker ResponseWriter type …").
+func TestResponseWrappersForwardHijack(t *testing.T) {
+	base := &hijackableRW{ResponseWriter: httptest.NewRecorder()}
+
+	sr := &statusRecorder{ResponseWriter: base}
+	if _, ok := interface{}(sr).(http.Hijacker); !ok {
+		t.Fatal("statusRecorder does not implement http.Hijacker")
+	}
+	sr.Hijack()
+	if !base.hijacked {
+		t.Fatal("statusRecorder.Hijack did not forward to the underlying writer")
+	}
+
+	base.hijacked = false
+	cw := &cachingResponseWriter{ResponseWriter: base}
+	if _, ok := interface{}(cw).(http.Hijacker); !ok {
+		t.Fatal("cachingResponseWriter does not implement http.Hijacker")
+	}
+	cw.Hijack()
+	if !base.hijacked {
+		t.Fatal("cachingResponseWriter.Hijack did not forward to the underlying writer")
+	}
+}
+
 func TestIsWebSocketUpgrade(t *testing.T) {
 	cases := []struct {
 		conn, upg string


### PR DESCRIPTION
## Context

`wss://zigbee.gk2.secubox.in/api` failed with WebSocket close 1006 + a reconnect loop, while the LXC-direct `http://10.100.0.111:8080/#/dashboard` worked. Every vhost proxied through the Go `sbxwaf` WAF that needed a WebSocket upgrade was affected — not just Zigbee.

## Root cause (3 layers)

1. **`main.go`** forced `Connection: close` on every upstream request (a #496 keep-alive tweak), which clobbered the client's `Connection: Upgrade` → `httputil.ReverseProxy` never saw the handshake.
2. **`statusRecorder`** (visit-stats wrapper) did not implement `http.Hijacker`, so even once the upgrade reached the proxy it couldn't switch protocols (`can't switch protocols using non-Hijacker ResponseWriter`).
3. **`cachingResponseWriter`** (media-cache wrapper) had the same missing `Hijack`.

## Fix

- `isWebSocketUpgrade()` helper (RFC-correct token check); guard the `Connection: close` rewrite so WS upgrades keep `Connection: Upgrade`
- `statusRecorder.Hijack()` + `cachingResponseWriter.Hijack()` forward to the underlying writer
- `ErrorHandler` now logs upstream errors (`sbxwaf: upstream error host=… -> code: err`) — this is what pinned the Hijacker layer

## Tests (`websocket_test.go`, new)

- `TestIsWebSocketUpgrade` — token matrix
- `TestResponseWrappersForwardHijack` — both wrappers implement + forward `Hijack`
- `TestHandlerPreservesWebSocketUpgrade` — real handshake through the handler (rules loaded → clobber path active) reaches the backend as `101`, not a clobbered plain GET
- `TestHandlerProxiesNonWebSocket` — regression: ordinary requests still proxy

## Verification

`go test ./cmd/sbxwaf/` green. **Live on gk2**: `wss://zigbee.gk2.secubox.in/api` → `101 Switching Protocols`, dashboard stable (no reconnect loop). Clean auto-merge with current master.

Closes #796