### PR TITLE
feat(toolbox): activate Sentinel + surface compromise detections (WebUI tab · kbin report · PDF) — ref #823

### DIFF
--- a/common/nginx/webui.conf
+++ b/common/nginx/webui.conf
@@ -3,6 +3,14 @@ server {
     root /usr/share/secubox/www;
     index index.html;
 
+    # Revalidate versioned webui assets so a package deploy is picked up
+    # immediately (ETag makes revalidation a cheap 304). Without this, browsers
+    # heuristically cache luci-static JS/CSS and serve a stale UI after updates.
+    location ^~ /luci-static/ {
+        add_header Cache-Control "no-cache" always;
+        try_files $uri =404;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/docs/demos/2026-07-06-kbin-sentinel-augmentation-prompt.md
+++ b/docs/demos/2026-07-06-kbin-sentinel-augmentation-prompt.md
@@ -1,0 +1,33 @@
+# Demo Prompt — kbin ToolBoX × Sentinel Augmentation (#823)
+
+## What changed
+The SecuBox kbin (ToolBoX) gained an on-network **compromise-detection**
+capability group ("Sentinelle"): the `sbx-sentinel` daemon inspects mirrored
+tunnel traffic against commercial-spyware / exploit / botnet IOC packs (Pegasus,
+Predator/Intellexa, plus live abuse.ch + MVT/Citizen-Lab feeds) and records
+per-device verdicts. Findings now surface in three places:
+- **Admin WebUI** — a fleet "🛡️ Sentinelle" tab (all recent detections +
+  compromise evaluation).
+- **kbin "mon rapport"** — a per-device Compromission tab.
+- **PDF report** — a per-device Sentinelle section.
+
+All findings are report-only and carry an anonymous `mac_hash` only. Heuristic
+and zero-click signals are shown as "suspect", never as a confirmed compromise.
+
+## GPT prompt (paste into a model)
+
+> You are presenting SecuBox, a Debian-based home/SMB security gateway. It just
+> shipped a new capability group called **Sentinelle**: while a device browses
+> through the SecuBox tunnel, the box inspects the traffic against threat-intel
+> indicators for commercial spyware (Pegasus, Predator/Intellexa), exploits, and
+> botnets, and produces a per-device **compromise assessment** (clean / suspect /
+> compromised) plus a detection list. It surfaces this to the admin as a fleet
+> dashboard tab, to each user in their personal "mon rapport", and in a printable
+> PDF — all keyed on an anonymous session hash, no personal data.
+>
+> Write a short, punchy narrative (max 250 words) for a security-savvy audience
+> that (a) explains why on-network compromise detection at the gateway is a
+> meaningful augmentation over endpoint-only tools, (b) walks through what a user
+> sees when their phone contacts a known Pegasus C2, and (c) is honest that the
+> system is detection/reporting, not blocking, and that heuristic signals are
+> flagged as suspicion rather than proof. Avoid hype; be technically credible.

--- a/docs/superpowers/plans/2026-07-06-sentinel-activation-toolbox-surfaces.md
+++ b/docs/superpowers/plans/2026-07-06-sentinel-activation-toolbox-surfaces.md
@@ -1,0 +1,1100 @@
+# Sentinel Activation + ToolBoX Surfaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the `sbx-sentinel` compromise-detection daemon live (async, report-only) on gk2 and surface its detections on three ToolBoX surfaces — the admin WebUI fleet tab, the per-device kbin HTML report, and the per-device PDF report — then produce a GPT demo prompt.
+
+**Architecture:** The already-merged (dark) `sbx-sentinel` daemon exposes a read-only localhost status HTTP (`/stats`, `/verdicts`). A one-line Go change adds a per-`mac` filter to `/verdicts`. A new Python module `sentinel_link.py` in the `secubox-toolbox` portal does fail-safe stdlib fetches of that HTTP and computes a compromise/evaluation summary (`assess`). Three surfaces consume it: admin proxy routes + a WebUI tab (fleet), and `build_report_data`'s new `sentinel` key feeding both the kbin HTML template and the PDF renderer (per-device). Activation is the final deploy+verify task.
+
+**Tech Stack:** Go (bbolt store, net/http), Python 3.11 (FastAPI portal, fpdf2, Jinja2), vanilla JS (P31 light-skin portal), systemd on Debian arm64 (gk2).
+
+## Global Constraints
+
+- **Report-only, defensive.** Do NOT enable the inline hot-path blocking gate. Heuristic and zero-click detections NEVER escalate to a "compromised" verdict and are never auto-blocked. `FinalizeAction` threshold stays 85.
+- **PII floor:** every surface shows `mac_hash` ONLY — no IP, no other identifier.
+- **No `waf_bypass`; no new external surface.** Daemon status HTTP binds `127.0.0.1:8790` only — no nft rule, never proxied to the outside.
+- **Fail-safe everywhere:** a dark/wedged daemon must NEVER raise out to a portal client or break a report/PDF build. Absent daemon → an "inactive" state, HTTP 200, valid PDF.
+- **No new Debian dependency** for the daemon fetch — use the Python stdlib (`urllib.request`) with a bounded timeout (1.5s).
+- **gk2 ops rules:** never touch the shared `/run/secubox` (1777) or `/var/lib/secubox` parents; restart the 4 sbxmitm ng-workers sequentially with socket-wait (no mass restart); respect `RuntimeDirectoryPreserve=yes`.
+- **Honest disposition:** `action=block` → "Bloquée"; `action=report` → "Détectée — observée" (never claim "blocked before any data left" for an observed/async detection).
+- **Commit trailer:** every commit ends with `(ref #823)`. No Claude Code references in commits/PRs.
+- **Verdict JSON keys are lowercase:** `class, severity, confidence, action, evidence, mac_hash, ts, report`.
+- **Python tests run:** `cd packages/secubox-toolbox && PYTHONPATH=../../common:. python3 -m pytest tests/<file> -q`.
+- **Go tests run:** `cd packages/secubox-toolbox-ng && go test ./cmd/sbx-sentinel/...`.
+
+---
+
+### Task 1: Go — per-`mac` filter on `/verdicts`
+
+**Files:**
+- Modify: `packages/secubox-toolbox-ng/cmd/sbx-sentinel/http.go` (the `/verdicts` handler, ~line 102-134)
+- Test: `packages/secubox-toolbox-ng/cmd/sbx-sentinel/http_test.go`
+
+**Interfaces:**
+- Consumes: `store.Recent(limit int) ([]Verdict, error)` and `store.ByMac(macHash string, limit int) ([]Verdict, error)` (both exist in `internal/sentinel/store.go`); `verdictView` struct (http.go:47); `statusRecentLimit = 500`.
+- Produces: `GET /verdicts?mac=<hash>&limit=N` → JSON array of `verdictView`, filtered to `macHash` via `ByMac`. `mac` absent → unchanged `Recent` behavior.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/secubox-toolbox-ng/cmd/sbx-sentinel/http_test.go`:
+
+```go
+func TestVerdictsFilterByMac(t *testing.T) {
+	store := openTestStore(t)
+	store.Record(&sentinel.Verdict{
+		Class: sentinel.ClassSpywarePegasus, Action: sentinel.ActionBlock,
+		Evidence: map[string]string{"ioc_value": "a.example"},
+		MacHash:  "aaaa", TS: time.Now().Unix(),
+	})
+	store.Record(&sentinel.Verdict{
+		Class: sentinel.ClassSpywarePredator, Action: sentinel.ActionReport,
+		Evidence: map[string]string{"ioc_value": "b.example"},
+		MacHash:  "bbbb", TS: time.Now().Unix(),
+	})
+	mux := newStatusMux(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/verdicts?mac=aaaa", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var got []verdictView
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 || got[0].MacHash != "aaaa" {
+		t.Fatalf("want 1 verdict for aaaa, got %d: %+v", len(got), got)
+	}
+
+	// Unknown mac → empty list, still 200.
+	req = httptest.NewRequest(http.MethodGet, "/verdicts?mac=zzzz", nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unknown-mac status %d", rec.Code)
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode2: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want 0 for unknown mac, got %d", len(got))
+	}
+}
+```
+
+> Note: `store.Record` takes `*Verdict` (see the existing `/verdicts` test which builds the store the same way). If the existing test uses a helper to seed, mirror it — keep this test self-contained otherwise.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/secubox-toolbox-ng && go test ./cmd/sbx-sentinel/ -run TestVerdictsFilterByMac -v`
+Expected: FAIL — the `mac` param is ignored, so `mac=aaaa` returns both verdicts (len 2, not 1).
+
+- [ ] **Step 3: Implement the filter in the `/verdicts` handler**
+
+In `http.go`, inside the `mux.HandleFunc("/verdicts", …)` handler, after the `limit` is parsed and BEFORE `recent, err := store.Recent(limit)`, branch on `mac`:
+
+```go
+		limit := statusRecentLimit
+		if q := r.URL.Query().Get("limit"); q != "" {
+			if n, err := strconv.Atoi(q); err == nil && n > 0 && n <= statusRecentLimit {
+				limit = n
+			}
+		}
+		var (
+			recent []sentinel.Verdict
+			err    error
+		)
+		if mac := r.URL.Query().Get("mac"); mac != "" {
+			recent, err = store.ByMac(mac, limit)
+		} else {
+			recent, err = store.Recent(limit)
+		}
+		if err != nil {
+			http.Error(w, "store error", http.StatusInternalServerError)
+			return
+		}
+```
+
+Replace the existing `recent, err := store.Recent(limit)` line (and its `if err != nil` block) with the block above. Leave the `verdictView` marshalling loop below it unchanged. Confirm the `sentinel` package is already imported in http.go (it is — `verdictView` uses `v.Class` etc.).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/secubox-toolbox-ng && go test ./cmd/sbx-sentinel/...`
+Expected: PASS — `TestVerdictsFilterByMac` plus the existing `/verdicts`, `/stats`, non-GET tests all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/secubox-toolbox-ng/cmd/sbx-sentinel/http.go packages/secubox-toolbox-ng/cmd/sbx-sentinel/http_test.go
+git commit -m "feat(sentinel): add mac filter to /verdicts status endpoint (ref #823)"
+```
+
+---
+
+### Task 2: Python — `sentinel_link.py` (fail-safe fetch + assess)
+
+**Files:**
+- Create: `packages/secubox-toolbox/secubox_toolbox/sentinel_link.py`
+- Test: `packages/secubox-toolbox/tests/test_sentinel_link.py`
+
+**Interfaces:**
+- Consumes: the daemon HTTP `GET /stats` → `{"detections":N,"blocked":N,"spyware":N}` and `GET /verdicts[?mac=&limit=]` → list of `{class,severity,confidence,action,evidence,mac_hash,ts,report}`.
+- Produces (imported by Tasks 3, 5, 6):
+  - `daemon_base() -> str | None`
+  - `fetch_stats() -> dict`
+  - `fetch_verdicts(limit: int = 50) -> list[dict]`
+  - `fetch_detections(mac_hash: str, limit: int = 50) -> list[dict]`
+  - `assess(detections: list[dict]) -> dict` with keys `tier` (`"clean"|"suspicious"|"compromised"`), `worst_severity: int`, `worst_confidence: int`, `count: int`, `dominant_class: str`, `strongest: dict | None`
+  - `disposition(action: str) -> str`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/secubox-toolbox/tests/test_sentinel_link.py`:
+
+```python
+from secubox_toolbox import sentinel_link as sl
+
+
+def test_assess_clean_when_no_detections():
+    a = sl.assess([])
+    assert a["tier"] == "clean"
+    assert a["count"] == 0
+    assert a["strongest"] is None
+
+
+def test_assess_report_only_spyware_is_suspicious():
+    dets = [{"class": "spyware_pegasus", "severity": 95, "confidence": 95,
+             "action": "report", "evidence": {}, "mac_hash": "aa", "ts": 1}]
+    a = sl.assess(dets)
+    assert a["tier"] == "suspicious"
+    assert a["worst_severity"] == 95
+    assert a["dominant_class"] == "spyware_pegasus"
+    assert a["strongest"]["class"] == "spyware_pegasus"
+
+
+def test_assess_high_conf_block_spyware_is_compromised():
+    dets = [{"class": "spyware_pegasus", "severity": 95, "confidence": 95,
+             "action": "block", "evidence": {}, "mac_hash": "aa", "ts": 1}]
+    assert sl.assess(dets)["tier"] == "compromised"
+
+
+def test_assess_zero_click_never_compromised_even_if_block():
+    # zero-click is heuristic — must stay suspicious regardless of action.
+    dets = [{"class": "zero_click", "severity": 90, "confidence": 90,
+             "action": "block", "evidence": {}, "mac_hash": "aa", "ts": 1}]
+    assert sl.assess(dets)["tier"] == "suspicious"
+
+
+def test_assess_low_confidence_block_is_not_compromised():
+    dets = [{"class": "malware_generic", "severity": 90, "confidence": 60,
+             "action": "block", "evidence": {}, "mac_hash": "aa", "ts": 1}]
+    assert sl.assess(dets)["tier"] == "suspicious"
+
+
+def test_disposition_labels():
+    assert sl.disposition("block") == "Bloquée"
+    assert sl.disposition("report") == "Détectée — observée"
+    assert sl.disposition("") == "Détectée — observée"
+
+
+def test_fetch_stats_failsafe_when_daemon_down(monkeypatch):
+    # Point at a base but make the HTTP call raise → {} (never raises out).
+    monkeypatch.setattr(sl, "daemon_base", lambda: "http://127.0.0.1:9")
+    assert sl.fetch_stats() == {}
+    assert sl.fetch_verdicts() == []
+    assert sl.fetch_detections("aa") == []
+
+
+def test_fetch_stats_none_base_returns_empty(monkeypatch):
+    monkeypatch.setattr(sl, "daemon_base", lambda: None)
+    assert sl.fetch_stats() == {}
+    assert sl.fetch_verdicts() == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=../../common:. python3 -m pytest tests/test_sentinel_link.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'secubox_toolbox.sentinel_link'`.
+
+- [ ] **Step 3: Implement `sentinel_link.py`**
+
+Create `packages/secubox-toolbox/secubox_toolbox/sentinel_link.py`:
+
+```python
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+SecuBox-Deb :: ToolBoX Sentinel link
+CyberMind — https://cybermind.fr
+
+Fail-safe bridge from the ToolBoX portal to the sbx-sentinel daemon's
+read-only localhost status HTTP, plus the compromise/evaluation summary.
+
+Everything here is defensive and MUST NOT raise out to a caller: a dark or
+wedged daemon degrades to empty results, never an exception. Detections
+carry mac_hash only — no other PII passes through this module.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import urllib.request
+from collections import Counter
+
+log = logging.getLogger("secubox.toolbox.sentinel")
+
+_TIMEOUT = 1.5  # seconds — a wedged daemon must not stall a portal request
+_DEFAULT_ADDR = "127.0.0.1:8790"
+_SENTINEL_ENV = "/etc/secubox/sentinel.env"
+
+# Heuristic classes never escalate to "compromised" — they are behavioral
+# guesses, not confirmed known-infrastructure hits. Keep in sync with the Go
+# scorer's heuristicClasses (currently zero-click).
+_HEURISTIC_CLASSES = {"zero_click"}
+_HIGH_CONFIDENCE = 85  # mirrors Go HighConfidenceThreshold
+
+
+def daemon_base() -> str | None:
+    """Resolve the daemon status-HTTP base URL, or None if unconfigured.
+
+    Order: SENTINEL_HTTP_ADDR from the process env, then from
+    /etc/secubox/sentinel.env, then the 127.0.0.1:8790 default. An explicitly
+    empty value (the dark default) yields None so callers show 'inactive'.
+    """
+    addr = os.environ.get("SENTINEL_HTTP_ADDR")
+    if addr is None:
+        addr = _read_env_addr()
+    if addr is None:
+        addr = _DEFAULT_ADDR
+    addr = addr.strip()
+    if not addr:
+        return None
+    if not addr.startswith("http"):
+        addr = "http://" + addr
+    return addr.rstrip("/")
+
+
+def _read_env_addr() -> str | None:
+    """Best-effort read of SENTINEL_HTTP_ADDR from sentinel.env; None on any issue."""
+    try:
+        with open(_SENTINEL_ENV, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line.startswith("SENTINEL_HTTP_ADDR="):
+                    return line.split("=", 1)[1].strip().strip('"')
+    except Exception:
+        pass
+    return None
+
+
+def _get_json(path: str):
+    """GET base+path and parse JSON. Returns None on ANY failure (never raises)."""
+    base = daemon_base()
+    if not base:
+        return None
+    try:
+        req = urllib.request.Request(base + path, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:  # connection refused, timeout, bad JSON, HTTP error
+        log.debug("sentinel fetch %s failed: %s", path, exc)
+        return None
+
+
+def fetch_stats() -> dict:
+    data = _get_json("/stats")
+    return data if isinstance(data, dict) else {}
+
+
+def fetch_verdicts(limit: int = 50) -> list[dict]:
+    limit = max(1, min(int(limit), 500))
+    data = _get_json(f"/verdicts?limit={limit}")
+    return data if isinstance(data, list) else []
+
+
+def fetch_detections(mac_hash: str, limit: int = 50) -> list[dict]:
+    if not mac_hash or not re.fullmatch(r"[0-9a-fA-F]{1,64}", mac_hash):
+        return []
+    limit = max(1, min(int(limit), 500))
+    data = _get_json(f"/verdicts?mac={mac_hash}&limit={limit}")
+    return data if isinstance(data, list) else []
+
+
+def disposition(action: str) -> str:
+    """Honest disposition label — an observed/async detection is not a block."""
+    return "Bloquée" if action == "block" else "Détectée — observée"
+
+
+def _is_confirmed_compromise(d: dict) -> bool:
+    cls = str(d.get("class", ""))
+    if cls in _HEURISTIC_CLASSES:
+        return False
+    return (
+        d.get("action") == "block"
+        and int(d.get("confidence", 0)) >= _HIGH_CONFIDENCE
+    )
+
+
+def assess(detections: list[dict]) -> dict:
+    """Compromise/evaluation summary over one device's (or the fleet's) detections.
+
+    tier: clean (none) · suspicious (report-only/heuristic) · compromised
+    (a high-confidence, non-heuristic, block-action detection).
+    """
+    dets = detections or []
+    if not dets:
+        return {"tier": "clean", "worst_severity": 0, "worst_confidence": 0,
+                "count": 0, "dominant_class": "", "strongest": None}
+    strongest = max(dets, key=lambda d: (int(d.get("severity", 0)),
+                                          int(d.get("confidence", 0))))
+    tier = "compromised" if any(_is_confirmed_compromise(d) for d in dets) else "suspicious"
+    classes = Counter(str(d.get("class", "")) for d in dets if d.get("class"))
+    dominant = classes.most_common(1)[0][0] if classes else ""
+    return {
+        "tier": tier,
+        "worst_severity": max(int(d.get("severity", 0)) for d in dets),
+        "worst_confidence": max(int(d.get("confidence", 0)) for d in dets),
+        "count": len(dets),
+        "dominant_class": dominant,
+        "strongest": strongest,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=../../common:. python3 -m pytest tests/test_sentinel_link.py -q`
+Expected: PASS — all 8 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/secubox-toolbox/secubox_toolbox/sentinel_link.py packages/secubox-toolbox/tests/test_sentinel_link.py
+git commit -m "feat(toolbox): sentinel_link — fail-safe daemon fetch + compromise assess (ref #823)"
+```
+
+---
+
+### Task 3: Portal admin proxy routes (fleet)
+
+**Files:**
+- Modify: `packages/secubox-toolbox/secubox_toolbox/api.py` (add two routes on the existing `router`)
+- Test: `packages/secubox-toolbox/tests/test_sentinel_api.py`
+
+**Interfaces:**
+- Consumes: `sentinel_link.fetch_stats()`, `sentinel_link.fetch_verdicts(limit)`, `sentinel_link.assess(...)`.
+- Produces: `GET /admin/sentinel/stats` → `{"active":bool,"detections":int,"blocked":int,"spyware":int}`; `GET /admin/sentinel/verdicts?limit=N` → `{"active":bool,"assess":{…},"detections":[…]}`. Both HTTP 200 even when the daemon is dark. Placed under `/admin/` so they inherit the portal's existing admin gating (like the other `/admin/*` routes, which carry no per-route `Depends`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/secubox-toolbox/tests/test_sentinel_api.py`:
+
+```python
+from fastapi.testclient import TestClient
+from secubox_toolbox.app import app
+from secubox_toolbox import sentinel_link as sl
+
+client = TestClient(app)
+
+
+def test_stats_active_when_daemon_up(monkeypatch):
+    monkeypatch.setattr(sl, "fetch_stats",
+                        lambda: {"detections": 3, "blocked": 1, "spyware": 2})
+    r = client.get("/admin/sentinel/stats")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["active"] is True
+    assert body["detections"] == 3 and body["spyware"] == 2
+
+
+def test_stats_inactive_when_daemon_down(monkeypatch):
+    monkeypatch.setattr(sl, "fetch_stats", lambda: {})
+    r = client.get("/admin/sentinel/stats")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["active"] is False
+    assert body["detections"] == 0 and body["blocked"] == 0 and body["spyware"] == 0
+
+
+def test_verdicts_shape_and_failsafe(monkeypatch):
+    monkeypatch.setattr(sl, "fetch_verdicts", lambda limit=50: [
+        {"class": "spyware_pegasus", "severity": 95, "confidence": 95,
+         "action": "report", "evidence": {}, "mac_hash": "aa", "ts": 1, "report": "R"},
+    ])
+    r = client.get("/admin/sentinel/verdicts")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["active"] is True
+    assert body["assess"]["tier"] == "suspicious"
+    assert len(body["detections"]) == 1
+
+    monkeypatch.setattr(sl, "fetch_verdicts", lambda limit=50: [])
+    r = client.get("/admin/sentinel/verdicts")
+    assert r.status_code == 200
+    assert r.json()["active"] is False
+    assert r.json()["assess"]["tier"] == "clean"
+```
+
+> If `TestClient(app)` requires auth and returns 401 for `/admin/*` in tests, check how the existing `tests/test_admin_*.py` construct the client (they may use a fixture or a test app without the gate). Mirror that exact setup — do not weaken the gate to make the test pass.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=../../common:. python3 -m pytest tests/test_sentinel_api.py -q`
+Expected: FAIL — routes return 404 (not yet defined).
+
+- [ ] **Step 3: Implement the two routes**
+
+In `packages/secubox-toolbox/secubox_toolbox/api.py`, add near the other `/admin/*` GET routes (e.g. after the `/admin/tor/*` block). First ensure the import exists at the top of the file with the other `from secubox_toolbox import …`:
+
+```python
+from secubox_toolbox import sentinel_link
+```
+
+Then add:
+
+```python
+@router.get("/admin/sentinel/stats")
+async def admin_sentinel_stats() -> dict:
+    """Fleet Sentinel counters for the WebUI tab. Fail-safe: a dark daemon
+    yields active=false with zeroed counters (HTTP 200), never a 5xx."""
+    stats = sentinel_link.fetch_stats()
+    if not stats:
+        return {"active": False, "detections": 0, "blocked": 0, "spyware": 0}
+    return {
+        "active": True,
+        "detections": int(stats.get("detections", 0)),
+        "blocked": int(stats.get("blocked", 0)),
+        "spyware": int(stats.get("spyware", 0)),
+    }
+
+
+@router.get("/admin/sentinel/verdicts")
+async def admin_sentinel_verdicts(limit: int = 50) -> dict:
+    """Recent fleet detections + the compromise assessment for the WebUI tab."""
+    dets = sentinel_link.fetch_verdicts(limit)
+    return {
+        "active": bool(dets),
+        "assess": sentinel_link.assess(dets),
+        "detections": dets,
+    }
+```
+
+> `limit` is a plain query int — FastAPI parses `?limit=`. `fetch_verdicts` already clamps it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=../../common:. python3 -m pytest tests/test_sentinel_api.py -q`
+Expected: PASS — 3 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/secubox-toolbox/secubox_toolbox/api.py packages/secubox-toolbox/tests/test_sentinel_api.py
+git commit -m "feat(toolbox): /admin/sentinel/{stats,verdicts} fleet proxy routes (ref #823)"
+```
+
+---
+
+### Task 4: WebUI ToolBoX Sentinel tab (fleet)
+
+**Files:**
+- Modify: `packages/secubox-toolbox/www/toolbox/index.html` (nav button, panel section, `switchTab` hook, `loadSentinel()` JS)
+
+**Interfaces:**
+- Consumes: `GET /admin/sentinel/stats` and `GET /admin/sentinel/verdicts` (Task 3); the existing `J(path)` fetch helper (returns parsed JSON or `{__error}`); the existing `switchTab(name)` function; `.tabs`/`.panel` CSS classes.
+- Produces: a `data-tab="sentinel"` tab.
+
+- [ ] **Step 1: Add the nav button**
+
+In `www/toolbox/index.html`, in `<nav class="tabs" id="tabs">`, insert between the `tor` and `config` buttons:
+
+```html
+        <button class="tab" data-tab="sentinel" onclick="switchTab('sentinel')">🛡️ Sentinelle</button>
+```
+
+- [ ] **Step 2: Add the panel section**
+
+After the `tor` panel `</section>` (and before the `config` panel), insert:
+
+```html
+    <section class="panel" id="panel-sentinel">
+        <div class="row" style="margin-bottom:.6rem">
+            <button onclick="loadSentinel()">🔁 Refresh</button>
+            <span id="sentinel-state" class="v" style="margin-left:.5rem">…</span>
+        </div>
+        <div id="sentinel-verdict" class="card" style="margin-bottom:.8rem"></div>
+        <div id="sentinel-detections"></div>
+    </section>
+```
+
+> Use whatever the file's existing panels use for a wrapper (`class="card"`/`class="row"`); match the surrounding markup exactly. If those classes differ, copy the tor panel's structure and swap the ids.
+
+- [ ] **Step 3: Hook lazy-load into `switchTab`**
+
+In the `switchTab(name)` function, add alongside the other lazy-loads:
+
+```javascript
+    if (name === 'sentinel') loadSentinel();
+```
+
+- [ ] **Step 4: Add `loadSentinel()`**
+
+Near the other `load*()` functions, add:
+
+```javascript
+const SENTINEL_TIER = {
+    clean:        { emoji: '🟢', label: 'Aucune compromission détectée', color: 'var(--green,#2a9d3a)' },
+    suspicious:   { emoji: '🟠', label: 'Activité suspecte',              color: 'var(--amber,#c77d00)' },
+    compromised:  { emoji: '🔴', label: 'Compromission confirmée',        color: 'var(--red,#e63946)' },
+};
+
+function sentinelDisposition(action) {
+    return action === 'block' ? 'Bloquée' : 'Détectée — observée';
+}
+
+function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"]/g, c =>
+        ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+}
+
+async function loadSentinel() {
+    const stateEl = document.getElementById('sentinel-state');
+    const vEl = document.getElementById('sentinel-verdict');
+    const dEl = document.getElementById('sentinel-detections');
+    const stats = await J('/admin/sentinel/stats');
+    const data = await J('/admin/sentinel/verdicts');
+
+    if (stats.__error || data.__error || !data.active) {
+        stateEl.textContent = '⚪ Sentinelle inactive';
+        vEl.innerHTML = '<span class="v">Sentinelle inactive — aucune donnée de détection réseau.</span>';
+        dEl.innerHTML = '';
+        return;
+    }
+
+    stateEl.textContent = `🟢 active · ${stats.detections || 0} détections · ${stats.blocked || 0} bloquées · ${stats.spyware || 0} spyware`;
+
+    const a = data.assess || { tier: 'clean' };
+    const t = SENTINEL_TIER[a.tier] || SENTINEL_TIER.clean;
+    vEl.innerHTML =
+        `<div style="font-size:1.1rem;color:${t.color}">${t.emoji} ${esc(t.label)}</div>` +
+        `<div class="v" style="margin-top:.4rem">Sévérité max ${a.worst_severity || 0}/100 · ` +
+        `Confiance ${a.worst_confidence || 0}/100 · ${a.count || 0} détections · ` +
+        `${esc(a.dominant_class || '—')}</div>`;
+
+    const rows = (data.detections || []).map(d => {
+        const when = d.ts ? new Date(d.ts * 1000).toISOString().replace('T', ' ').slice(0, 19) : '?';
+        return `<tr>
+            <td>${esc(d.class)}</td>
+            <td>${d.severity || 0}/${d.confidence || 0}</td>
+            <td>${esc(sentinelDisposition(d.action))}</td>
+            <td>${when}</td>
+            <td><details><summary>rapport</summary><pre style="white-space:pre-wrap;font-size:.75rem">${esc(d.report)}</pre></details></td>
+        </tr>`;
+    }).join('');
+    dEl.innerHTML = rows
+        ? `<table><thead><tr><th>Menace</th><th>Sév/Conf</th><th>Disposition</th><th>Vu</th><th>Détail</th></tr></thead><tbody>${rows}</tbody></table>`
+        : '<span class="v">Aucune détection récente.</span>';
+}
+```
+
+- [ ] **Step 5: Verify the inline JS parses**
+
+Extract the inline `<script>` block and syntax-check:
+
+Run:
+```bash
+cd packages/secubox-toolbox && python3 - <<'PY'
+import re, subprocess, tempfile, os
+html = open("www/toolbox/index.html", encoding="utf-8").read()
+scripts = re.findall(r"<script>(.*?)</script>", html, re.S)
+src = "\n".join(scripts)
+p = tempfile.NamedTemporaryFile("w", suffix=".js", delete=False)
+p.write(src); p.close()
+print(subprocess.run(["node", "--check", p.name]).returncode)
+os.unlink(p.name)
+PY
+```
+Expected: prints `0` (no syntax errors). If `node` is unavailable, load the page in a browser against a running portal and confirm the Sentinelle tab renders without console errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/secubox-toolbox/www/toolbox/index.html
+git commit -m "feat(toolbox): WebUI Sentinelle fleet tab (evaluation + detections) (ref #823)"
+```
+
+---
+
+### Task 5: Fold Sentinel into `build_report_data` (per-device data path)
+
+**Files:**
+- Modify: `packages/secubox-toolbox/secubox_toolbox/reports.py` (`build_report_data`, ~line 60)
+- Test: `packages/secubox-toolbox/tests/test_report_sentinel.py`
+
+**Interfaces:**
+- Consumes: `sentinel_link.fetch_detections(mac_hash)`, `sentinel_link.assess(...)`.
+- Produces: `report["sentinel"] = {"active": bool, "assess": {…}, "detections": [ … ]}` — consumed by Task 6 (HTML) and Task 7 (PDF).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/secubox-toolbox/tests/test_report_sentinel.py`:
+
+```python
+from secubox_toolbox import reports
+from secubox_toolbox import sentinel_link as sl
+
+
+def test_build_report_data_folds_sentinel_active(monkeypatch):
+    monkeypatch.setattr(sl, "fetch_detections", lambda mh, limit=50: [
+        {"class": "spyware_pegasus", "severity": 95, "confidence": 95,
+         "action": "report", "evidence": {}, "mac_hash": "aa", "ts": 1, "report": "R"},
+    ])
+    rep = reports.build_report_data("aa", {"device_type": "phone"})
+    assert rep["sentinel"]["active"] is True
+    assert rep["sentinel"]["assess"]["tier"] == "suspicious"
+    assert len(rep["sentinel"]["detections"]) == 1
+
+
+def test_build_report_data_sentinel_inactive_when_daemon_down(monkeypatch):
+    monkeypatch.setattr(sl, "fetch_detections", lambda mh, limit=50: [])
+    rep = reports.build_report_data("aa", {})
+    assert rep["sentinel"]["active"] is False
+    assert rep["sentinel"]["assess"]["tier"] == "clean"
+    assert rep["sentinel"]["detections"] == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=../../common:. python3 -m pytest tests/test_report_sentinel.py -q`
+Expected: FAIL — `KeyError: 'sentinel'`.
+
+- [ ] **Step 3: Fold the `sentinel` key into `build_report_data`**
+
+At the top of `reports.py`, add with the other imports:
+
+```python
+from secubox_toolbox import sentinel_link
+```
+
+Rewrite `build_report_data` to build the base dict then attach `sentinel`:
+
+```python
+def build_report_data(mac_hash: str, session_data: dict) -> dict:
+    """Aggregate session data into the structure consumed by render_pdf().
+    session_data is expected to be the dict produced by api._aggregate_session()."""
+    report = {
+        "mac_hash": mac_hash,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        **session_data,
+    }
+    detections = sentinel_link.fetch_detections(mac_hash)
+    report["sentinel"] = {
+        "active": bool(detections),
+        "assess": sentinel_link.assess(detections),
+        "detections": detections,
+    }
+    return report
+```
+
+> `fetch_detections` is fully fail-safe (dark daemon → `[]`), so `active` is `False` and the report still builds. This means "no detections" and "daemon dark" both render as the calm inactive/clean state — acceptable and safe (the surfaces don't over-claim either way).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=../../common:. python3 -m pytest tests/test_report_sentinel.py -q`
+Expected: PASS — 2 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/secubox-toolbox/secubox_toolbox/reports.py packages/secubox-toolbox/tests/test_report_sentinel.py
+git commit -m "feat(toolbox): fold per-device Sentinel detections into build_report_data (ref #823)"
+```
+
+---
+
+### Task 6: kbin HTML report — Sentinel tab (per-device)
+
+**Files:**
+- Modify: `packages/secubox-toolbox/conf/report-live.html.j2` (add a tab in the existing `.tabs`/`.tab-pane` shell)
+
+**Interfaces:**
+- Consumes: the Jinja `report` context, specifically `report.sentinel = {active, assess:{tier,worst_severity,worst_confidence,count,dominant_class}, detections:[{class,severity,confidence,action,ts,report}]}` (Task 5).
+- Produces: a per-device Compromission tab in the report.
+
+- [ ] **Step 1: Locate the tab shell**
+
+Read `conf/report-live.html.j2` around the `<div class="tabs">` (~line 208) and the sibling `.tab-pane` blocks. Note the exact button markup and how a pane is shown/hidden (the file's own `.tabs button` / `.tab-pane.active` convention from #699), and the tab-switch JS already in the file.
+
+- [ ] **Step 2: Add the tab button + pane**
+
+Following the file's existing tab pattern, add a new tab button (label `🛡️ Compromission`) and a matching `.tab-pane`. Use the file's own show/hide mechanism (match how the neighboring panes wire their button → pane). The pane body:
+
+```html
+{# 🛡️ Sentinel — per-device compromise, evaluation, detections (#823) #}
+<div class="tab-pane" id="tab-sentinel">
+  {% set s = report.sentinel or {} %}
+  {% set a = s.assess or {} %}
+  {% if not s.active %}
+    <div class="card"><span style="color:var(--dim)">🛡️ Sentinelle inactive — aucune donnée de détection réseau.</span></div>
+  {% else %}
+    <div class="card">
+      {% set tier = a.tier or 'clean' %}
+      <h3>
+        {% if tier == 'compromised' %}🔴 Compromission confirmée
+        {% elif tier == 'suspicious' %}🟠 Activité suspecte
+        {% else %}🟢 Aucune compromission détectée{% endif %}
+      </h3>
+      <div style="color:var(--dim);font-size:.85rem;margin-top:.3rem">
+        Sévérité max {{ a.worst_severity or 0 }}/100 · Confiance {{ a.worst_confidence or 0 }}/100 ·
+        {{ a.count or 0 }} détection(s) · {{ a.dominant_class or '—' }}
+      </div>
+    </div>
+    <div class="card">
+      <h3>Détections</h3>
+      {% if s.detections %}
+      <table>
+        <thead><tr><th>Menace</th><th>Sév/Conf</th><th>Disposition</th><th>Vu</th></tr></thead>
+        <tbody>
+        {% for d in s.detections %}
+          <tr>
+            <td>{{ d.class }}</td>
+            <td>{{ d.severity or 0 }}/{{ d.confidence or 0 }}</td>
+            <td>{% if d.action == 'block' %}Bloquée{% else %}Détectée — observée{% endif %}</td>
+            <td>{{ d.ts }}</td>
+          </tr>
+          {% if d.report %}
+          <tr><td colspan="4"><details><summary style="cursor:pointer;color:var(--dim)">rapport</summary><pre style="white-space:pre-wrap;font-size:.72rem">{{ d.report }}</pre></details></td></tr>
+          {% endif %}
+        {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <span style="color:var(--dim)">Aucune détection récente sur cet appareil.</span>
+      {% endif %}
+    </div>
+  {% endif %}
+</div>
+```
+
+> Jinja `{{ d.report }}` and `{{ d.class }}` are auto-escaped by the template environment (the file already renders untrusted-ish fields elsewhere the same way — confirm the env has autoescape on for `.html.j2`; if not, wrap with `| e`). Match the file's card/heading classes exactly.
+
+- [ ] **Step 3: Render-smoke the template**
+
+Run:
+```bash
+cd packages/secubox-toolbox && PYTHONPATH=../../common:. python3 - <<'PY'
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+env = Environment(loader=FileSystemLoader("conf"), autoescape=select_autoescape(["html", "j2"]))
+tpl = env.get_template("report-live.html.j2")
+# inactive
+print("inactive ok:", bool(tpl.render(report={"mac_hash": "aa", "sentinel": {"active": False, "assess": {}, "detections": []}})))
+# with a detection
+print("active ok:", bool(tpl.render(report={"mac_hash": "aa", "sentinel": {
+    "active": True,
+    "assess": {"tier": "suspicious", "worst_severity": 95, "worst_confidence": 95, "count": 1, "dominant_class": "spyware_pegasus"},
+    "detections": [{"class": "spyware_pegasus", "severity": 95, "confidence": 95, "action": "report", "ts": 1, "report": "R"}],
+}})))
+PY
+```
+Expected: prints `inactive ok: True` and `active ok: True` with no Jinja exception.
+
+> If the template requires many other context keys to render (it aggregates a full report), pass a minimal stub for those it references, OR render only by loading and checking `env.get_template(...).render(...)` doesn't raise on the `report.sentinel` access path. If full render needs too much scaffolding, at minimum assert the template *compiles* with `env.get_template("report-live.html.j2")` and visually confirm the added block against the file's tab pattern.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/secubox-toolbox/conf/report-live.html.j2
+git commit -m "feat(toolbox): kbin report per-device Compromission tab (ref #823)"
+```
+
+---
+
+### Task 7: PDF report — Sentinel section (per-device)
+
+**Files:**
+- Modify: `packages/secubox-toolbox/secubox_toolbox/reports.py` (`render_pdf`, add a section near the "🚨 ANALYSE COMPROMISSION" block ~line 170; `_render_text_fallback` ~line 1095)
+- Test: `packages/secubox-toolbox/tests/test_report_sentinel_pdf.py`
+
+**Interfaces:**
+- Consumes: `report["sentinel"]` (Task 5); the existing `_section(pdf, title)` and `_kv(pdf, key, value)` helpers.
+- Produces: a "🛡️ SENTINELLE" section in the rendered PDF bytes.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/secubox-toolbox/tests/test_report_sentinel_pdf.py`:
+
+```python
+from secubox_toolbox import reports
+
+
+def _report(sentinel):
+    return {"mac_hash": "aa", "generated_at": "2026-07-06T00:00:00Z",
+            "device_type": "phone", "sentinel": sentinel}
+
+
+def test_pdf_renders_with_sentinel_detection():
+    rep = _report({
+        "active": True,
+        "assess": {"tier": "compromised", "worst_severity": 95, "worst_confidence": 95,
+                   "count": 1, "dominant_class": "spyware_pegasus",
+                   "strongest": {"class": "spyware_pegasus"}},
+        "detections": [{"class": "spyware_pegasus", "severity": 95, "confidence": 95,
+                        "action": "block", "evidence": {"source": "amnesty-mvt"},
+                        "mac_hash": "aa", "ts": 1, "report": "R"}],
+    })
+    out = reports.render_pdf(rep)
+    assert isinstance(out, (bytes, bytearray)) and len(out) > 500
+
+
+def test_pdf_renders_with_sentinel_inactive():
+    rep = _report({"active": False, "assess": {"tier": "clean"}, "detections": []})
+    out = reports.render_pdf(rep)
+    assert isinstance(out, (bytes, bytearray)) and len(out) > 500
+
+
+def test_pdf_renders_when_sentinel_key_absent():
+    rep = {"mac_hash": "aa", "generated_at": "2026-07-06T00:00:00Z", "device_type": "phone"}
+    out = reports.render_pdf(rep)  # must not KeyError
+    assert isinstance(out, (bytes, bytearray)) and len(out) > 500
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=../../common:. python3 -m pytest tests/test_report_sentinel_pdf.py -q`
+Expected: The two "renders with sentinel" tests may pass structurally (no section yet) but assert nothing about the section; the goal is they stay green after adding the section AND the section actually appears. To make this a true failing test first, add a content assertion using the text fallback path (Step 3 also touches `_render_text_fallback`):
+
+Append to the test file:
+
+```python
+def test_text_fallback_includes_sentinel_line():
+    rep = _report({
+        "active": True,
+        "assess": {"tier": "compromised", "worst_severity": 95, "worst_confidence": 95,
+                   "count": 1, "dominant_class": "spyware_pegasus", "strongest": None},
+        "detections": [{"class": "spyware_pegasus", "severity": 95, "confidence": 95,
+                        "action": "block", "evidence": {}, "mac_hash": "aa", "ts": 1, "report": "R"}],
+    })
+    txt = reports._render_text_fallback(rep)
+    assert "SENTINELLE" in txt.upper()
+    assert "spyware_pegasus" in txt
+```
+
+Run the same pytest command. Expected: FAIL — `test_text_fallback_includes_sentinel_line` fails (no Sentinel line in the fallback yet).
+
+- [ ] **Step 3: Add the PDF section + text-fallback line**
+
+In `render_pdf`, immediately after the "🚨 ANALYSE COMPROMISSION" block (the section starting ~line 170), add a helper call. First add a module-level helper (near the other `_section`-using code):
+
+```python
+def _sentinel_section(pdf, report: dict) -> None:
+    """🛡️ Sentinel per-device compromise + detections (#823). Safe when the
+    key is absent or the daemon was dark — renders an 'inactive' line, never
+    raises."""
+    sen = report.get("sentinel") or {}
+    _section(pdf, "🛡️ SENTINELLE - DETECTION DE COMPROMISSION")
+    if not sen.get("active"):
+        _kv(pdf, "Etat", "Sentinelle inactive - aucune detection reseau")
+        return
+    a = sen.get("assess") or {}
+    tier = a.get("tier", "clean")
+    verdict = {"compromised": "COMPROMISSION CONFIRMEE",
+               "suspicious": "ACTIVITE SUSPECTE",
+               "clean": "Aucune compromission detectee"}.get(tier, "?")
+    _kv(pdf, "Verdict", verdict)
+    _kv(pdf, "Severite max", f"{a.get('worst_severity', 0)}/100")
+    _kv(pdf, "Confiance", f"{a.get('worst_confidence', 0)}/100")
+    _kv(pdf, "Detections", str(a.get("count", 0)))
+    _kv(pdf, "Classe dominante", a.get("dominant_class") or "-")
+    dets = sen.get("detections") or []
+    if dets:
+        _section(pdf, "SENTINELLE - DETECTIONS")
+        for d in dets[:20]:
+            disp = "Bloquee" if d.get("action") == "block" else "Detectee - observee"
+            _kv(pdf, d.get("class", "?"),
+                f"sev {d.get('severity', 0)}/conf {d.get('confidence', 0)} - {disp}")
+```
+
+Then call it in `render_pdf` right after the ANALYSE COMPROMISSION section renders:
+
+```python
+    _sentinel_section(pdf, report)
+```
+
+In `_render_text_fallback`, add near its compromise output:
+
+```python
+    sen = report.get("sentinel") or {}
+    lines.append("")
+    lines.append("SENTINELLE - DETECTION DE COMPROMISSION")
+    if not sen.get("active"):
+        lines.append("  Sentinelle inactive - aucune detection reseau")
+    else:
+        a = sen.get("assess") or {}
+        lines.append(f"  Verdict: {a.get('tier', 'clean')} "
+                     f"(sev {a.get('worst_severity', 0)}/conf {a.get('worst_confidence', 0)}, "
+                     f"{a.get('count', 0)} detection(s))")
+        for d in (sen.get("detections") or [])[:20]:
+            disp = "Bloquee" if d.get("action") == "block" else "Detectee"
+            lines.append(f"  - {d.get('class', '?')}: sev {d.get('severity', 0)} [{disp}]")
+```
+
+> Match the fallback's actual accumulator variable name (it may be `lines`, `out`, or built via `"\n".join(...)`) — read `_render_text_fallback` first and append using its own idiom. The ASCII-only wording (no accents) mirrors the fallback's Helvetica/latin-1 safety.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=../../common:. python3 -m pytest tests/test_report_sentinel_pdf.py -q`
+Expected: PASS — all four tests green (PDF renders in all three sentinel states; text fallback carries the line).
+
+- [ ] **Step 5: Run the full report test module to confirm no regression**
+
+Run: `cd packages/secubox-toolbox && PYTHONPATH=../../common:. python3 -m pytest tests/ -q -k "report or sentinel"`
+Expected: PASS — existing report tests still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/secubox-toolbox/secubox_toolbox/reports.py packages/secubox-toolbox/tests/test_report_sentinel_pdf.py
+git commit -m "feat(toolbox): PDF + text-fallback Sentinel compromise section (ref #823)"
+```
+
+---
+
+### Task 8: GPT demo prompt doc
+
+**Files:**
+- Create: `docs/demos/2026-07-06-kbin-sentinel-augmentation-prompt.md`
+
+**Interfaces:** none (documentation artifact).
+
+- [ ] **Step 1: Write the demo prompt**
+
+Create `docs/demos/2026-07-06-kbin-sentinel-augmentation-prompt.md` describing the kbin's new capability group and a ready-to-paste GPT prompt. Content:
+
+```markdown
+# Demo Prompt — kbin ToolBoX × Sentinel Augmentation (#823)
+
+## What changed
+The SecuBox kbin (ToolBoX) gained an on-network **compromise-detection**
+capability group ("Sentinelle"): the `sbx-sentinel` daemon inspects mirrored
+tunnel traffic against commercial-spyware / exploit / botnet IOC packs (Pegasus,
+Predator/Intellexa, plus live abuse.ch + MVT/Citizen-Lab feeds) and records
+per-device verdicts. Findings now surface in three places:
+- **Admin WebUI** — a fleet "🛡️ Sentinelle" tab (all recent detections +
+  compromise evaluation).
+- **kbin "mon rapport"** — a per-device Compromission tab.
+- **PDF report** — a per-device Sentinelle section.
+
+All findings are report-only and carry an anonymous `mac_hash` only. Heuristic
+and zero-click signals are shown as "suspect", never as a confirmed compromise.
+
+## GPT prompt (paste into a model)
+
+> You are presenting SecuBox, a Debian-based home/SMB security gateway. It just
+> shipped a new capability group called **Sentinelle**: while a device browses
+> through the SecuBox tunnel, the box inspects the traffic against threat-intel
+> indicators for commercial spyware (Pegasus, Predator/Intellexa), exploits, and
+> botnets, and produces a per-device **compromise assessment** (clean / suspect /
+> compromised) plus a detection list. It surfaces this to the admin as a fleet
+> dashboard tab, to each user in their personal "mon rapport", and in a printable
+> PDF — all keyed on an anonymous session hash, no personal data.
+>
+> Write a short, punchy narrative (max 250 words) for a security-savvy audience
+> that (a) explains why on-network compromise detection at the gateway is a
+> meaningful augmentation over endpoint-only tools, (b) walks through what a user
+> sees when their phone contacts a known Pegasus C2, and (c) is honest that the
+> system is detection/reporting, not blocking, and that heuristic signals are
+> flagged as suspicion rather than proof. Avoid hype; be technically credible.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/demos/2026-07-06-kbin-sentinel-augmentation-prompt.md
+git commit -m "docs: GPT demo prompt for kbin Sentinel augmentation (ref #823)"
+```
+
+---
+
+### Task 9: Deploy + activate + live-verify (gk2)
+
+**Files:** none in-repo (ops task). Operates on gk2 (`ssh root@192.168.1.200`).
+
+**Interfaces:** Consumes the branch build of `secubox-toolbox-ng` (`sbx-sentinel` binary, packs, units, `sentinel.env`) and the merged portal changes.
+
+> This task is deployment + functional verification, not TDD. Do it last so the deployed daemon carries the Task 1 `mac` filter and all three surfaces exist to verify against. Follow every gk2 ops rule in Global Constraints.
+
+- [ ] **Step 1: Build the toolbox-ng binaries from the branch**
+
+Run (cgo-free default build):
+```bash
+cd packages/secubox-toolbox-ng && go build -trimpath -ldflags=-s -o /tmp/sbx-sentinel ./cmd/sbx-sentinel
+```
+Expected: builds clean; `/tmp/sbx-sentinel` exists.
+
+- [ ] **Step 2: Stage the daemon + packs + units on gk2**
+
+Copy the binary, `packs/base/*.json`, `debian/sbx-sentinel.service`, `debian/sentinel.env`, and `tmpfiles/zz-secubox-sentinel.conf` to their install paths on gk2 (`/usr/sbin/sbx-sentinel`, `/usr/share/secubox/sentinel/packs/base/`, `/etc/systemd/system/` or the unit path, `/etc/secubox/sentinel.env`, `/usr/lib/tmpfiles.d/`). Prefer building + installing the `.deb` if the branch's `debian/rules` builds cleanly; otherwise stage the files directly. Do NOT create/modify the shared `/run/secubox` or `/var/lib/secubox` parents — let `RuntimeDirectory`/tmpfiles handle them.
+
+- [ ] **Step 3: Configure the status HTTP**
+
+Set in `/etc/secubox/sentinel.env` on gk2:
+```
+SENTINEL_HTTP_ADDR=127.0.0.1:8790
+```
+Leave `SENTINEL_MIRROR_SOCK`, store, and pack dirs at their defaults. Do not open any nft port — this stays localhost.
+
+- [ ] **Step 4: Verify the mirror emit path**
+
+Confirm the running sbxmitm ng-workers emit to `/run/secubox/sentinel-mirror.sock`:
+```bash
+ssh root@192.168.1.200 'ls -la /run/secubox/sentinel-mirror.sock 2>/dev/null; systemctl cat secubox-toolbox-ng-worker@1 | grep -i mirror'
+```
+If the workers lack the mirror hook, rebuild `sbxmitm` from the branch, deploy it, and restart the 4 workers **sequentially with a socket-wait between each** (never all at once). If they already emit, leave the workers untouched.
+
+- [ ] **Step 5: Enable + start the daemon**
+
+```bash
+ssh root@192.168.1.200 'systemctl daemon-reload && systemctl enable --now sbx-sentinel.service && sleep 2 && systemctl is-active sbx-sentinel'
+```
+Expected: `active`.
+
+- [ ] **Step 6: Verify the status HTTP + a live detection**
+
+```bash
+ssh root@192.168.1.200 'curl -s 127.0.0.1:8790/stats; echo; curl -s "127.0.0.1:8790/verdicts?limit=5"'
+```
+Expected: `/stats` returns the counters JSON; `/verdicts` returns an array (possibly empty initially). Then drive a benign flow and a placeholder-IOC flow through the tunnel (reuse the #823 e2e technique — a request to a base-pack placeholder host such as `notif-alert-news.example` via the tunnel) and re-check `/verdicts` shows the recorded spyware verdict.
+
+- [ ] **Step 7: Verify all three surfaces against the live daemon**
+
+- WebUI: open the ToolBoX admin portal, click the 🛡️ Sentinelle tab — confirm the evaluation banner + detections table populate (and show "inactive" cleanly if the daemon is stopped).
+- kbin report: open a device's "mon rapport", confirm the Compromission tab shows that device's detections.
+- PDF: generate the PDF report for that device, confirm the Sentinelle section is present.
+Confirm daemon RSS is bounded (`systemctl status sbx-sentinel`) and the portal + aggregator are unaffected (no board-wide latency).
+
+- [ ] **Step 8: Record activation state**
+
+Note the deployed daemon version, `SENTINEL_HTTP_ADDR`, and whether workers were redeployed in the PR description / issue comment on #823. No repo commit for this task (config lives on the board).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Part 1 (activation) → Task 9. ✓
+- Part 2 (Go `/verdicts?mac=`) → Task 1. ✓
+- Part 3 (`sentinel_link.py` fetch + assess) → Task 2. ✓
+- Part 4 (WebUI fleet tab: proxy + tab) → Tasks 3 + 4. ✓
+- Part 5 (kbin HTML per-device tab) → Tasks 5 (data) + 6 (template). ✓
+- Part 6 (PDF section) → Tasks 5 (data) + 7 (render). ✓
+- Part 7 (GPT demo prompt) → Task 8. ✓
+- Global constraints (report-only, mac_hash-only, fail-safe, no waf_bypass, honest disposition, localhost HTTP, no new dep) → encoded in Global Constraints + enforced per task (assess never escalates heuristic/zero-click; fetch fail-safe; urllib stdlib; `/admin/` gating). ✓
+
+**Placeholder scan:** No TBD/TODO; every code step carries full code. The two "match the file's existing pattern" notes (Task 4 panel markup, Task 6 tab shell, Task 7 fallback accumulator) are grounded reads of specific existing conventions, not vague hand-waves — each names the exact structure to mirror.
+
+**Type consistency:** `assess()` return keys (`tier`, `worst_severity`, `worst_confidence`, `count`, `dominant_class`, `strongest`) are used identically in Tasks 4 (JS reads `worst_severity`/`worst_confidence`/`count`/`dominant_class`), 6 (Jinja reads same), 7 (PDF reads same). `report["sentinel"]` shape (`active`/`assess`/`detections`) consistent across Tasks 5→6→7. `disposition` logic (`block`→"Bloquée") duplicated as literals in JS (Task 4) and Jinja (Task 6) and PDF (Task 7) because they're separate runtimes — intentional, not a drift. Route paths `/admin/sentinel/{stats,verdicts}` consistent between Task 3 (define) and Task 4 (consume).

--- a/docs/superpowers/specs/2026-07-06-sentinel-activation-toolbox-tab-design.md
+++ b/docs/superpowers/specs/2026-07-06-sentinel-activation-toolbox-tab-design.md
@@ -1,0 +1,273 @@
+# Sentinel Activation + ToolBoX Surfaces (WebUI tab · kbin report · PDF) — Design
+
+**Date:** 2026-07-06
+**Related:** #823 (sbxmitm Sentinel engine, merged dark via #824)
+**Status:** Design — pending user review
+
+---
+
+## Goal
+
+Bring the `sbx-sentinel` compromise-detection daemon **live** and surface its
+findings on every place the ToolBoX user/admin looks at their security, then
+produce a demo artifact.
+
+1. **Activate Sentinel** on gk2 — async / report-only / defensive. Currently
+   dark: no binary deployed, units installed `--no-enable --no-start`,
+   `SENTINEL_HTTP_ADDR` empty. Run the daemon consuming the sbxmitm mirror
+   channel, with a localhost status HTTP.
+2. **Three surfaces** for the detections:
+   - **A. WebUI ToolBoX tab** — a fleet view (all recent detections) in the
+     admin portal (`www/toolbox/index.html`, sub-tab nav #513, `:8088`).
+   - **B. kbin report HTML tab** — a per-device tab in the ephemeral "mon
+     rapport" (`conf/report-live.html.j2`), keyed on the report's `mac_hash`.
+   - **C. PDF report section** — a Sentinel section in `render_pdf`
+     (`reports.py`), same per-device data.
+3. **Test + use** the daemon end-to-end (placeholder-IOC flow → verdict →
+   visible on all three surfaces).
+4. **Demo prompt** — after it works, produce a GPT prompt (doc artifact)
+   demonstrating the kbin's augmentation by this new Sentinel function group.
+
+Non-goal: enabling the inline hot-path *blocking* gate. Sentinel stays
+report-only (heuristic/zero-click never auto-block; `FinalizeAction`
+threshold 85). All surfaces carry `mac_hash` only — no other PII.
+
+---
+
+## Background — what already exists
+
+- **Daemon** `sbx-sentinel` (Go, `packages/secubox-toolbox-ng/cmd/sbx-sentinel`):
+  consumes the mirror channel, runs analyzers (IOC gate / spyware / YARA-stub /
+  behavioral), records verdicts to a bbolt store, exposes a read-only status HTTP:
+  - `GET /stats`    → `{"detections":N,"blocked":N,"spyware":N}`
+  - `GET /verdicts?limit=N` → list of
+    `{class,severity,confidence,action,evidence,mac_hash,ts,report}`
+    (`report` = rendered plain-text threat report; keys lowercase).
+  Bound to `SENTINEL_HTTP_ADDR`; **empty = disabled** (current state).
+  Store already has `Recent(limit)` and `ByMac(macHash, limit)`.
+- **Env** `/etc/secubox/sentinel.env`: `SENTINEL_ENABLED=0`,
+  `SENTINEL_MIRROR_SOCK=/run/secubox/sentinel-mirror.sock`,
+  `SENTINEL_STORE_DB=/var/lib/secubox/sentinel/verdicts.db`,
+  `SENTINEL_HTTP_ADDR=` (empty), pack/overlay dirs, feed URLs.
+- **Units**: `sbx-sentinel.service`, `secubox-sentinel-feeds.{service,timer}` —
+  installed disabled, not started.
+- **Portal** (`secubox-toolbox`, Python/FastAPI, `:8088`):
+  - Tabs in `www/toolbox/index.html`: `<nav class="tabs" id="tabs">` of
+    `<button data-tab="…" onclick="switchTab('…')">` + `<section class="panel"
+    id="panel-…">`. Existing: overview, clients, filtres, social, ads, reseau,
+    tor, config. P31 light skin.
+  - Routes: `APIRouter(tags=["toolbox"])` in `secubox_toolbox/api.py`.
+  - Per-device report: `build_report_data(mac_hash, session_data)` →
+    `render_pdf(report)` (PDF) and `conf/report-live.html.j2` (HTML). The HTML
+    already has a tabbed shell (#699: `.tabs`/`.tab-pane`); the PDF already has
+    `_section` "🚨 ANALYSE COMPROMISSION" and "THREAT INTEL" sections.
+
+Board state (gk2, 2026-07-06): `sbx-sentinel` binary **absent**; portal active;
+ng-workers active. `secubox-sentinelle-gsm.service` is unrelated — out of scope.
+
+---
+
+## Part 1 — Activation (deploy/ops)
+
+**Async, report-only, defensive.** The daemon observes *mirrored* traffic and
+records verdicts; it never sits in the hot path. Inline blocking stays off.
+
+Executed as the plan's first deployment task (gk2, source-first):
+
+1. **Build** `secubox-toolbox-ng` from master (cgo-free default → `sbx-sentinel`
+   + `sbxmitm`, packs, env, units, tmpfiles).
+2. **Deploy** to gk2: `sbx-sentinel` binary (`/usr/sbin/sbx-sentinel`),
+   `packs/base`, `sentinel.env`, units, tmpfiles. Deploy the rebuilt `sbxmitm`
+   worker binary **only if** the running workers lack the mirror-emit hook
+   (verify first; don't churn workers needlessly).
+3. **Configure** `/etc/secubox/sentinel.env`:
+   `SENTINEL_HTTP_ADDR=127.0.0.1:8790` (localhost only — proxied by the portal;
+   no external exposure, no nft opening). Optionally enable the feeds timer for
+   the live-feed overlay.
+4. **Wire the mirror**: confirm sbxmitm ng-workers emit to
+   `/run/secubox/sentinel-mirror.sock`. If a worker redeploy is needed, restart
+   the 4 workers **sequentially with socket-wait** (no mass restart — gk2 rule).
+5. **Enable + start** `sbx-sentinel.service` (single unit). Respect
+   `RuntimeDirectoryPreserve=yes`; never touch shared `/run/secubox` (1777) /
+   `/var/lib/secubox` parents.
+6. **Verify** (functional): `curl 127.0.0.1:8790/stats` + `/verdicts` return;
+   drive benign + placeholder-IOC flows through the tunnel, confirm a verdict is
+   recorded; daemon RSS bounded; portal + aggregator unaffected.
+
+**Reversibility:** `systemctl disable --now sbx-sentinel` + clear
+`SENTINEL_HTTP_ADDR` → dark. All surfaces degrade to "inactive".
+
+---
+
+## Part 2 — Go: per-mac verdict filter (`cmd/sbx-sentinel/http.go`)
+
+The per-device surfaces (B, C) need this device's detections. Add a `mac` query
+param to the existing `/verdicts` handler:
+
+- `GET /verdicts?mac=<hash>&limit=N` → `store.ByMac(mac, limit)` (bounded like
+  today). `mac` absent → unchanged `store.Recent(limit)` (no regression).
+- Same `verdictView` response shape. Fail-safe: bad/empty `mac` → empty list.
+
+Test: `mac=` filters to that hash; `mac` absent behaves as before; unknown mac
+→ `[]`.
+
+---
+
+## Part 3 — Python shared link + assessment (`secubox_toolbox/sentinel_link.py`)
+
+One new module, consumed by all three surfaces. **Never raises** — a dark or
+wedged daemon must never break the portal or a report.
+
+- `daemon_base() -> str|None` — resolve HTTP base from `SENTINEL_HTTP_ADDR`
+  (env / `sentinel.env`), `127.0.0.1:8790` fallback; None if truly unset.
+- `fetch_stats() -> dict` — GET `/stats` (timeout ~1.5s). Fail → `{}`.
+- `fetch_verdicts(limit) -> list[dict]` — GET `/verdicts?limit=` (fleet). Fail → `[]`.
+- `fetch_detections(mac_hash, limit) -> list[dict]` — GET `/verdicts?mac=&limit=`
+  (per-device). Fail → `[]`.
+- `assess(detections) -> dict` — pure compromise/evaluation summary:
+  - `tier`: `clean` (none) · `suspicious` (report-only / heuristic / zero-click)
+    · `compromised` (a high-confidence `block`-action spyware/malware verdict).
+    Heuristic/zero-click **never** escalate to `compromised` (Sentinel invariant).
+  - `worst_severity`, `worst_confidence`, `count`, `dominant_class`,
+    `strongest` (the single highest-severity detection).
+  - `disposition(action)` helper → `block`→"Bloquée", `report`→"Détectée —
+    observée" (honest; no "blocked before any data left" over-claim — folds in
+    #823 blocker #5 at the presentation layer).
+
+---
+
+## Part 4 — Surface A: WebUI ToolBoX tab (fleet)
+
+### 4a. Portal proxy routes (`api.py`), admin-auth like sibling routes
+- `GET /api/v1/sentinel/stats` → `fetch_stats()`; daemon down → HTTP 200
+  `{"active":false,"detections":0,"blocked":0,"spyware":0}`; up →
+  `{"active":true, …}`.
+- `GET /api/v1/sentinel/verdicts?limit=N` → `fetch_verdicts(N)`; fail → `[]`,
+  HTTP 200. Never 5xx on Sentinel state; daemon HTTP stays localhost-only.
+
+### 4b. Tab (`www/toolbox/index.html`), P31 skin, existing `.tabs`/`.panel`
+- Nav: `<button data-tab="sentinel" onclick="switchTab('sentinel')">🛡️
+  Sentinelle</button>` (after "tor", before "config").
+- `<section class="panel" id="panel-sentinel">` + `loadSentinel()` rendering:
+  1. **Évaluation** — banner from `assess().tier`: 🟢 Aucune compromission /
+     🟠 Activité suspecte / 🔴 Compromission confirmée + score row.
+  2. **Détections** — table: class, severity, confidence, disposition, time,
+     expandable `report`.
+  3. **État** — daemon active/dark + `{detections,blocked,spyware}` counters.
+- Lazy fetch on first switch (like other panels).
+- Dark daemon → one calm line "Sentinelle inactive — aucune donnée de détection
+  réseau." (not an error).
+
+---
+
+## Part 5 — Surface B: kbin report HTML tab (per-device)
+
+`build_report_data(mac_hash, session_data)` folds a `sentinel` key:
+`{"active":bool, "assess":assess(detections), "detections":detections}` using
+`fetch_detections(mac_hash)` (fail-safe: absent daemon → `active:false`, empty).
+
+`conf/report-live.html.j2` gains a tab in the existing `.tabs`/`.tab-pane` shell
+(#699): 🛡️ **Compromission** — three cards mirroring Part 4b (Compromission
+banner, Évaluation score, Détections table with expandable report), keyed on the
+report's own device. Dark/empty → calm "Sentinelle inactive" state, never an
+error. Uses the report's arcade-HUD skin already in the file.
+
+---
+
+## Part 6 — Surface C: PDF report section (per-device)
+
+`render_pdf(report)` (`reports.py`) gains a Sentinel section fed by the same
+`report["sentinel"]` key (built in Part 5, so both HTML and PDF share one data
+path). Rendered with the existing `_section`/`_kv` helpers, placed near the
+current "ANALYSE COMPROMISSION" block:
+
+- **🛡️ SENTINELLE — COMPROMISSION** — tier verdict line (clean/suspect/
+  compromised) + `worst_severity`/`worst_confidence`/`count`/`dominant_class`.
+- **DÉTECTIONS** — one row per verdict: class, disposition (honest), time,
+  key evidence. `mac_hash` only.
+- Empty/dark → a single "Sentinelle inactive — aucune détection" line (the PDF
+  must render even with no Sentinel data — text-fallback safe).
+
+---
+
+## Part 7 — Demo prompt (doc artifact, after it works)
+
+Once activation + all three surfaces are verified, write a GPT prompt to
+`docs/demos/2026-07-06-kbin-sentinel-augmentation-prompt.md` that demonstrates
+the kbin's new capability group: the prompt frames the kbin (ToolBoX) as now
+detecting commercial-spyware / exploit / botnet compromise on-network and
+surfacing it per-device (report + PDF) and fleet-wide (portal), and asks the
+model to narrate/showcase the augmentation. Content only — no code.
+
+---
+
+## Data flow
+
+```
+sbxmitm ng-workers ─mirror sock─▶ sbx-sentinel ─▶ bbolt store
+                                       │
+                            /stats  /verdicts[?mac=]  (127.0.0.1:8790)
+                                       │
+   ┌───────────────────────────┬──────┴───────────────┐
+   ▼ portal /api/v1/sentinel/* ▼ build_report_data     ▼ (same key)
+ WebUI tab (fleet)        kbin HTML tab (per-device)  PDF section (per-device)
+```
+
+---
+
+## Error handling
+
+- Daemon unreachable / HTTP disabled → proxy `active:false` + empty (HTTP 200);
+  report surfaces render an "inactive" state. No 5xx, no broken PDF.
+- Malformed JSON → treated as unreachable.
+- Proxy/fetch timeout ~1.5s so a wedged daemon can't stall a portal request or a
+  report build.
+- Auth: proxy routes require the portal's admin auth; report surfaces inherit
+  the report's existing HMAC-token / `mac_hash` scoping (a report only ever
+  shows its own device's detections). No new public surface.
+
+---
+
+## Testing
+
+- **Go**: `/verdicts?mac=` filters to that mac; `mac` absent unchanged; unknown
+  mac → `[]`.
+- **Python** `sentinel_link`: `assess()` tier table (clean / report-only→suspect
+  / block→compromised / heuristic→suspect-never-compromised); `fetch_*` fail-safe
+  (daemon down → `{}`/`[]`, no raise; bad JSON → same); `build_report_data`
+  folds the `sentinel` key (present when up, `active:false` when down).
+- **Python** routes: daemon up (monkeypatched) → 200 data; down → 200
+  inactive/empty; unauth rejected like siblings.
+- **PDF** `render_pdf`: renders a Sentinel section with detections; renders the
+  "inactive" line with no data; text-fallback path safe.
+- **Templates**: `node --check` extracted inline JS (index.html + report-live);
+  panels render clean / detections / inactive states.
+- **Activation (gk2, functional)**: placeholder-IOC flow → verdict visible on
+  all three surfaces; benign ignored; RSS bounded; portal/aggregator unaffected.
+
+---
+
+## Files
+
+- `packages/secubox-toolbox-ng/cmd/sbx-sentinel/http.go` — **modify** (`mac` param).
+- `packages/secubox-toolbox-ng/cmd/sbx-sentinel/http_test.go` — **modify**.
+- `packages/secubox-toolbox/secubox_toolbox/sentinel_link.py` — **create**.
+- `packages/secubox-toolbox/secubox_toolbox/api.py` — **modify** (proxy routes).
+- `packages/secubox-toolbox/secubox_toolbox/reports.py` — **modify**
+  (`build_report_data` folds `sentinel`; `render_pdf` Sentinel section).
+- `packages/secubox-toolbox/www/toolbox/index.html` — **modify** (fleet tab).
+- `packages/secubox-toolbox/conf/report-live.html.j2` — **modify** (per-device tab).
+- `packages/secubox-toolbox/tests/` — **create/modify**.
+- `docs/demos/2026-07-06-kbin-sentinel-augmentation-prompt.md` — **create** (Part 7).
+- `/etc/secubox/sentinel.env` on gk2 — **configure** (`SENTINEL_HTTP_ADDR`);
+  source default stays empty (activation is per-board).
+
+---
+
+## Out of scope (deferred)
+
+- Inline hot-path blocking activation.
+- The Go `RenderReport` daemon-text disposition fix (#823 blocker #5) — the
+  surfaces label disposition honestly at presentation; the daemon-text fix stays
+  tracked on #823.
+- Live-feed timer tuning; YARA cgo build.

--- a/packages/secubox-toolbox-ng/cmd/sbx-sentinel/http.go
+++ b/packages/secubox-toolbox-ng/cmd/sbx-sentinel/http.go
@@ -110,7 +110,15 @@ func newStatusMux(store *sentinel.Store) *http.ServeMux {
 				limit = n
 			}
 		}
-		recent, err := store.Recent(limit)
+		var (
+			recent []sentinel.Verdict
+			err    error
+		)
+		if mac := r.URL.Query().Get("mac"); mac != "" {
+			recent, err = store.ByMac(mac, limit)
+		} else {
+			recent, err = store.Recent(limit)
+		}
 		if err != nil {
 			http.Error(w, "store error", http.StatusInternalServerError)
 			return

--- a/packages/secubox-toolbox-ng/cmd/sbx-sentinel/http_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbx-sentinel/http_test.go
@@ -101,6 +101,49 @@ func TestStatusVerdicts(t *testing.T) {
 	}
 }
 
+func TestVerdictsFilterByMac(t *testing.T) {
+	store := openTestStore(t)
+	store.Record(&sentinel.Verdict{
+		Class: sentinel.ClassSpywarePegasus, Action: sentinel.ActionBlock,
+		Evidence: map[string]string{"ioc_value": "a.example"},
+		MacHash:  "aaaa", TS: time.Now().Unix(),
+	})
+	store.Record(&sentinel.Verdict{
+		Class: sentinel.ClassSpywarePredator, Action: sentinel.ActionReport,
+		Evidence: map[string]string{"ioc_value": "b.example"},
+		MacHash:  "bbbb", TS: time.Now().Unix(),
+	})
+	mux := newStatusMux(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/verdicts?mac=aaaa", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var got []verdictView
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 || got[0].MacHash != "aaaa" {
+		t.Fatalf("want 1 verdict for aaaa, got %d: %+v", len(got), got)
+	}
+
+	// Unknown mac → empty list, still 200.
+	req = httptest.NewRequest(http.MethodGet, "/verdicts?mac=zzzz", nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unknown-mac status %d", rec.Code)
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode2: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want 0 for unknown mac, got %d", len(got))
+	}
+}
+
 func TestStatusRejectsNonGet(t *testing.T) {
 	store := openTestStore(t)
 	mux := newStatusMux(store)

--- a/packages/secubox-toolbox/conf/report-live.html.j2
+++ b/packages/secubox-toolbox/conf/report-live.html.j2
@@ -209,6 +209,7 @@ ul{list-style:none;padding-left:.2rem}li{padding:.12rem 0;font-size:.82rem}li::b
   <button class="active" data-tab="pistage">🍪 Pistage</button>
   <button data-tab="dpi">🛰️ DPI-Exfil</button>
   <button data-tab="overall">🌍 Overall</button>
+  <button data-tab="sentinel">🛡️ Compromission</button>
 </div>
 
 <div class="tab-pane active" id="pane-pistage">
@@ -513,6 +514,48 @@ ul{list-style:none;padding-left:.2rem}li{padding:.12rem 0;font-size:.82rem}li::b
     {% endif %}
   </div>
 </div>{# /pane-overall #}
+
+{# ── COMPROMISSION TAB : per-device Sentinel assessment (#823) ── #}
+<div class="tab-pane" id="pane-sentinel">
+  {% set s = report.sentinel or {} %}
+  {% set a = s.assess or {} %}
+  {% if not s.active %}
+  <div class="card"><span style="color:var(--dim)">🛡️ Sentinelle inactive — aucune donnée de détection réseau.</span></div>
+  {% else %}
+  {% set tier = a.tier or 'clean' %}
+  <div class="card">
+    <h2>
+      {% if tier == 'compromised' %}🔴 Compromission confirmée
+      {% elif tier == 'suspicious' %}🟠 Activité suspecte
+      {% else %}🟢 Aucune compromission détectée{% endif %}
+    </h2>
+    <div style="color:var(--dim);font-size:.85rem;margin-top:.3rem">
+      Sévérité max {{ a.worst_severity or 0 }}/100 · Confiance {{ a.worst_confidence or 0 }}/100 ·
+      {{ a.count or 0 }} détection(s) · {{ a.dominant_class or '—' }}
+    </div>
+  </div>
+  <div class="card">
+    <h2>Détections</h2>
+    {% if s.detections %}
+    <table><thead><tr><th>Menace</th><th>Sév/Conf</th><th>Disposition</th><th>Vu</th></tr></thead><tbody>
+      {% for d in s.detections %}
+      <tr>
+        <td>{{ d.class }}</td>
+        <td>{{ d.severity or 0 }}/{{ d.confidence or 0 }}</td>
+        <td>{% if d.action == 'block' %}Bloquée{% else %}Détectée — observée{% endif %}</td>
+        <td>{{ d.ts }}</td>
+      </tr>
+      {% if d.report %}
+      <tr><td colspan="4"><details><summary style="cursor:pointer;color:var(--dim)">rapport</summary><pre style="white-space:pre-wrap;font-size:.72rem">{{ d.report }}</pre></details></td></tr>
+      {% endif %}
+      {% endfor %}
+    </tbody></table>
+    {% else %}
+    <span style="color:var(--dim)">Aucune détection récente sur cet appareil.</span>
+    {% endif %}
+  </div>
+  {% endif %}
+</div>{# /pane-sentinel #}
 
 <div class="actions">
   <a href="/report/me?mh={{ mac_hash }}">⬇ Télécharger le PDF</a>

--- a/packages/secubox-toolbox/conf/report-live.html.j2
+++ b/packages/secubox-toolbox/conf/report-live.html.j2
@@ -517,7 +517,7 @@ ul{list-style:none;padding-left:.2rem}li{padding:.12rem 0;font-size:.82rem}li::b
 
 {# ── COMPROMISSION TAB : per-device Sentinel assessment (#823) ── #}
 <div class="tab-pane" id="pane-sentinel">
-  {% set s = report.sentinel or {} %}
+  {% set s = (report or {}).sentinel or {} %}
   {% set a = s.assess or {} %}
   {% if not s.active %}
   <div class="card"><span style="color:var(--dim)">🛡️ Sentinelle inactive — aucune donnée de détection réseau.</span></div>

--- a/packages/secubox-toolbox/mitmproxy_addons/inject_banner.py
+++ b/packages/secubox-toolbox/mitmproxy_addons/inject_banner.py
@@ -523,9 +523,10 @@ def _banner_html_dynamic(sha1: str, ctx: dict, csp_strict: bool,
     for _i, _p in enumerate(right_parts):
         _c = _GUIRLANDE[_i % len(_GUIRLANDE)]
         _chips.append(
-            f"<span style=\"background:{_c};color:#0a0a0f;padding:1px 7px;"
-            f"margin:0 2px;border-radius:9px;font-weight:bold;white-space:nowrap;"
-            f"box-shadow:0 0 6px {_c},0 0 2px {_c}\">{_p}</span>")
+            f"<span style=\"flex:0 0 auto;display:inline-flex;align-items:center;"
+            f"background:{_c};color:#0a0a0f;padding:2px 8px;border-radius:999px;"
+            f"font-weight:bold;white-space:nowrap;box-shadow:0 0 7px {_c},"
+            f"inset 0 0 4px rgba(255,255,255,.3)\">{_p}</span>")
     right_text = "".join(_chips)
     grade = ctx["grade"]
     grade_color = ctx["grade_color"]
@@ -534,12 +535,17 @@ def _banner_html_dynamic(sha1: str, ctx: dict, csp_strict: bool,
 
     # ── theme resolution (#545) : R3/R4 neon tube, R2 amber flat ──
     th = _LEVEL_THEME.get(level, _LEVEL_THEME["r2"])
+    # #620 redesign — three-cluster arcade HUD. box-sizing:border-box so the
+    # padding never overflows the viewport width; overflow:hidden clips the
+    # scrolling middle cluster. No justify-content: the middle (flex:1) does the
+    # spacing, keeping the left rank+grade and the right report+close pinned.
     _base = (
         "position:fixed!important;top:0!important;left:0!important;right:0!important;"
         "z-index:2147483647!important;font-family:Menlo,Consolas,monospace!important;"
-        "padding:6px 12px!important;font-size:11px!important;line-height:1.4!important;"
-        "text-align:left!important;display:flex!important;justify-content:space-between!important;"
-        "align-items:center!important;gap:8px!important;"
+        "box-sizing:border-box!important;overflow:hidden!important;"
+        "padding:5px 10px!important;font-size:11px!important;line-height:1.4!important;"
+        "text-align:left!important;display:flex!important;"
+        "align-items:center!important;gap:10px!important;"
     )
     if th["neon"]:
         # glowing glass tube : outer + inset accent glow, neon edge
@@ -564,39 +570,63 @@ def _banner_html_dynamic(sha1: str, ctx: dict, csp_strict: bool,
     link_css = f"color:{th['link']};text-decoration:underline;font-weight:bold"
     title_attr = f" style=\"{title_css}\"" if title_css else ""
 
+    # ── #620 three clusters, shared by both paths ──────────────────────────
+    th_glow = th["glow"] or th["accent"]
+    # LEFT pinned : rank chip (📡 ToolBoX <level>) + grade shield + CA SHA1 proof.
+    # This is the "score" — the tier accent + grade colour drive the whole HUD.
+    left_html = (
+        f"<span style=\"flex:0 0 auto;display:flex;align-items:center;gap:6px\">"
+        f"<span{title_attr} style=\"display:inline-flex;align-items:center;gap:4px;box-sizing:border-box;"
+        f"padding:2px 8px;border-radius:6px;font-weight:800;color:#0a0a0f;background:{th['accent']};"
+        f"box-shadow:0 0 10px {th_glow},inset 0 0 6px rgba(255,255,255,.4)\">"
+        f"{SAT_EMOJI} ToolBoX {level_label}</span>"
+        f"<span title=\"grade\" style=\"display:inline-flex;align-items:center;justify-content:center;"
+        f"min-width:20px;height:20px;box-sizing:border-box;padding:0 4px;font-weight:900;border-radius:5px;"
+        f"color:#0a0a0f;background:{grade_color};box-shadow:0 0 9px {grade_color},inset 0 0 5px rgba(0,0,0,.25)\">{grade}</span>"
+        f"<code style=\"{code_css}\">{sha1[:23]}</code>"
+        f"</span>"
+    )
+    # MIDDLE : scrolling evidence pills — flex:1, min-width:0, overflow-x:auto so
+    # it shrinks/scrolls instead of pushing the report+close cluster off-screen.
+    mid_html = (
+        f"<span style=\"flex:1 1 auto;min-width:0;display:flex;align-items:center;gap:5px;"
+        f"overflow-x:auto;white-space:nowrap\">{right_text}</span>"
+    )
+    # RIGHT : report CTA (both paths) + close ✕ (JS path only). flex:0 0 auto.
+    report_css = (
+        f"flex:0 0 auto;display:inline-flex;align-items:center;gap:4px;text-decoration:none;"
+        f"font-weight:800;white-space:nowrap;color:{th['accent']};border:1px solid {th['accent']};"
+        f"background:rgba(10,10,15,.55);padding:3px 9px;border-radius:6px;box-shadow:0 0 8px {th_glow}"
+    )
+    report_html = f"<a href=\"{report_url}\" style=\"{report_css}\">&#x1F4C4; Mon rapport</a>"
+    close_css = (
+        "flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;"
+        "width:24px;height:24px;box-sizing:border-box;border-radius:6px;cursor:pointer;"
+        f"text-decoration:none;font-weight:900;line-height:1;color:{th['fg']};"
+        f"background:rgba(255,255,255,0.08);border:1px solid {th['accent']}"
+    )
+
     if csp_strict:
-        # JS-less HTML banner — visible only, no close button. !important
-        # everywhere so page CSS can't override the fixed positioning.
+        # JS-less HTML banner — visible only, no close button (non-dismissible).
+        # !important everywhere so page CSS can't override the fixed positioning.
         # NCRs work even when page charset is iso-8859-1.
         html = (
             f"<div id=\"gondwana-mitm-banner\" role=\"status\" style=\"{bar_css}\">"
-            f"<span><b{title_attr}>{SAT_EMOJI} ToolBoX {level_label}</b> &#xB7; CA SHA1: "
-            f"<code style=\"{code_css}\">{sha1[:23]}</code>"
-            f" &#xB7; <a href=\"{report_url}\" style=\"{link_css}\">Mon rapport</a></span>"
-            f"<span style=\"color:#e8e6d9;background:rgba(0,0,0,0.4);padding:3px 8px;border-radius:3px\">"
-            f"{right_text}"
-            f" &#xB7; <b style=\"color:{grade_color};background:#0a0a0f;padding:1px 5px;border-radius:2px\">{grade}</b>"
-            f"</span></div>"
+            + left_html + mid_html
+            + f"<span style=\"flex:0 0 auto;display:flex;align-items:center;gap:8px\">{report_html}</span>"
+            + "</div>"
         )
         return (b"<!-- " + _GUARD + b" -->" + html.encode("ascii"))
 
-    # Interactive JS version. We assemble innerHTML with NCRs already in place
-    # so the resulting DOM text is charset-agnostic.
+    # Interactive JS version. The cluster HTML already carries NCRs; json.dumps
+    # (ensure_ascii=True) escapes any raw non-ASCII (geo flag) so `js.encode("ascii")`
+    # stays valid. The close ✕ lives in the RIGHT pinned cluster (the responsive fix).
     import json as _json
-    right_js = _json.dumps(right_text)             # already NCR-encoded
-    grade_js = _json.dumps(grade)
-    grade_col_js = _json.dumps(grade_color)
-    sha1_js = _json.dumps(sha1[:23])
-    report_js = _json.dumps(report_url)
-    level_js = _json.dumps(level_label)
-    sat_js = _json.dumps(SAT_EMOJI)
-    mid_js = _json.dumps(" &#xB7; ")
-    # theme (#545) — JS-encoded so the same neon/amber styling applies here
     bar_css_js = _json.dumps(bar_css)
-    title_attr_js = _json.dumps(title_attr)
-    code_css_js = _json.dumps(code_css)
-    link_css_js = _json.dumps(link_css)
-    close_col_js = _json.dumps(th["fg"])
+    left_js = _json.dumps(left_html)
+    mid_js = _json.dumps(mid_html)
+    report_js = _json.dumps(report_html)
+    close_css_js = _json.dumps(close_css)
 
     js = f"""
 (function(){{
@@ -608,26 +638,13 @@ def _banner_html_dynamic(sha1: str, ctx: dict, csp_strict: bool,
     b.id='gondwana-mitm-banner';
     b.setAttribute('role','status');
     b.style.cssText={bar_css_js};
-    var rightText={right_js};
-    var grade={grade_js};
-    var gradeCol={grade_col_js};
-    var sha1={sha1_js};
-    var reportUrl={report_js};
-    var level={level_js};
-    var SAT={sat_js};
+    var LEFT={left_js};
     var MID={mid_js};
-    var TITLE_ATTR={title_attr_js};
-    var CODE_CSS={code_css_js};
-    var LINK_CSS={link_css_js};
-    var CLOSE_COL={close_col_js};
-    b.innerHTML='<span><b'+TITLE_ATTR+'>'+SAT+' ToolBoX '+level+'</b>'+MID+'CA SHA1: '+
-      '<code style=\"'+CODE_CSS+'\">'+sha1+'</code>'+
-      MID+'<a href=\"'+reportUrl+'\" style=\"'+LINK_CSS+'\">Mon rapport</a></span>'+
-      '<span style=\"display:flex;align-items:center;gap:8px\">'+
-        '<span style=\"color:#e8e6d9;background:rgba(0,0,0,0.4);padding:3px 8px;border-radius:3px\">'+
-          rightText+MID+'<b style=\"color:'+gradeCol+';background:#0a0a0f;padding:1px 5px;border-radius:2px\">'+grade+'</b>'+
-        '</span>'+
-        '<a href=\"javascript:void(0)\" onclick=\"document.getElementById(\\'gondwana-mitm-banner\\').style.display=\\'none\\';document.body.style.paddingTop=0\" style=\"color:'+CLOSE_COL+';text-decoration:none;font-weight:bold;cursor:pointer\">[&#xD7;]</a>'+
+    var REPORT={report_js};
+    var CLOSE={close_css_js};
+    b.innerHTML=LEFT+MID+
+      '<span style=\"flex:0 0 auto;display:flex;align-items:center;gap:8px\">'+REPORT+
+        '<a href=\"javascript:void(0)\" aria-label=\"dismiss\" onclick=\"document.getElementById(\\'gondwana-mitm-banner\\').style.display=\\'none\\';document.body.style.paddingTop=0\" style=\"'+CLOSE+'\">&#x2715;</a>'+
       '</span>';
     if(document.body.firstChild){{document.body.insertBefore(b,document.body.firstChild)}}
     else{{document.body.appendChild(b)}}

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -3697,9 +3697,9 @@ async def admin_sentinel_stats() -> dict:
         return {"active": False, "detections": 0, "blocked": 0, "spyware": 0}
     return {
         "active": True,
-        "detections": int(stats.get("detections", 0)),
-        "blocked": int(stats.get("blocked", 0)),
-        "spyware": int(stats.get("spyware", 0)),
+        "detections": sentinel_link._safe_int(stats.get("detections", 0)),
+        "blocked": sentinel_link._safe_int(stats.get("blocked", 0)),
+        "spyware": sentinel_link._safe_int(stats.get("spyware", 0)),
     }
 
 

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -2978,6 +2978,10 @@ async def report_me_html(request: Request) -> HTMLResponse:
     cumulative = _cumulative_stats()
     _level = store.get_client_level(mac_hash) if mac_hash else "r1"
     _dpi_e = _dpi_stats(mac_hash)
+    # #823 — fold in the per-device Sentinel compromission assessment (same
+    # data source the PDF routes already use via build_report_data) so the
+    # "🛡️ Compromission" tab (report.sentinel) is fed instead of Undefined.
+    report_data = reports.build_report_data(mac_hash, session)
     html = _env.get_template("report-live.html.j2").render(
         mac_hash=mac_hash, ip=ip,
         request_args=dict(request.query_params),
@@ -2991,6 +2995,7 @@ async def report_me_html(request: Request) -> HTMLResponse:
         persona=_persona_sheet(mac_hash, _level, gs, exposure_score, _dpi_e,
                                session.get("device_type", ""),
                                request.headers.get("user-agent", "")),
+        report=report_data,
         **session,
     )
     return HTMLResponse(html, headers={

--- a/packages/secubox-toolbox/secubox_toolbox/api.py
+++ b/packages/secubox-toolbox/secubox_toolbox/api.py
@@ -78,6 +78,7 @@ from . import (
     nft,
     reports,
     scoring,
+    sentinel_link,
     store,
     threat_intel,
 )
@@ -3685,6 +3686,32 @@ async def admin_tor_check_leaks(request: Request) -> dict:
         result["tor_ip"] = None
         result["error"] = "SOCKS probe failed (python3-socksio installed? tor bootstrapped?)"
     return result
+
+
+@router.get("/admin/sentinel/stats")
+async def admin_sentinel_stats() -> dict:
+    """Fleet Sentinel counters for the WebUI tab. Fail-safe: a dark daemon
+    yields active=false with zeroed counters (HTTP 200), never a 5xx."""
+    stats = sentinel_link.fetch_stats()
+    if not stats:
+        return {"active": False, "detections": 0, "blocked": 0, "spyware": 0}
+    return {
+        "active": True,
+        "detections": int(stats.get("detections", 0)),
+        "blocked": int(stats.get("blocked", 0)),
+        "spyware": int(stats.get("spyware", 0)),
+    }
+
+
+@router.get("/admin/sentinel/verdicts")
+async def admin_sentinel_verdicts(limit: int = 50) -> dict:
+    """Recent fleet detections + the compromise assessment for the WebUI tab."""
+    dets = sentinel_link.fetch_verdicts(limit)
+    return {
+        "active": bool(dets),
+        "assess": sentinel_link.assess(dets),
+        "detections": dets,
+    }
 
 
 @router.get("/admin/filters/ui", response_class=HTMLResponse)

--- a/packages/secubox-toolbox/secubox_toolbox/bundle.py
+++ b/packages/secubox-toolbox/secubox_toolbox/bundle.py
@@ -198,7 +198,7 @@ _BANNER_CORE = r"""
   // and lets the client change it: GET /__toolbox/set-level (same-origin, the Go
   // engine reverse-proxies it to the portal), then reload so the new tier applies.
   // #740 — mk(): build an element via DOM API only. textContent / setAttribute are
-  // NOT Trusted Types sinks (unlike innerHTML), so the banner renders on EVERY site
+  // NOT Trusted Types sinks (unlike a raw-HTML string sink), so the banner renders on EVERY site
   // — incl. strict-CSP/Trusted-Types ones (franceinfo, leparisien, 20minutes, cnn,
   // x/twitter) — with ZERO CSP/TT bypass. This is the robust, permanent fix.
   function mk(tag, opts){
@@ -212,17 +212,38 @@ _BANNER_CORE = r"""
     if (opts.attrs) for (var k in opts.attrs) if (Object.prototype.hasOwnProperty.call(opts.attrs, k)) e.setAttribute(k, opts.attrs[k]);
     return e;
   }
-  var BTN = "border-radius:3px;padding:0 5px;margin:0 2px;font:inherit;font-size:11px;cursor:pointer";
+  var BTN = "border-radius:3px;padding:0 5px;margin:0 1px;font:inherit;font-size:11px;cursor:pointer";
+  // #620 redesign — C3BOX tier palette. The R0..R4 rank IS the score, so its
+  // accent drives the whole arcade HUD (border, glow, rank chip, level switch).
+  // [accent, glow-rgba]. r0 gold, r1 green, r2 amber, r3 cyan, r4 pink.
+  function tierTheme(lvl){
+    var T = {r0:["#c9a84c","rgba(201,168,76,.55)"], r1:["#00ff41","rgba(0,255,65,.45)"],
+             r2:["#ffb347","rgba(255,179,71,.5)"],  r3:["#00d4ff","rgba(0,212,255,.5)"],
+             r4:["#ff3df0","rgba(255,61,240,.5)"]};
+    return T[String(lvl||"r1").toLowerCase()] || T.r1;
+  }
+  // neon evidence pill — reused for the middle-cluster chips + toggles. opts:
+  // {tag,id,text,title,bg,fg,glow,cur,attrs}. Built via mk() (DOM API only).
+  function pill(opts){
+    var st = "flex:0 0 auto;display:inline-flex;align-items:center;gap:4px;white-space:nowrap;"
+      + "box-sizing:border-box;padding:2px 8px;border-radius:999px;font:inherit;font-weight:700;border:0;"
+      + "cursor:" + (opts.cur || "default") + ";color:" + (opts.fg || "#0a0a0f") + ";background:" + opts.bg + ";"
+      + "box-shadow:0 0 7px " + (opts.glow || opts.bg) + ",inset 0 0 4px rgba(255,255,255,.3)";
+    return mk(opts.tag || "span", {id:opts.id, cls:"sbx-pill", text:opts.text, title:opts.title, style:st, attrs:opts.attrs});
+  }
   function lvlSwitch(b){
     var cur = String(b.level || "r1").toLowerCase();
+    var th = tierTheme(cur), acc = th[0], glow = th[1];
     // #736 — R4 = analyst / reverse-catcher tier (deepest): everything MITM'd +
     // media URLs caught for cloning. Reconciled into the #740 DOM-API switch.
     var lv = ["r0","r1","r2","r3","r4"];
-    var span = mk("span", {id:"sbx-lvl", title:"Niveau d'analyse — R4 = analyste/capteur média, clique pour changer"});
+    var span = mk("span", {id:"sbx-lvl", title:"Niveau d'analyse — R4 = analyste/capteur média, clique pour changer",
+      style:"display:inline-flex;align-items:center"});
     for (var i=0;i<lv.length;i++){ var on = lv[i]===cur;
+      // current level = filled tier-accent glowing (the "score"); others = dim outline.
       span.appendChild(mk("button", {cls:"sbx-lvl", text:lv[i].toUpperCase(), attrs:{"data-lvl":lv[i]},
-        style:"background:"+(on?"#148C66":"transparent")+";color:"+(on?"#0A0E14":"#8A9AA8")
-          +";border:1px solid #148C66;"+BTN}));
+        style:"background:"+(on?acc:"transparent")+";color:"+(on?"#0a0a0f":"#8A9AA8")
+          +";border:1px solid "+acc+";"+(on?"box-shadow:0 0 8px "+glow+";":"")+"font-weight:"+(on?"800":"600")+";"+BTN}));
     }
     return span;
   }
@@ -246,34 +267,81 @@ _BANNER_CORE = r"""
     if (document.getElementById("sbx-banner")) return;
     var trk = countTrackers(b.tracker_patterns);
     var ck = countCookies();
+    var th = tierTheme(b.level), acc = th[0], glow = th[1];
     var bar = document.createElement("div");
     bar.id = "sbx-banner";
     // #740 — !important on the visibility-critical props makes the banner IMMUNE
     // to any stylesheet cosmetic hide (inline !important outranks author
     // stylesheet !important): it stays ABOVE everything and visible, always.
+    // #620 redesign — arcade-HUD skin: C3BOX dark ground, tier-accent bottom
+    // edge + glow. box-sizing:border-box so padding never overflows the width.
     bar.setAttribute("style", "position:fixed!important;left:0;right:0;top:0;z-index:2147483647!important;"
       + "display:flex!important;visibility:visible!important;opacity:1!important;"
-      + "font:12px/1.4 system-ui,-apple-system,sans-serif;background:#0A0E14;color:#E8E6E0;"
-      + "border-bottom:2px solid #148C66;padding:6px 12px;gap:14px;align-items:center;"
-      + "box-shadow:0 2px 12px rgba(0,0,0,.4)");
-    // #740 — built entirely with DOM API (no innerHTML → not a Trusted Types
+      + "box-sizing:border-box;align-items:center;gap:10px;overflow:hidden;"
+      + "font:600 11px/1.3 Menlo,Consolas,ui-monospace,monospace;color:#e8e6d9;padding:5px 10px;"
+      + "background:linear-gradient(180deg,rgba(20,20,30,.65),rgba(10,10,15,.96)),#0a0a0f;"
+      + "border-bottom:2px solid " + acc + ";"
+      + "box-shadow:0 0 12px " + glow + ",0 4px 22px rgba(0,0,0,.55),inset 0 -1px 8px " + glow);
+    // #740 — built entirely with DOM API (no raw-HTML string → not a Trusted Types
     // sink), so the banner renders identically on every site, strict-CSP/TT
-    // included, without touching the page's CSP.
-    bar.appendChild(mk("b", {text:"SecuBox", style:"color:#148C66"}));
-    if (csp === "1") bar.appendChild(mk("span", {text:"🔓", title:"CSP contourné par SecuBox (démonstration)"}));
-    bar.appendChild(mk("button", {id:"sbx-tor", text:"🧅 " + (b.tor_mode?"ON":"OFF"),
+    // included, without touching the page's CSP. #620 — three clusters:
+    // LEFT pinned (rank), MIDDLE scrolling evidence, RIGHT pinned (report + ✕).
+    // LEFT — rank chip (brand + tier accent glow) wrapping the R0..R4 switch. Never shrinks.
+    var left = mk("div", {style:"flex:0 0 auto;display:flex;align-items:center;gap:7px"});
+    var rank = mk("span", {style:"display:inline-flex;align-items:center;gap:5px;box-sizing:border-box;"
+      + "padding:2px 8px;border-radius:6px;font-weight:800;color:#0a0a0f;background:" + acc + ";"
+      + "box-shadow:0 0 10px " + glow + ",inset 0 0 6px rgba(255,255,255,.4)"});
+    rank.appendChild(mk("span", {text:"📡"}));
+    rank.appendChild(mk("b", {text:"SecuBox"}));
+    left.appendChild(rank);
+    left.appendChild(lvlSwitch(b));
+    bar.appendChild(left);
+    // MIDDLE — evidence + toggles as neon pills. Grows, shrinks to nothing,
+    // scrolls horizontally (fade mask, hidden scrollbar) instead of pushing the
+    // right cluster off-screen. This is the responsive fix.
+    var mid = mk("div", {style:"flex:1 1 auto;min-width:0;display:flex;align-items:center;gap:6px;"
+      + "overflow-x:auto;scrollbar-width:none;padding:1px 2px;"
+      + "-webkit-mask-image:linear-gradient(90deg,transparent 0,#000 12px,#000 calc(100% - 12px),transparent 100%);"
+      + "mask-image:linear-gradient(90deg,transparent 0,#000 12px,#000 calc(100% - 12px),transparent 100%)"});
+    if (csp === "1") mid.appendChild(pill({text:"🔓", title:"CSP contourné par SecuBox (démonstration)",
+      bg:"#0a0a0f", fg:"#ff3df0", glow:"rgba(255,61,240,.6)"}));
+    var torOn = !!b.tor_mode;
+    mid.appendChild(pill({tag:"button", id:"sbx-tor", cur:"pointer", text:"🧅 Tor " + (torOn?"ON":"OFF"),
       title:"Tor du tunnel toolbox — clique pour basculer",
-      style:"background:"+(b.tor_mode?"#3D2A6B":"transparent")+";color:"+(b.tor_mode?"#C9B8FF":"#8A9AA8")+";border:1px solid #6E40C9;"+BTN}));
-    bar.appendChild(lvlSwitch(b));
-    bar.appendChild(mk("button", {id:"sbx-adg", text:"🛡️ " + (b.ad_guard===false?"OFF":"ON"),
+      bg:(torOn?"#9e76ff":"#0a0a0f"), fg:(torOn?"#0a0a0f":"#8A9AA8"), glow:(torOn?"rgba(158,118,255,.6)":"rgba(158,118,255,.25)")}));
+    var adgOn = b.ad_guard!==false;
+    mid.appendChild(pill({tag:"button", id:"sbx-adg", cur:"pointer", text:"🛡️ Ad-Guard " + (adgOn?"ON":"OFF"),
       title:"Ad-Guard (blocage pub) — clique pour basculer",
-      style:"background:"+(b.ad_guard===false?"transparent":"#148C66")+";color:"+(b.ad_guard===false?"#8A9AA8":"#0A0E14")+";border:1px solid #148C66;"+BTN}));
-    bar.appendChild(mk("span", {id:"sbx-trk", text:"🛰️ " + trk + " trackers"}));
-    bar.appendChild(mk("span", {id:"sbx-ck", text:"🍪 " + ck + " cookies"}));
-    if (b.pin) bar.appendChild(mk("span", {text:"📌 " + b.pin, title:"pinned"}));
-    bar.appendChild(mk("a", {text:"report ▸", style:"margin-left:auto;color:#2C70C0;text-decoration:none", attrs:{href: b.report_url || "#"}}));
-    bar.appendChild(mk("button", {text:"✕", title:"dismiss",
-      style:"background:none;border:0;color:#8A9AA8;cursor:pointer;font-size:14px", attrs:{"aria-label":"dismiss"}}));
+      bg:(adgOn?"#00ff41":"#0a0a0f"), fg:(adgOn?"#0a0a0f":"#8A9AA8"), glow:(adgOn?"rgba(0,255,65,.5)":"rgba(0,255,65,.2)")}));
+    mid.appendChild(pill({id:"sbx-trk", text:"🛰️ " + trk + " trackers", bg:"#00d4ff", glow:"rgba(0,212,255,.5)"}));
+    mid.appendChild(pill({id:"sbx-ck", text:"🍪 " + ck + " cookies", bg:"#c9a84c", glow:"rgba(201,168,76,.5)"}));
+    if (b.pin) mid.appendChild(pill({text:"📌 " + b.pin, title:"pinned", bg:"#ffb347", glow:"rgba(255,179,71,.5)"}));
+    bar.appendChild(mid);
+    // RIGHT — report CTA + dismiss ✕. flex:0 0 auto → the ✕ is ALWAYS on-screen.
+    var right = mk("div", {style:"flex:0 0 auto;display:flex;align-items:center;gap:8px"});
+    right.appendChild(mk("a", {text:"report ▸", attrs:{href: b.report_url || "#"},
+      style:"display:inline-flex;align-items:center;gap:4px;text-decoration:none;font-weight:800;white-space:nowrap;"
+        + "color:#0a0a0f;background:linear-gradient(92deg,#00d4ff,#9e76ff);padding:3px 9px;border-radius:6px;box-shadow:0 0 10px rgba(0,212,255,.45)"}));
+    right.appendChild(mk("button", {text:"✕", title:"dismiss", attrs:{"aria-label":"dismiss"},
+      style:"flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;"
+        + "box-sizing:border-box;border-radius:6px;cursor:pointer;background:rgba(255,255,255,.06);"
+        + "border:1px solid rgba(255,255,255,.14);color:#e8e6d9;font-size:14px;font-weight:900;line-height:1"}));
+    bar.appendChild(right);
+    // #620 — ONE scoped <style> (textContent on <style> is NOT a Trusted-Types
+    // sink) for a sheen sweep + pill hover, ALL selectors scoped under
+    // #sbx-banner and gated on prefers-reduced-motion. Layout NEVER depends on
+    // it: if a site's style-src blocks it, the HUD still renders from the inline
+    // style attributes above and the ✕ stays visible.
+    bar.appendChild(mk("style", {text:
+        "#sbx-banner>div{position:relative;z-index:2}"
+      + "#sbx-banner ::-webkit-scrollbar{width:0;height:0}"
+      + "@media (prefers-reduced-motion:no-preference){"
+      + "#sbx-banner::after{content:'';position:absolute;inset:0;pointer-events:none;mix-blend-mode:screen;"
+      + "background:linear-gradient(105deg,transparent 30%,rgba(255,255,255,.12) 47%,rgba(255,255,255,.24) 50%,rgba(255,255,255,.12) 53%,transparent 70%);"
+      + "transform:translateX(-120%);animation:sbxSheen 5.5s ease-in-out 1.2s infinite}"
+      + "@keyframes sbxSheen{0%{transform:translateX(-120%)}18%,100%{transform:translateX(120%)}}"
+      + "#sbx-banner .sbx-pill{transition:transform .12s ease,box-shadow .12s ease}"
+      + "#sbx-banner .sbx-pill:hover{transform:translateY(-1px) scale(1.06)}}"}));
     document.body.appendChild(bar);
     try { document.body.style.paddingTop = (bar.offsetHeight || 34) + "px"; } catch (_) {}
     wireLevels(bar, b);
@@ -281,13 +349,13 @@ _BANNER_CORE = r"""
     var adg = bar.querySelector("#sbx-adg");
     if (adg) adg.onclick = function(){ var on = b.ad_guard!==false; adg.textContent="…";
       fetch("/__toolbox/set-adguard?on=" + (on?"0":"1"), {credentials:"omit",cache:"no-store"})
-        .then(function(r){ if(r&&r.ok) location.reload(); else adg.textContent="🛡️ "+(on?"ON":"OFF"); })
-        .catch(function(){ adg.textContent="🛡️ "+(on?"ON":"OFF"); }); };
+        .then(function(r){ if(r&&r.ok) location.reload(); else adg.textContent="🛡️ Ad-Guard "+(on?"ON":"OFF"); })
+        .catch(function(){ adg.textContent="🛡️ Ad-Guard "+(on?"ON":"OFF"); }); };
     var tg = bar.querySelector("#sbx-tor");
     if (tg) tg.onclick = function(){ var on = !!b.tor_mode; tg.textContent="…";
       fetch("/__toolbox/set-tor?on=" + (on?"0":"1"), {credentials:"omit",cache:"no-store"})
-        .then(function(r){ if(r&&r.ok) location.reload(); else tg.textContent="🧅 "+(on?"ON":"OFF"); })
-        .catch(function(){ tg.textContent="🧅 "+(on?"ON":"OFF"); }); };
+        .then(function(r){ if(r&&r.ok) location.reload(); else tg.textContent="🧅 Tor "+(on?"ON":"OFF"); })
+        .catch(function(){ tg.textContent="🧅 Tor "+(on?"ON":"OFF"); }); };
     var btn = bar.querySelector("button[aria-label=\"dismiss\"]");
     if (btn) btn.onclick = function(){ dismissed = true; try { document.body.style.paddingTop = ""; } catch (_) {} bar.remove(); };
   }

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -188,6 +188,9 @@ def render_pdf(report: dict) -> bytes:
         _bullet(pdf, sig)
     pdf.ln(2)
 
+    # 🛡️ Sentinel per-device compromise + detections (#823)
+    _sentinel_section(pdf, report)
+
     # Score breakdown — per-category transparency (Phase 2a)
     scoring_data = report.get("scoring") or {}
     breakdown = scoring_data.get("breakdown") or []
@@ -828,6 +831,34 @@ def _kv(pdf, key: str, value: str) -> None:
     pdf.cell(_page_w(pdf) - 45, 5, _ascii_safe(value)[:100], ln=True)
 
 
+def _sentinel_section(pdf, report: dict) -> None:
+    """🛡️ Sentinel per-device compromise + detections (#823). Safe when the
+    key is absent or the daemon was dark — renders an 'inactive' line, never
+    raises."""
+    sen = report.get("sentinel") or {}
+    _section(pdf, "🛡️ SENTINELLE - DETECTION DE COMPROMISSION")
+    if not sen.get("active"):
+        _kv(pdf, "Etat", "Sentinelle inactive - aucune detection reseau")
+        return
+    a = sen.get("assess") or {}
+    tier = a.get("tier", "clean")
+    verdict = {"compromised": "COMPROMISSION CONFIRMEE",
+               "suspicious": "ACTIVITE SUSPECTE",
+               "clean": "Aucune compromission detectee"}.get(tier, "?")
+    _kv(pdf, "Verdict", verdict)
+    _kv(pdf, "Severite max", f"{a.get('worst_severity', 0)}/100")
+    _kv(pdf, "Confiance", f"{a.get('worst_confidence', 0)}/100")
+    _kv(pdf, "Detections", str(a.get("count", 0)))
+    _kv(pdf, "Classe dominante", a.get("dominant_class") or "-")
+    dets = sen.get("detections") or []
+    if dets:
+        _section(pdf, "SENTINELLE - DETECTIONS")
+        for d in dets[:20]:
+            disp = "Bloquee" if d.get("action") == "block" else "Detectee - observee"
+            _kv(pdf, d.get("class", "?"),
+                f"sev {d.get('severity', 0)}/conf {d.get('confidence', 0)} - {disp}")
+
+
 def _bullet(pdf, text: str, font_size: int = 9) -> None:
     """Render a bullet line. multi_cell with hard truncation to avoid fpdf
     'Not enough horizontal space' errors on long tokens/URLs."""
@@ -1112,6 +1143,24 @@ def _render_text_fallback(report: dict) -> str:
         f"Type appareil  : {report.get('device_type', '?')}",
         f"Date           : {report.get('generated_at', '?')}",
         "",
-        "fpdf2 not installed -- text fallback. apt install python3-fpdf2",
     ]
+
+    # 🛡️ SENTINELLE - detection de compromission (#823) — safe when the key
+    # is absent or the daemon was dark: never raises, always a valid line.
+    sen = report.get("sentinel") or {}
+    lines.append("")
+    lines.append("SENTINELLE - DETECTION DE COMPROMISSION")
+    if not sen.get("active"):
+        lines.append("  Sentinelle inactive - aucune detection reseau")
+    else:
+        a = sen.get("assess") or {}
+        lines.append(f"  Verdict: {a.get('tier', 'clean')} "
+                     f"(sev {a.get('worst_severity', 0)}/conf {a.get('worst_confidence', 0)}, "
+                     f"{a.get('count', 0)} detection(s))")
+        for d in (sen.get("detections") or [])[:20]:
+            disp = "Bloquee" if d.get("action") == "block" else "Detectee"
+            lines.append(f"  - {d.get('class', '?')}: sev {d.get('severity', 0)} [{disp}]")
+    lines.append("")
+
+    lines.append("fpdf2 not installed -- text fallback. apt install python3-fpdf2")
     return "\n".join(lines)

--- a/packages/secubox-toolbox/secubox_toolbox/reports.py
+++ b/packages/secubox-toolbox/secubox_toolbox/reports.py
@@ -12,6 +12,8 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from secubox_toolbox import sentinel_link
+
 from .models import ReportToken
 
 log = logging.getLogger("secubox.toolbox.reports")
@@ -60,11 +62,18 @@ def verify_token(token: str, salt: str) -> tuple[bool, str | None]:
 def build_report_data(mac_hash: str, session_data: dict) -> dict:
     """Aggregate session data into the structure consumed by render_pdf().
     session_data is expected to be the dict produced by api._aggregate_session()."""
-    return {
+    report = {
         "mac_hash": mac_hash,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         **session_data,
     }
+    detections = sentinel_link.fetch_detections(mac_hash)
+    report["sentinel"] = {
+        "active": bool(detections),
+        "assess": sentinel_link.assess(detections),
+        "detections": detections,
+    }
+    return report
 
 
 def _setup_fonts(pdf) -> str:

--- a/packages/secubox-toolbox/secubox_toolbox/sentinel_link.py
+++ b/packages/secubox-toolbox/secubox_toolbox/sentinel_link.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+SecuBox-Deb :: ToolBoX Sentinel link
+CyberMind — https://cybermind.fr
+
+Fail-safe bridge from the ToolBoX portal to the sbx-sentinel daemon's
+read-only localhost status HTTP, plus the compromise/evaluation summary.
+
+Everything here is defensive and MUST NOT raise out to a caller: a dark or
+wedged daemon degrades to empty results, never an exception. Detections
+carry mac_hash only — no other PII passes through this module.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import urllib.request
+from collections import Counter
+
+log = logging.getLogger("secubox.toolbox.sentinel")
+
+_TIMEOUT = 1.5  # seconds — a wedged daemon must not stall a portal request
+_DEFAULT_ADDR = "127.0.0.1:8790"
+_SENTINEL_ENV = "/etc/secubox/sentinel.env"
+
+# Heuristic classes never escalate to "compromised" — they are behavioral
+# guesses, not confirmed known-infrastructure hits. Keep in sync with the Go
+# scorer's heuristicClasses (currently zero-click).
+_HEURISTIC_CLASSES = {"zero_click"}
+_HIGH_CONFIDENCE = 85  # mirrors Go HighConfidenceThreshold
+
+
+def daemon_base() -> str | None:
+    """Resolve the daemon status-HTTP base URL, or None if unconfigured.
+
+    Order: SENTINEL_HTTP_ADDR from the process env, then from
+    /etc/secubox/sentinel.env, then the 127.0.0.1:8790 default. An explicitly
+    empty value (the dark default) yields None so callers show 'inactive'.
+    """
+    addr = os.environ.get("SENTINEL_HTTP_ADDR")
+    if addr is None:
+        addr = _read_env_addr()
+    if addr is None:
+        addr = _DEFAULT_ADDR
+    addr = addr.strip()
+    if not addr:
+        return None
+    if not addr.startswith("http"):
+        addr = "http://" + addr
+    return addr.rstrip("/")
+
+
+def _read_env_addr() -> str | None:
+    """Best-effort read of SENTINEL_HTTP_ADDR from sentinel.env; None on any issue."""
+    try:
+        with open(_SENTINEL_ENV, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line.startswith("SENTINEL_HTTP_ADDR="):
+                    return line.split("=", 1)[1].strip().strip('"')
+    except Exception:
+        pass
+    return None
+
+
+def _get_json(path: str):
+    """GET base+path and parse JSON. Returns None on ANY failure (never raises)."""
+    base = daemon_base()
+    if not base:
+        return None
+    try:
+        req = urllib.request.Request(base + path, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:  # connection refused, timeout, bad JSON, HTTP error
+        log.debug("sentinel fetch %s failed: %s", path, exc)
+        return None
+
+
+def fetch_stats() -> dict:
+    data = _get_json("/stats")
+    return data if isinstance(data, dict) else {}
+
+
+def fetch_verdicts(limit: int = 50) -> list[dict]:
+    limit = max(1, min(int(limit), 500))
+    data = _get_json(f"/verdicts?limit={limit}")
+    return data if isinstance(data, list) else []
+
+
+def fetch_detections(mac_hash: str, limit: int = 50) -> list[dict]:
+    if not mac_hash or not re.fullmatch(r"[0-9a-fA-F]{1,64}", mac_hash):
+        return []
+    limit = max(1, min(int(limit), 500))
+    data = _get_json(f"/verdicts?mac={mac_hash}&limit={limit}")
+    return data if isinstance(data, list) else []
+
+
+def disposition(action: str) -> str:
+    """Honest disposition label — an observed/async detection is not a block."""
+    return "Bloquée" if action == "block" else "Détectée — observée"
+
+
+def _is_confirmed_compromise(d: dict) -> bool:
+    cls = str(d.get("class", ""))
+    if cls in _HEURISTIC_CLASSES:
+        return False
+    return (
+        d.get("action") == "block"
+        and int(d.get("confidence", 0)) >= _HIGH_CONFIDENCE
+    )
+
+
+def assess(detections: list[dict]) -> dict:
+    """Compromise/evaluation summary over one device's (or the fleet's) detections.
+
+    tier: clean (none) · suspicious (report-only/heuristic) · compromised
+    (a high-confidence, non-heuristic, block-action detection).
+    """
+    dets = detections or []
+    if not dets:
+        return {"tier": "clean", "worst_severity": 0, "worst_confidence": 0,
+                "count": 0, "dominant_class": "", "strongest": None}
+    strongest = max(dets, key=lambda d: (int(d.get("severity", 0)),
+                                          int(d.get("confidence", 0))))
+    tier = "compromised" if any(_is_confirmed_compromise(d) for d in dets) else "suspicious"
+    classes = Counter(str(d.get("class", "")) for d in dets if d.get("class"))
+    dominant = classes.most_common(1)[0][0] if classes else ""
+    return {
+        "tier": tier,
+        "worst_severity": max(int(d.get("severity", 0)) for d in dets),
+        "worst_confidence": max(int(d.get("confidence", 0)) for d in dets),
+        "count": len(dets),
+        "dominant_class": dominant,
+        "strongest": strongest,
+    }

--- a/packages/secubox-toolbox/secubox_toolbox/sentinel_link.py
+++ b/packages/secubox-toolbox/secubox_toolbox/sentinel_link.py
@@ -36,6 +36,14 @@ _HEURISTIC_CLASSES = {"zero_click"}
 _HIGH_CONFIDENCE = 85  # mirrors Go HighConfidenceThreshold
 
 
+def _safe_int(value, default: int = 0) -> int:
+    """Coerce daemon/caller-supplied values to int, never raising."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def daemon_base() -> str | None:
     """Resolve the daemon status-HTTP base URL, or None if unconfigured.
 
@@ -89,7 +97,7 @@ def fetch_stats() -> dict:
 
 
 def fetch_verdicts(limit: int = 50) -> list[dict]:
-    limit = max(1, min(int(limit), 500))
+    limit = max(1, min(_safe_int(limit, 50), 500))
     data = _get_json(f"/verdicts?limit={limit}")
     return data if isinstance(data, list) else []
 
@@ -97,7 +105,7 @@ def fetch_verdicts(limit: int = 50) -> list[dict]:
 def fetch_detections(mac_hash: str, limit: int = 50) -> list[dict]:
     if not mac_hash or not re.fullmatch(r"[0-9a-fA-F]{1,64}", mac_hash):
         return []
-    limit = max(1, min(int(limit), 500))
+    limit = max(1, min(_safe_int(limit, 50), 500))
     data = _get_json(f"/verdicts?mac={mac_hash}&limit={limit}")
     return data if isinstance(data, list) else []
 
@@ -113,7 +121,7 @@ def _is_confirmed_compromise(d: dict) -> bool:
         return False
     return (
         d.get("action") == "block"
-        and int(d.get("confidence", 0)) >= _HIGH_CONFIDENCE
+        and _safe_int(d.get("confidence", 0)) >= _HIGH_CONFIDENCE
     )
 
 
@@ -127,15 +135,15 @@ def assess(detections: list[dict]) -> dict:
     if not dets:
         return {"tier": "clean", "worst_severity": 0, "worst_confidence": 0,
                 "count": 0, "dominant_class": "", "strongest": None}
-    strongest = max(dets, key=lambda d: (int(d.get("severity", 0)),
-                                          int(d.get("confidence", 0))))
+    strongest = max(dets, key=lambda d: (_safe_int(d.get("severity", 0)),
+                                          _safe_int(d.get("confidence", 0))))
     tier = "compromised" if any(_is_confirmed_compromise(d) for d in dets) else "suspicious"
     classes = Counter(str(d.get("class", "")) for d in dets if d.get("class"))
     dominant = classes.most_common(1)[0][0] if classes else ""
     return {
         "tier": tier,
-        "worst_severity": max(int(d.get("severity", 0)) for d in dets),
-        "worst_confidence": max(int(d.get("confidence", 0)) for d in dets),
+        "worst_severity": max(_safe_int(d.get("severity", 0)) for d in dets),
+        "worst_confidence": max(_safe_int(d.get("confidence", 0)) for d in dets),
         "count": len(dets),
         "dominant_class": dominant,
         "strongest": strongest,

--- a/packages/secubox-toolbox/secubox_toolbox/sentinel_link.py
+++ b/packages/secubox-toolbox/secubox_toolbox/sentinel_link.py
@@ -99,7 +99,7 @@ def fetch_stats() -> dict:
 def fetch_verdicts(limit: int = 50) -> list[dict]:
     limit = max(1, min(_safe_int(limit, 50), 500))
     data = _get_json(f"/verdicts?limit={limit}")
-    return data if isinstance(data, list) else []
+    return [d for d in data if isinstance(d, dict)] if isinstance(data, list) else []
 
 
 def fetch_detections(mac_hash: str, limit: int = 50) -> list[dict]:
@@ -107,7 +107,7 @@ def fetch_detections(mac_hash: str, limit: int = 50) -> list[dict]:
         return []
     limit = max(1, min(_safe_int(limit, 50), 500))
     data = _get_json(f"/verdicts?mac={mac_hash}&limit={limit}")
-    return data if isinstance(data, list) else []
+    return [d for d in data if isinstance(d, dict)] if isinstance(data, list) else []
 
 
 def disposition(action: str) -> str:
@@ -131,7 +131,7 @@ def assess(detections: list[dict]) -> dict:
     tier: clean (none) · suspicious (report-only/heuristic) · compromised
     (a high-confidence, non-heuristic, block-action detection).
     """
-    dets = detections or []
+    dets = [d for d in (detections or []) if isinstance(d, dict)]
     if not dets:
         return {"tier": "clean", "worst_severity": 0, "worst_confidence": 0,
                 "count": 0, "dominant_class": "", "strongest": None}

--- a/packages/secubox-toolbox/tests/test_inline_banner.py
+++ b/packages/secubox-toolbox/tests/test_inline_banner.py
@@ -85,6 +85,44 @@ def test_inline_keeps_guards_and_spa_hooks():
     assert "countTrackers" in s
 
 
+def test_inline_no_innerhtml_trusted_types_invariant():
+    # #740 hard invariant: the client renderer is built ENTIRELY via mk() (DOM
+    # API). NO innerHTML anywhere → not a Trusted-Types sink → renders on strict
+    # CSP / Trusted-Types sites without any bypass. Do NOT regress this.
+    s = bundle.inline_script("x", wg=True, csp=True)
+    assert "innerHTML" not in s
+
+
+def test_inline_arcade_hud_ids_and_toggles_preserved():
+    # #620 redesign keeps every interactive control + live-count node id.
+    s = bundle.inline_script("x", wg=True, csp=True)
+    assert 'id:"sbx-lvl"' in s and 'cls:"sbx-lvl"' in s   # R0..R4 rank switch
+    assert '"data-lvl"' in s and "/__toolbox/set-level" in s
+    assert 'id:"sbx-tor"' in s and "/__toolbox/set-tor" in s      # Tor toggle
+    assert 'id:"sbx-adg"' in s and "/__toolbox/set-adguard" in s  # Ad-Guard toggle
+    assert 'id:"sbx-trk"' in s and "trackers" in s   # live tracker count node
+    assert 'id:"sbx-ck"' in s and "cookies" in s     # live cookie count node
+    # updateCounts still writes the exact text into the same ids (live 2s poll).
+    assert '"🛰️ " + countTrackers' in s
+    assert '"🍪 " + countCookies()' in s
+
+
+def test_inline_three_cluster_responsive_fix():
+    # The bug fix is structural: LEFT + RIGHT clusters are flex:0 0 auto (never
+    # shrink); the MIDDLE evidence cluster is flex:1 1 auto; min-width:0;
+    # overflow-x:auto (scrolls instead of pushing) → the close ✕ is ALWAYS on
+    # screen. box-sizing:border-box keeps padding from overflowing the width.
+    s = bundle.inline_script("x", wg=True, csp=True)
+    assert "box-sizing:border-box" in s
+    assert "flex:0 0 auto" in s      # pinned clusters
+    assert "flex:1 1 auto" in s      # middle grows
+    assert "min-width:0" in s        # middle can shrink to nothing
+    assert "overflow-x:auto" in s    # middle scrolls
+    # the dismiss control sits in the RIGHT pinned cluster (built just before it).
+    right = s[s.index("flex:0 0 auto;display:flex;align-items:center;gap:8px"):]
+    assert 'aria-label":"dismiss"' in right   # ✕ lives in the right-pinned cluster
+
+
 def test_inline_escapes_script_breakout():
     # A bundle value that literally contains </script> must NOT close the inline
     # <script> — it must be escaped to <\/script>.

--- a/packages/secubox-toolbox/tests/test_loader_top.py
+++ b/packages/secubox-toolbox/tests/test_loader_top.py
@@ -7,7 +7,9 @@ def test_loader_renders_top_bar():
     assert "top:0" in js                       # banner pinned to top
     assert "bottom:0" not in js                # not a bottom bar anymore
     assert "paddingTop" in js                  # pushes content down
-    assert "border-bottom:2px solid #148C66" in js  # divider now on the bottom edge
+    # #620 arcade redesign — the bottom-edge divider is now the tier accent
+    # (colour derived from b.level at render time), not a fixed brand green.
+    assert 'border-bottom:2px solid " + acc' in js  # divider on the bottom edge, tier-accent
 
 
 def test_loader_dismiss_resets_padding():

--- a/packages/secubox-toolbox/tests/test_report_html_sentinel.py
+++ b/packages/secubox-toolbox/tests/test_report_html_sentinel.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+"""#823 regression — the live HTML report (/report/me/html) must actually feed
+the "🛡️ Compromission" tab from Sentinel data, not render it Undefined/inert.
+
+report_me_html() previously rendered report-live.html.j2 with **session and a
+pile of named kwargs but never a `report=` kwarg, while the template's
+Compromission pane reads `report.sentinel`. Since build_report_data() is the
+one place that folds sentinel_link.fetch_detections()+assess() into a
+`sentinel` key (already used by the PDF routes), the fix threads that same
+dict into the HTML render too.
+"""
+from fastapi.testclient import TestClient
+
+from secubox_toolbox import api
+from secubox_toolbox import sentinel_link as sl
+from secubox_toolbox.app import app
+
+client = TestClient(app)
+
+MH = "aabbccdd11223344"
+
+
+def test_report_me_html_surfaces_sentinel_detection(monkeypatch):
+    # Local test env has no /etc/secubox/toolbox.toml — the route resolves
+    # identity via _get_salt() even on the ?mh= bypass path, so stub it
+    # rather than touching real config (unrelated to what's under test).
+    monkeypatch.setattr(api, "_get_salt", lambda: "testsalt")
+    monkeypatch.setattr(sl, "fetch_detections", lambda mac_hash, limit=50: [
+        {"class": "spyware_pegasus", "action": "report", "severity": 95,
+         "confidence": 95, "ts": 1234567890, "report": "RPT", "mac_hash": MH},
+    ])
+
+    r = client.get(f"/report/me/html?mh={MH}")
+
+    assert r.status_code == 200
+    body = r.text
+    # The tab button itself is always rendered (static markup)...
+    assert "Compromission" in body
+    # ...but the fix under test is that it's now FED: the detection class
+    # text must appear in the rendered pane, proving report.sentinel is a
+    # real dict (not Undefined degrading to the "inactive" branch).
+    assert "spyware_pegasus" in body
+    assert "Sentinelle inactive" not in body
+
+
+def test_report_me_html_stays_inactive_when_daemon_dark(monkeypatch):
+    """Fail-safe: no detections → tab still renders, just says 'inactive'."""
+    monkeypatch.setattr(api, "_get_salt", lambda: "testsalt")
+    monkeypatch.setattr(sl, "fetch_detections", lambda mac_hash, limit=50: [])
+
+    r = client.get(f"/report/me/html?mh={MH}")
+
+    assert r.status_code == 200
+    assert "Sentinelle inactive" in r.text
+    assert "spyware_pegasus" not in r.text

--- a/packages/secubox-toolbox/tests/test_report_sentinel.py
+++ b/packages/secubox-toolbox/tests/test_report_sentinel.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+from secubox_toolbox import reports
+from secubox_toolbox import sentinel_link as sl
+
+
+def test_build_report_data_folds_sentinel_active(monkeypatch):
+    monkeypatch.setattr(sl, "fetch_detections", lambda mh, limit=50: [
+        {"class": "spyware_pegasus", "severity": 95, "confidence": 95,
+         "action": "report", "evidence": {}, "mac_hash": "aa", "ts": 1, "report": "R"},
+    ])
+    rep = reports.build_report_data("aa", {"device_type": "phone"})
+    assert rep["sentinel"]["active"] is True
+    assert rep["sentinel"]["assess"]["tier"] == "suspicious"
+    assert len(rep["sentinel"]["detections"]) == 1
+
+
+def test_build_report_data_sentinel_inactive_when_daemon_down(monkeypatch):
+    monkeypatch.setattr(sl, "fetch_detections", lambda mh, limit=50: [])
+    rep = reports.build_report_data("aa", {})
+    assert rep["sentinel"]["active"] is False
+    assert rep["sentinel"]["assess"]["tier"] == "clean"
+    assert rep["sentinel"]["detections"] == []

--- a/packages/secubox-toolbox/tests/test_report_sentinel_pdf.py
+++ b/packages/secubox-toolbox/tests/test_report_sentinel_pdf.py
@@ -1,0 +1,45 @@
+from secubox_toolbox import reports
+
+
+def _report(sentinel):
+    return {"mac_hash": "aa", "generated_at": "2026-07-06T00:00:00Z",
+            "device_type": "phone", "sentinel": sentinel}
+
+
+def test_pdf_renders_with_sentinel_detection():
+    rep = _report({
+        "active": True,
+        "assess": {"tier": "compromised", "worst_severity": 95, "worst_confidence": 95,
+                   "count": 1, "dominant_class": "spyware_pegasus",
+                   "strongest": {"class": "spyware_pegasus"}},
+        "detections": [{"class": "spyware_pegasus", "severity": 95, "confidence": 95,
+                        "action": "block", "evidence": {"source": "amnesty-mvt"},
+                        "mac_hash": "aa", "ts": 1, "report": "R"}],
+    })
+    out = reports.render_pdf(rep)
+    assert isinstance(out, (bytes, bytearray)) and len(out) > 500
+
+
+def test_pdf_renders_with_sentinel_inactive():
+    rep = _report({"active": False, "assess": {"tier": "clean"}, "detections": []})
+    out = reports.render_pdf(rep)
+    assert isinstance(out, (bytes, bytearray)) and len(out) > 500
+
+
+def test_pdf_renders_when_sentinel_key_absent():
+    rep = {"mac_hash": "aa", "generated_at": "2026-07-06T00:00:00Z", "device_type": "phone"}
+    out = reports.render_pdf(rep)  # must not KeyError
+    assert isinstance(out, (bytes, bytearray)) and len(out) > 500
+
+
+def test_text_fallback_includes_sentinel_line():
+    rep = _report({
+        "active": True,
+        "assess": {"tier": "compromised", "worst_severity": 95, "worst_confidence": 95,
+                   "count": 1, "dominant_class": "spyware_pegasus", "strongest": None},
+        "detections": [{"class": "spyware_pegasus", "severity": 95, "confidence": 95,
+                        "action": "block", "evidence": {}, "mac_hash": "aa", "ts": 1, "report": "R"}],
+    })
+    txt = reports._render_text_fallback(rep)
+    assert "SENTINELLE" in txt.upper()
+    assert "spyware_pegasus" in txt

--- a/packages/secubox-toolbox/tests/test_sentinel_api.py
+++ b/packages/secubox-toolbox/tests/test_sentinel_api.py
@@ -24,6 +24,17 @@ def test_stats_inactive_when_daemon_down(monkeypatch):
     assert body["detections"] == 0 and body["blocked"] == 0 and body["spyware"] == 0
 
 
+def test_stats_malformed_daemon_value_does_not_500(monkeypatch):
+    monkeypatch.setattr(sl, "fetch_stats",
+                        lambda: {"detections": "not-a-number", "blocked": 1, "spyware": 2})
+    r = client.get("/admin/sentinel/stats")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["active"] is True
+    assert body["detections"] == 0  # coerced safely
+    assert body["blocked"] == 1 and body["spyware"] == 2
+
+
 def test_verdicts_shape_and_failsafe(monkeypatch):
     monkeypatch.setattr(sl, "fetch_verdicts", lambda limit=50: [
         {"class": "spyware_pegasus", "severity": 95, "confidence": 95,

--- a/packages/secubox-toolbox/tests/test_sentinel_api.py
+++ b/packages/secubox-toolbox/tests/test_sentinel_api.py
@@ -1,0 +1,43 @@
+from fastapi.testclient import TestClient
+from secubox_toolbox.app import app
+from secubox_toolbox import sentinel_link as sl
+
+client = TestClient(app)
+
+
+def test_stats_active_when_daemon_up(monkeypatch):
+    monkeypatch.setattr(sl, "fetch_stats",
+                        lambda: {"detections": 3, "blocked": 1, "spyware": 2})
+    r = client.get("/admin/sentinel/stats")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["active"] is True
+    assert body["detections"] == 3 and body["spyware"] == 2
+
+
+def test_stats_inactive_when_daemon_down(monkeypatch):
+    monkeypatch.setattr(sl, "fetch_stats", lambda: {})
+    r = client.get("/admin/sentinel/stats")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["active"] is False
+    assert body["detections"] == 0 and body["blocked"] == 0 and body["spyware"] == 0
+
+
+def test_verdicts_shape_and_failsafe(monkeypatch):
+    monkeypatch.setattr(sl, "fetch_verdicts", lambda limit=50: [
+        {"class": "spyware_pegasus", "severity": 95, "confidence": 95,
+         "action": "report", "evidence": {}, "mac_hash": "aa", "ts": 1, "report": "R"},
+    ])
+    r = client.get("/admin/sentinel/verdicts")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["active"] is True
+    assert body["assess"]["tier"] == "suspicious"
+    assert len(body["detections"]) == 1
+
+    monkeypatch.setattr(sl, "fetch_verdicts", lambda limit=50: [])
+    r = client.get("/admin/sentinel/verdicts")
+    assert r.status_code == 200
+    assert r.json()["active"] is False
+    assert r.json()["assess"]["tier"] == "clean"

--- a/packages/secubox-toolbox/tests/test_sentinel_link.py
+++ b/packages/secubox-toolbox/tests/test_sentinel_link.py
@@ -68,3 +68,23 @@ def test_assess_never_raises_on_malformed_detection():
 def test_fetch_verdicts_bad_limit_does_not_raise(monkeypatch):
     monkeypatch.setattr(sl, "daemon_base", lambda: None)
     assert sl.fetch_verdicts(limit="oops") == []
+
+
+def test_assess_ignores_non_dict_elements():
+    # a malformed daemon array must not raise and must count only dicts
+    dets = [None, 1, "x", {"class": "spyware_pegasus", "severity": 95,
+            "confidence": 95, "action": "report", "evidence": {}, "mac_hash": "aa", "ts": 1}]
+    a = sl.assess(dets)  # must not raise
+    assert a["count"] == 1
+    assert a["tier"] == "suspicious"
+
+
+def test_assess_all_non_dict_is_clean():
+    assert sl.assess([None, 1, "x"])["tier"] == "clean"
+
+
+def test_fetch_verdicts_filters_non_dict_elements(monkeypatch):
+    monkeypatch.setattr(sl, "_get_json", lambda path: [None, {"class": "malware_generic",
+        "severity": 10, "confidence": 10, "action": "report", "evidence": {}, "mac_hash": "aa", "ts": 1}])
+    out = sl.fetch_verdicts()
+    assert len(out) == 1 and out[0]["class"] == "malware_generic"

--- a/packages/secubox-toolbox/tests/test_sentinel_link.py
+++ b/packages/secubox-toolbox/tests/test_sentinel_link.py
@@ -1,0 +1,57 @@
+from secubox_toolbox import sentinel_link as sl
+
+
+def test_assess_clean_when_no_detections():
+    a = sl.assess([])
+    assert a["tier"] == "clean"
+    assert a["count"] == 0
+    assert a["strongest"] is None
+
+
+def test_assess_report_only_spyware_is_suspicious():
+    dets = [{"class": "spyware_pegasus", "severity": 95, "confidence": 95,
+             "action": "report", "evidence": {}, "mac_hash": "aa", "ts": 1}]
+    a = sl.assess(dets)
+    assert a["tier"] == "suspicious"
+    assert a["worst_severity"] == 95
+    assert a["dominant_class"] == "spyware_pegasus"
+    assert a["strongest"]["class"] == "spyware_pegasus"
+
+
+def test_assess_high_conf_block_spyware_is_compromised():
+    dets = [{"class": "spyware_pegasus", "severity": 95, "confidence": 95,
+             "action": "block", "evidence": {}, "mac_hash": "aa", "ts": 1}]
+    assert sl.assess(dets)["tier"] == "compromised"
+
+
+def test_assess_zero_click_never_compromised_even_if_block():
+    # zero-click is heuristic — must stay suspicious regardless of action.
+    dets = [{"class": "zero_click", "severity": 90, "confidence": 90,
+             "action": "block", "evidence": {}, "mac_hash": "aa", "ts": 1}]
+    assert sl.assess(dets)["tier"] == "suspicious"
+
+
+def test_assess_low_confidence_block_is_not_compromised():
+    dets = [{"class": "malware_generic", "severity": 90, "confidence": 60,
+             "action": "block", "evidence": {}, "mac_hash": "aa", "ts": 1}]
+    assert sl.assess(dets)["tier"] == "suspicious"
+
+
+def test_disposition_labels():
+    assert sl.disposition("block") == "Bloquée"
+    assert sl.disposition("report") == "Détectée — observée"
+    assert sl.disposition("") == "Détectée — observée"
+
+
+def test_fetch_stats_failsafe_when_daemon_down(monkeypatch):
+    # Point at a base but make the HTTP call raise → {} (never raises out).
+    monkeypatch.setattr(sl, "daemon_base", lambda: "http://127.0.0.1:9")
+    assert sl.fetch_stats() == {}
+    assert sl.fetch_verdicts() == []
+    assert sl.fetch_detections("aa") == []
+
+
+def test_fetch_stats_none_base_returns_empty(monkeypatch):
+    monkeypatch.setattr(sl, "daemon_base", lambda: None)
+    assert sl.fetch_stats() == {}
+    assert sl.fetch_verdicts() == []

--- a/packages/secubox-toolbox/tests/test_sentinel_link.py
+++ b/packages/secubox-toolbox/tests/test_sentinel_link.py
@@ -55,3 +55,16 @@ def test_fetch_stats_none_base_returns_empty(monkeypatch):
     monkeypatch.setattr(sl, "daemon_base", lambda: None)
     assert sl.fetch_stats() == {}
     assert sl.fetch_verdicts() == []
+
+
+def test_assess_never_raises_on_malformed_detection():
+    dets = [{"class": "malware_generic", "severity": None, "confidence": "n/a",
+             "action": "block", "evidence": {}, "mac_hash": "aa", "ts": 1}]
+    a = sl.assess(dets)  # must not raise
+    assert a["tier"] in ("suspicious", "compromised", "clean")
+    assert a["count"] == 1
+
+
+def test_fetch_verdicts_bad_limit_does_not_raise(monkeypatch):
+    monkeypatch.setattr(sl, "daemon_base", lambda: None)
+    assert sl.fetch_verdicts(limit="oops") == []

--- a/packages/secubox-toolbox/tests/test_tor_switch.py
+++ b/packages/secubox-toolbox/tests/test_tor_switch.py
@@ -135,15 +135,52 @@ def _banner_ctx(tor_mode):
     }
 
 
-def test_banner_shows_tor_chip_when_armed():
-    import sys, pathlib
+def _inject_banner_mod():
+    import sys, pathlib, importlib
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "mitmproxy_addons"))
-    import importlib, inject_banner
+    import inject_banner
     importlib.reload(inject_banner)
+    return inject_banner
+
+
+def test_banner_shows_tor_chip_when_armed():
+    inject_banner = _inject_banner_mod()
     on = inject_banner._banner_html_dynamic("sha", _banner_ctx(True), True, "https://kbin/r", "R3", "r3")
     off = inject_banner._banner_html_dynamic("sha", _banner_ctx(False), True, "https://kbin/r", "R3", "r3")
     assert b"&#x1F9C5; Tor" in on        # 🧅 chip present when armed
     assert b"&#x1F9C5;" not in off       # absent when off
+
+
+def test_inject_banner_output_is_ascii_encodable():
+    # #620 invariant — both render paths must stay ASCII-encodable (NCR-encoded
+    # emoji). The csp_strict path html.encode("ascii") and the JS-path
+    # js.encode("ascii") are exercised here; a raw non-ASCII byte would raise.
+    inject_banner = _inject_banner_mod()
+    for csp_strict in (True, False):
+        out = inject_banner._banner_html_dynamic(
+            "3A:9F:C1", _banner_ctx(True), csp_strict, "https://kbin/r", "R3", "r3")
+        assert isinstance(out, bytes)
+        out.decode("ascii")                         # must not raise
+        assert b"__GONDWANA_MITM_BANNER__" in out   # _GUARD idempotency marker
+        assert b"gondwana-mitm-banner" in out       # banner id preserved
+
+
+def test_inject_banner_three_cluster_and_close():
+    # Structural responsive fix — left rank+grade pinned, middle chips scroll,
+    # right report+close pinned. The JS (dismissible) path carries the close ✕
+    # in the right-pinned cluster; the csp_strict path has NO close (non-dismiss).
+    inject_banner = _inject_banner_mod()
+    js = inject_banner._banner_html_dynamic(
+        "sha", _banner_ctx(False), False, "https://kbin/r", "R3", "r3").decode("ascii")
+    assert "box-sizing:border-box" in js
+    assert "flex:0 0 auto" in js and "flex:1 1 auto" in js  # pinned + growing clusters
+    assert "min-width:0" in js and "overflow-x:auto" in js  # middle scrolls
+    assert 'aria-label="dismiss"' in js                    # close control present
+    assert "&#x2715;" in js                                 # ✕ glyph
+    # csp_strict path is non-dismissible → no close control.
+    strict = inject_banner._banner_html_dynamic(
+        "sha", _banner_ctx(False), True, "https://kbin/r", "R3", "r3").decode("ascii")
+    assert "&#x2715;" not in strict and "aria-label" not in strict
 
 
 def test_nft_tunnel_failclosed_invariants():

--- a/packages/secubox-toolbox/www/toolbox/index.html
+++ b/packages/secubox-toolbox/www/toolbox/index.html
@@ -86,6 +86,7 @@
         <button class="tab" data-tab="ads" onclick="switchTab('ads')">🛑 Pubs</button>
         <button class="tab" data-tab="reseau" onclick="switchTab('reseau')">📡 Réseau</button>
         <button class="tab" data-tab="tor" onclick="switchTab('tor')">🧅 Tor</button>
+        <button class="tab" data-tab="sentinel" onclick="switchTab('sentinel')">🛡️ Sentinelle</button>
         <button class="tab" data-tab="config" onclick="switchTab('config')">⚙ Config</button>
     </nav>
 
@@ -248,6 +249,16 @@
         </div>
     </section>
 
+    <!-- Sentinelle -->
+    <section class="panel" id="panel-sentinel">
+        <div class="toolbar">
+            <button onclick="loadSentinel()">🔁 Refresh</button>
+            <span id="sentinel-state" class="v" style="margin-left:.5rem">…</span>
+        </div>
+        <div id="sentinel-verdict" class="card" style="margin-bottom:.8rem"></div>
+        <div id="sentinel-detections"></div>
+    </section>
+
     <!-- Config -->
     <section class="panel" id="panel-config">
         <div class="toolbar">
@@ -273,6 +284,7 @@ function switchTab(name) {
     if (name === 'ads') loadAds();
     if (name === 'reseau') loadNetstats();
     if (name === 'tor') loadTor();
+    if (name === 'sentinel') loadSentinel();
     location.hash = name;
 }
 
@@ -573,6 +585,61 @@ async function torLeaks() {
         msg.textContent = d.ok ? `IP de sortie : ${d.tor_ip}` : ('échec : ' + (d.error || 'tor down'));
         setTimeout(() => loadTor(), 800);
     } catch (e) { msg.textContent = 'échec : ' + e.message; }
+}
+
+// ── Sentinel — compromise evaluation + detections (#823) ──
+const SENTINEL_TIER = {
+    clean:        { emoji: '🟢', label: 'Aucune compromission détectée', color: 'var(--p31-hot,#0a0)' },
+    suspicious:   { emoji: '🟠', label: 'Activité suspecte',              color: 'var(--p31-decay,#c77d00)' },
+    compromised:  { emoji: '🔴', label: 'Compromission confirmée',        color: 'var(--red,#e63946)' },
+};
+
+function sentinelDisposition(action) {
+    return action === 'block' ? 'Bloquée' : 'Détectée — observée';
+}
+
+function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"]/g, c =>
+        ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+}
+
+async function loadSentinel() {
+    const stateEl = document.getElementById('sentinel-state');
+    const vEl = document.getElementById('sentinel-verdict');
+    const dEl = document.getElementById('sentinel-detections');
+    const stats = await J('/admin/sentinel/stats');
+    const data = await J('/admin/sentinel/verdicts');
+
+    if (stats.__error || data.__error || !data.active) {
+        stateEl.textContent = '⚪ Sentinelle inactive';
+        vEl.innerHTML = '<span class="v">Sentinelle inactive — aucune donnée de détection réseau.</span>';
+        dEl.innerHTML = '';
+        return;
+    }
+
+    stateEl.textContent = `🟢 active · ${stats.detections || 0} détections · ${stats.blocked || 0} bloquées · ${stats.spyware || 0} spyware`;
+
+    const a = data.assess || { tier: 'clean' };
+    const t = SENTINEL_TIER[a.tier] || SENTINEL_TIER.clean;
+    vEl.innerHTML =
+        `<div style="font-size:1.1rem;color:${t.color}">${t.emoji} ${esc(t.label)}</div>` +
+        `<div class="v" style="margin-top:.4rem">Sévérité max ${a.worst_severity || 0}/100 · ` +
+        `Confiance ${a.worst_confidence || 0}/100 · ${a.count || 0} détections · ` +
+        `${esc(a.dominant_class || '—')}</div>`;
+
+    const rows = (data.detections || []).map(d => {
+        const when = d.ts ? new Date(d.ts * 1000).toISOString().replace('T', ' ').slice(0, 19) : '?';
+        return `<tr>
+            <td>${esc(d.class)}</td>
+            <td>${d.severity || 0}/${d.confidence || 0}</td>
+            <td>${esc(sentinelDisposition(d.action))}</td>
+            <td>${when}</td>
+            <td><details><summary>rapport</summary><pre style="white-space:pre-wrap;font-size:.75rem">${esc(d.report)}</pre></details></td>
+        </tr>`;
+    }).join('');
+    dEl.innerHTML = rows
+        ? `<table><thead><tr><th>Menace</th><th>Sév/Conf</th><th>Disposition</th><th>Vu</th><th>Détail</th></tr></thead><tbody>${rows}</tbody></table>`
+        : '<span class="v">Aucune détection récente.</span>';
 }
 
 async function loadSocial() {

--- a/packages/secubox-toolbox/www/toolbox/index.html
+++ b/packages/secubox-toolbox/www/toolbox/index.html
@@ -628,7 +628,7 @@ async function loadSentinel() {
         `${esc(a.dominant_class || '—')}</div>`;
 
     const rows = (data.detections || []).map(d => {
-        const when = d.ts ? new Date(d.ts * 1000).toISOString().replace('T', ' ').slice(0, 19) : '?';
+        const when = Number.isFinite(d.ts) ? new Date(d.ts * 1000).toISOString().replace('T', ' ').slice(0, 19) : '?';
         return `<tr>
             <td>${esc(d.class)}</td>
             <td>${d.severity || 0}/${d.confidence || 0}</td>


### PR DESCRIPTION
## Summary

Surfaces the merged-but-dark **Sentinel** compromise-detection engine (#823/#824) to the ToolBoX user & admin, and prepares its live activation. Three read surfaces, one shared data path, fully fail-safe.

Built via brainstorm → spec → plan → subagent-driven execution (12 commits, per-task two-stage review + a final whole-branch review on the most capable model). Spec: `docs/superpowers/specs/2026-07-06-sentinel-activation-toolbox-tab-design.md` · Plan: `docs/superpowers/plans/2026-07-06-sentinel-activation-toolbox-surfaces.md`.

## What's in it

- **Go** — `sbx-sentinel` `/verdicts?mac=<hash>` per-device filter (no regression to the no-mac path; limit clamp preserved).
- **`sentinel_link.py`** — fail-safe stdlib bridge to the daemon's localhost status HTTP + the `assess()` compromise/evaluation logic. Never raises; heuristic/zero-click never escalate to *compromised* (only non-heuristic + `action=block` + `confidence≥85` does — mirrors the Go scorer).
- **Surface A — WebUI ToolBoX tab** (🛡️ Sentinelle, fleet view) via `/admin/sentinel/{stats,verdicts}` proxy routes (admin-gated, HTTP 200 even when the daemon is dark).
- **Surface B — kbin “mon rapport”** per-device Compromission tab (`report-live.html.j2`), wired into the live HTML render.
- **Surface C — PDF report** per-device Sentinelle section (+ text-fallback), sharing the `report["sentinel"]` key with the HTML.
- **Demo** — `docs/demos/2026-07-06-kbin-sentinel-augmentation-prompt.md` (GPT prompt showcasing the kbin augmentation).

## Safety / constraints honored

- **Report-only, defensive** — no inline hot-path blocking; findings carry `mac_hash` only (no other PII).
- **Fail-safe everywhere** — a dark/wedged/malformed daemon never 5xxes the portal, breaks a report, or breaks a PDF. Hardened against non-numeric fields and non-dict rows; template renders when `report` is absent.
- **No new external surface** — daemon HTTP stays `127.0.0.1:8790`; proxy under `/admin/` (reverse-proxy gated); stdlib `urllib` only (no new Debian dep).
- **XSS** — Jinja autoescape + JS `esc()` on every daemon-supplied string.
- **Honest disposition** — `block` → “Bloquée”, else “Détectée — observée” (no “blocked before any data left” over-claim on observed detections).

## Tests

`packages/secubox-toolbox` suite: 241 passed, 1 pre-existing unrelated failure (`test_bypass_sources.py`, no bypass code touched here). Go: `go test ./cmd/sbx-sentinel/...` green incl. the new mac-filter test.

## Not in this PR (follow-up on merge)

- **Live activation on gk2** — deploy `sbx-sentinel`, set `SENTINEL_HTTP_ADDR=127.0.0.1:8790`, wire the mirror sock, enable the daemon, verify all three surfaces with a placeholder-IOC flow. To be done from `master` after merge (source-first, no drift).
- Deferred Minors: `assess()["strongest"]` unused field; `active=bool(detections)` shows “inactive” wording for a clean-but-monitored device (cosmetic).

Refs #823