### PR TITLE
feat(sentinel): report-only surfacing of non-spyware feed IOCs (botnet_c2/malware) — ref #826

### DIFF
--- a/packages/secubox-toolbox-ng/cmd/sbx-sentinel/main.go
+++ b/packages/secubox-toolbox-ng/cmd/sbx-sentinel/main.go
@@ -355,6 +355,10 @@ func buildAnalyzers(packDir, overlayDir string, yaraRules []string) ([]Analyzer,
 		errs = append(errs, fmt.Errorf("pack loader (spyware analyzer disabled): %w", err))
 	} else {
 		analyzers = append(analyzers, sentinel.NewSpyware(loader))
+		// #826 report-only feed surfacing: correlate the non-spyware IOC
+		// classes (botnet_c2/malware/… from the live threat feeds) that the
+		// Spyware analyzer skips, as REPORT-ONLY (the daemon never blocks).
+		analyzers = append(analyzers, sentinel.NewIOCReporter(loader))
 	}
 
 	c2 := sentinel.NewC2Learner(sentinel.NewBehavioral(), sentinel.C2Config{

--- a/packages/secubox-toolbox-ng/cmd/sbx-sentinel/wiring_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbx-sentinel/wiring_test.go
@@ -13,35 +13,39 @@ import (
 	"github.com/CyberMind-FR/secubox-deb/secubox-toolbox-ng/internal/sentinel"
 )
 
-// TestBuildAnalyzersReturnsThree asserts the production analyzer construction
-// wires exactly the three real engines (spyware, the behavioral engine
-// wrapped in the #826 C2 auto-learn orchestrator, YARA) — this is the path
+// TestBuildAnalyzersReturnsFour asserts the production analyzer construction
+// wires exactly the four real engines (spyware, the #826 report-only IOC
+// reporter for non-spyware feed classes, the behavioral engine wrapped in the
+// #826 C2 auto-learn orchestrator, YARA) — this is the path
 // defaultConfig()/main() use, distinct from the tests' injected stubAnalyzer
 // path.
-func TestBuildAnalyzersReturnsThree(t *testing.T) {
+func TestBuildAnalyzersReturnsFour(t *testing.T) {
 	// Empty/missing dirs are best-effort (no error) — NewLoader tolerates
-	// them — so the happy path returns all three analyzers with no error.
+	// them — so the happy path returns all four analyzers with no error.
 	analyzers, err := buildAnalyzers("", "", nil)
 	if err != nil {
 		t.Fatalf("buildAnalyzers returned error on empty dirs: %v", err)
 	}
-	if len(analyzers) != 3 {
-		t.Fatalf("expected 3 analyzers, got %d", len(analyzers))
+	if len(analyzers) != 4 {
+		t.Fatalf("expected 4 analyzers, got %d", len(analyzers))
 	}
 
-	var haveSpyware, haveC2Learner, haveYara bool
+	var haveSpyware, haveReporter, haveC2Learner, haveYara bool
 	for _, a := range analyzers {
 		switch a.(type) {
 		case *sentinel.Spyware:
 			haveSpyware = true
+		case *sentinel.IOCReporter:
+			haveReporter = true
 		case *sentinel.C2Learner:
 			haveC2Learner = true
 		case *sentinel.YaraEngine:
 			haveYara = true
 		}
 	}
-	if !haveSpyware || !haveC2Learner || !haveYara {
-		t.Fatalf("missing an analyzer type: spyware=%v c2learner=%v yara=%v", haveSpyware, haveC2Learner, haveYara)
+	if !haveSpyware || !haveReporter || !haveC2Learner || !haveYara {
+		t.Fatalf("missing an analyzer type: spyware=%v reporter=%v c2learner=%v yara=%v",
+			haveSpyware, haveReporter, haveC2Learner, haveYara)
 	}
 }
 
@@ -86,8 +90,8 @@ func TestDefaultConfigWiresPipeline(t *testing.T) {
 	t.Setenv("SENTINEL_TTL", "24h")
 
 	cfg := defaultConfig()
-	if len(cfg.Analyzers) != 3 {
-		t.Fatalf("expected 3 analyzers wired, got %d", len(cfg.Analyzers))
+	if len(cfg.Analyzers) != 4 {
+		t.Fatalf("expected 4 analyzers wired, got %d", len(cfg.Analyzers))
 	}
 	if cfg.TTL.Hours() != 24 {
 		t.Fatalf("expected TTL 24h from env, got %s", cfg.TTL)

--- a/packages/secubox-toolbox-ng/debian/changelog
+++ b/packages/secubox-toolbox-ng/debian/changelog
@@ -1,3 +1,14 @@
+secubox-toolbox-ng (0.1.32-1~bookworm1) bookworm; urgency=medium
+
+  * #826 report-only feed surfacing: new daemon IOCReporter analyzer correlates
+    the non-spyware IOC classes (botnet_c2/malware/… from the live abuse.ch/
+    ThreatFox/Feodo feeds) that the Spyware analyzer skips, and records them
+    REPORT-ONLY (action forced to report, evidence disposition=observed) — the
+    async daemon observes, it never blocks. Feed detections now surface in the
+    Sentinelle tab / reports without any inline blocking.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Mon, 07 Jul 2026 15:00:00 +0200
+
 secubox-toolbox-ng (0.1.31-1~bookworm1) bookworm; urgency=medium
 
   * #826 fix: C2 autolearn false-positive — a first-seen browser-driven host

--- a/packages/secubox-toolbox-ng/internal/sentinel/iocreport.go
+++ b/packages/secubox-toolbox-ng/internal/sentinel/iocreport.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: LicenseRef-CMSD-1.0
+// Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+// Source-Disclosed License — All rights reserved except as expressly granted.
+// See LICENCE-CMSD-1.0.md for terms.
+
+package sentinel
+
+// IOCReporter is the async daemon's REPORT-ONLY correlator for the
+// non-spyware IOC classes (botnet_c2 / malware / trojan / phishing …) that the
+// live threat feeds materialise into the overlay pack. The narrower Spyware
+// analyzer only surfaces the commercial-spyware classes, so without this a
+// device contacting a known abuse.ch / ThreatFox C2 would be recorded by
+// nothing. IOCReporter matches the same IOCSet the inline gate uses, but —
+// because the daemon only ever OBSERVES mirrored flows, it never blocks — it
+// forces every verdict to ActionReport. So a feed IOC declared `action:block`
+// surfaces honestly as "detected / observed", never as "blocked" (the inline
+// gate does the blocking, when enabled; the daemon does not).
+//
+// It deliberately SKIPS the spyware classes (spywareClasses) so it never
+// double-reports a hit the Spyware analyzer already emits for the same flow.
+
+import (
+	"log"
+)
+
+// IOCReporter implements the daemon Analyzer interface over a pack Loader.
+// It holds no state beyond the Loader (which owns the hot-reloaded IOC set).
+type IOCReporter struct {
+	loader *Loader
+}
+
+// NewIOCReporter returns a report-only correlator over l's current IOC set.
+func NewIOCReporter(l *Loader) *IOCReporter { return &IOCReporter{loader: l} }
+
+// Analyze matches m against every IOC field and emits a report-only verdict for
+// each hit whose class is NOT a spyware class (those belong to the Spyware
+// analyzer). Fail-open: any panic recovers to no verdicts; a nil loader is a
+// no-op. Never blocks.
+func (r *IOCReporter) Analyze(m MirrorMsg) (verdicts []*Verdict) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Printf("sentinel: iocreport analyze recovered from panic (fail-open): %v", rec)
+			verdicts = nil
+		}
+	}()
+
+	if r == nil || r.loader == nil {
+		return nil
+	}
+
+	r.loader.MaybeReload()
+	set := r.loader.Set()
+
+	var hits []*IOC
+	if ioc, ok := set.MatchDomain(m.Meta.Host); ok && !spywareClasses[ioc.Class] {
+		hits = append(hits, ioc)
+	}
+	if ioc, ok := set.MatchIP(m.Meta.Host); ok && !spywareClasses[ioc.Class] {
+		hits = append(hits, ioc)
+	}
+	if ioc, ok := set.MatchJA3(m.Meta.JA3); ok && !spywareClasses[ioc.Class] {
+		hits = append(hits, ioc)
+	}
+	if ioc, ok := set.MatchJA4(m.Meta.JA4); ok && !spywareClasses[ioc.Class] {
+		hits = append(hits, ioc)
+	}
+	if ioc, ok := set.MatchCertSHA1(m.Meta.CertSHA1); ok && !spywareClasses[ioc.Class] {
+		hits = append(hits, ioc)
+	}
+	if ioc, ok := set.MatchURL(m.Meta.URL); ok && !spywareClasses[ioc.Class] {
+		hits = append(hits, ioc)
+	}
+
+	if len(hits) == 0 {
+		return nil
+	}
+
+	verdicts = make([]*Verdict, 0, len(hits))
+	for _, ioc := range hits {
+		verdicts = append(verdicts, iocReportVerdict(ioc, m))
+	}
+	return verdicts
+}
+
+// iocReportVerdict builds a REPORT-ONLY verdict for a non-spyware IOC hit. The
+// action is ALWAYS ActionReport regardless of the IOC's declared action: the
+// async daemon observes, it does not block, so surfacing "blocked" would
+// over-claim. `disposition:observed` makes that explicit for the reporter.
+func iocReportVerdict(ioc *IOC, m MirrorMsg) *Verdict {
+	return &Verdict{
+		Class:      ioc.Class,
+		Severity:   ioc.Severity,
+		Confidence: ioc.Severity,
+		Action:     ActionReport, // daemon observes only — never block
+		Evidence: map[string]string{
+			"ioc_type":    string(ioc.Type),
+			"ioc_value":   ioc.Value,
+			"source":      ioc.Source,
+			"disposition": "observed",
+		},
+		MacHash: m.Meta.MacHash,
+		TS:      m.TS,
+	}
+}

--- a/packages/secubox-toolbox-ng/internal/sentinel/iocreport.go
+++ b/packages/secubox-toolbox-ng/internal/sentinel/iocreport.go
@@ -55,6 +55,13 @@ func (r *IOCReporter) Analyze(m MirrorMsg) (verdicts []*Verdict) {
 	if ioc, ok := set.MatchDomain(m.Meta.Host); ok && !spywareClasses[ioc.Class] {
 		hits = append(hits, ioc)
 	}
+	// MatchIP is against Host, NOT ClientIP: Host is the DESTINATION (an IP
+	// literal for a direct-IP / no-SNI flow), so it matches a C2-IP IOC
+	// correctly. ClientIP is the client's SOURCE address — matching that
+	// against destination-C2 IP IOCs is a known false-positive vector
+	// (deliberately dropped from the inline gate), so it must NOT be used here.
+	// For an ordinary domain Host, MatchIP simply misses (domains aren't IPs)
+	// and MatchDomain above covers it.
 	if ioc, ok := set.MatchIP(m.Meta.Host); ok && !spywareClasses[ioc.Class] {
 		hits = append(hits, ioc)
 	}

--- a/packages/secubox-toolbox-ng/internal/sentinel/iocreport_test.go
+++ b/packages/secubox-toolbox-ng/internal/sentinel/iocreport_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: LicenseRef-CMSD-1.0
+package sentinel
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func iocReportLoader(t *testing.T, packJSON string) *Loader {
+	t.Helper()
+	base := t.TempDir()
+	if err := os.WriteFile(filepath.Join(base, "p.json"), []byte(packJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	l, err := NewLoader(base, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return l
+}
+
+func TestIOCReporterSurfacesBotnetAsReport(t *testing.T) {
+	// a botnet_c2 domain declared action:block must surface REPORT-only.
+	l := iocReportLoader(t, `{"version":"1","iocs":[
+		{"type":"domain","value":"c2.evil.example","class":"botnet_c2","severity":90,"source":"abuse.ch","action":"block"}]}`)
+	r := NewIOCReporter(l)
+	vs := r.Analyze(MirrorMsg{Meta: FlowMeta{Host: "c2.evil.example", MacHash: "aa"}, TS: 1})
+	if len(vs) != 1 {
+		t.Fatalf("want 1 verdict, got %d", len(vs))
+	}
+	if vs[0].Class != ClassBotnetC2 {
+		t.Errorf("class = %q", vs[0].Class)
+	}
+	if vs[0].Action != ActionReport {
+		t.Errorf("action must be report (daemon observes), got %q", vs[0].Action)
+	}
+	if vs[0].Evidence["disposition"] != "observed" {
+		t.Errorf("disposition must be observed, got %q", vs[0].Evidence["disposition"])
+	}
+}
+
+func TestIOCReporterSkipsSpywareClasses(t *testing.T) {
+	// spyware classes belong to the Spyware analyzer — reporter must not dupe.
+	l := iocReportLoader(t, `{"version":"1","iocs":[
+		{"type":"domain","value":"peg.example","class":"spyware_pegasus","severity":95,"source":"mvt","action":"block"}]}`)
+	r := NewIOCReporter(l)
+	vs := r.Analyze(MirrorMsg{Meta: FlowMeta{Host: "peg.example", MacHash: "aa"}, TS: 1})
+	if len(vs) != 0 {
+		t.Errorf("reporter must skip spyware classes (Spyware analyzer owns them), got %d", len(vs))
+	}
+}
+
+func TestIOCReporterNoMatchNoVerdict(t *testing.T) {
+	l := iocReportLoader(t, `{"version":"1","iocs":[
+		{"type":"domain","value":"c2.evil.example","class":"botnet_c2","severity":90,"source":"x","action":"block"}]}`)
+	r := NewIOCReporter(l)
+	if vs := r.Analyze(MirrorMsg{Meta: FlowMeta{Host: "benign.example", MacHash: "aa"}, TS: 1}); len(vs) != 0 {
+		t.Errorf("benign host must not match, got %d", len(vs))
+	}
+	// nil loader → no panic, no verdicts
+	var rn *IOCReporter
+	if vs := rn.Analyze(MirrorMsg{Meta: FlowMeta{Host: "x", MacHash: "a"}}); vs != nil {
+		t.Error("nil reporter must be a no-op")
+	}
+}

--- a/packages/secubox-toolbox-ng/internal/sentinel/iocreport_test.go
+++ b/packages/secubox-toolbox-ng/internal/sentinel/iocreport_test.go
@@ -64,3 +64,21 @@ func TestIOCReporterNoMatchNoVerdict(t *testing.T) {
 		t.Error("nil reporter must be a no-op")
 	}
 }
+
+func TestIOCReporterMatchesDestinationIP(t *testing.T) {
+	// a bare C2 IP IOC (Feodo-style) matches when the flow's Host IS that IP
+	// (direct-IP / no-SNI). ClientIP is never consulted (source-IP match would
+	// be a false-positive vector).
+	l := iocReportLoader(t, `{"version":"1","iocs":[
+		{"type":"ip","value":"192.0.2.77","class":"botnet_c2","severity":90,"source":"abuse.ch-feodo","action":"block"}]}`)
+	r := NewIOCReporter(l)
+	vs := r.Analyze(MirrorMsg{Meta: FlowMeta{Host: "192.0.2.77", ClientIP: "10.0.0.5", MacHash: "aa"}, TS: 1})
+	if len(vs) != 1 || vs[0].Class != ClassBotnetC2 || vs[0].Action != ActionReport {
+		t.Fatalf("destination-IP C2 must surface report-only, got %+v", vs)
+	}
+	// the client's own source IP must NOT match a destination-C2 IP IOC
+	vs = r.Analyze(MirrorMsg{Meta: FlowMeta{Host: "benign.example", ClientIP: "192.0.2.77", MacHash: "aa"}, TS: 1})
+	if len(vs) != 0 {
+		t.Errorf("client source IP must never match a destination-C2 IP IOC, got %+v", vs)
+	}
+}


### PR DESCRIPTION
## Why

Arming the live threat feeds (abuse.ch ThreatFox/Feodo → `botnet_c2`/`malware` IOCs) surfaced a gap: the daemon's `Spyware` analyzer class-filters to the commercial-spyware classes only, so a device contacting a known ThreatFox/Feodo C2 was recorded by **nothing** (and — with the inline overlay removed for report-only operation — not blocked either). The feeds were armed but invisible.

## What

New daemon analyzer `IOCReporter` (`internal/sentinel/iocreport.go`) correlates the **non-spyware** IOC classes the `Spyware` analyzer skips, as **REPORT-ONLY**:
- matches the same `IOCSet` (domain/ip/ja3/ja4/certsha1/url), skipping `spywareClasses` on every branch (no double-reporting with `Spyware`);
- **forces `Action: ActionReport`** regardless of the IOC's declared `action:block` — the async daemon observes, it never blocks — with `Evidence["disposition"]="observed"` so a feed detection surfaces honestly as *observed*, never *blocked*;
- fail-open (recover → no verdicts; nil loader/receiver no-op), mirrors the `Spyware` analyzer pattern; wired into `buildAnalyzers` on the same loader.

`MatchIP` is against `Host` (the destination, an IP literal for direct-IP/no-SNI flows), **not** `ClientIP` (the client source — matching that against destination-C2 IP IOCs is a known false-positive vector, deliberately avoided; documented + tested).

## Verified live (gk2, toolbox-ng 0.1.32)

Feeds armed report-only (inline gate overlay removed → cannot block; 3868 real IOCs in the overlay). Injected a flow to a real ThreatFox C2 domain → surfaced as:
`botnet_c2 · action=report · disposition=observed · source=abuse.ch-threatfox` — report-only, honest, not blocked.

## Tests

`iocreport_test.go`: botnet→report+observed, spyware-class skipped, no-match/nil no-op, destination-IP matches / client-source-IP does not. `wiring_test.go` updated (pipeline now 4 analyzers). Full `./internal/sentinel/... ./cmd/sbx-sentinel/...` green under `-race`; reviewed.

## Operational notes (follow-ups)

- Feeds run report-only because the **inline worker overlay was removed** (`SENTINEL_OVERLAY_DIR` commented in `toolbox-ng.env`) so the inline gate can't block. Re-adding it would re-enable inline blocking of high-confidence feed IOCs (an operator opt-in).
- MVT (Pegasus) feed URL 404s and SSLBL failed validation — stale feed URLs; the spyware feed needs its URL pinned to surface live Pegasus IOCs.
- `browser-ja4.txt` still empty (non_browser_ja disabled) — populating it needs real captured/referenced JA4s.

Refs #826