### PR TITLE
fix(peertube): stop webui login loop — getToken() reads sbx_token (#810)

### DIFF
--- a/packages/secubox-peertube/www/peertube/index.html
+++ b/packages/secubox-peertube/www/peertube/index.html
@@ -638,7 +638,7 @@
         let containerStatus = 'not_installed';
 
         function getToken() {
-            return localStorage.getItem('jwt_token') || localStorage.getItem('token') || '';
+            return localStorage.getItem('sbx_token') || localStorage.getItem('secubox_token') || localStorage.getItem('jwt_token') || localStorage.getItem('token') || '';
         }
 
         async function api(endpoint, options = {}) {


### PR DESCRIPTION
## Symptom

`admin.gk2.secubox.in:9080/peertube/` bounces to `/login.html?redirect=%2Fpeertube%2F` and **loops** after a successful login.

## Root cause

`getToken()` read `localStorage 'jwt_token' || 'token'` — keys the canonical `login.html` **never** writes. login.html (and waf, soc, crowdsec, metrics, shared `sidebar.js`) all use **`sbx_token`**. PeerTube sent an empty `Authorization` → API 401 → `api()`'s 401 handler redirects to login → login stores `sbx_token` → back to `/peertube/` → `getToken()` reads `jwt_token` (empty) → 401 → loop.

Pre-existing divergence (present in the May-28 board backup); **not** caused by #798. Same class as the cookies webui drift (#749).

## Fix

`getToken()` reads `sbx_token` first, legacy keys as fallback. One line, `www/peertube/index.html`. Applied live on the board to unblock.

## Verification

- Confirmed both ends: login.html writes `sbx_token`; peertube now reads it; API path identical to working modules (waf/soc) that already use `sbx_token` + the same `require_jwt`.
- Live board reload no longer loops.

Closes #810