### PR TITLE
fix(sentinel): correct MVT/Pegasus feed URL + env-gated JA4 capture infra (ref #826)

### DIFF
--- a/packages/secubox-toolbox-ng/cmd/sbx-sentinel/main.go
+++ b/packages/secubox-toolbox-ng/cmd/sbx-sentinel/main.go
@@ -69,6 +69,10 @@ type Analyzer interface {
 // *sentinel.C2Learner as "endpoints disabled" — fail-safe.
 var c2Learner *sentinel.C2Learner
 
+// ja4Capture is the optional operator JA4 recorder (SENTINEL_JA4_CAPTURE);
+// nil (the default) is a safe no-op. Set in buildAnalyzers.
+var ja4Capture *sentinel.JA4Capture
+
 // Default tuning, overridable via Config for production and tests alike.
 const (
 	defaultTTL           = 72 * time.Hour
@@ -254,6 +258,8 @@ func handleConn(ctx context.Context, conn net.Conn, store *sentinel.Store, analy
 // Verdict's Action (defense in depth against a misbehaving analyzer — see
 // sentinel.FinalizeAction), and records it to store.
 func processMsg(store *sentinel.Store, analyzers []Analyzer, msg sentinel.MirrorMsg) {
+	// Optional operator JA4 capture (SENTINEL_JA4_CAPTURE) — no-op when off.
+	ja4Capture.Observe(msg.Meta.Host, msg.Meta.JA4)
 	for _, a := range analyzers {
 		for _, v := range safeAnalyze(a, msg) {
 			if v == nil {
@@ -370,6 +376,8 @@ func buildAnalyzers(packDir, overlayDir string, yaraRules []string) ([]Analyzer,
 	})
 	analyzers = append(analyzers, c2)
 	c2Learner = c2 // package-level handle for the status mux (see http.go wiring)
+	// Optional operator JA4 capture — off unless SENTINEL_JA4_CAPTURE is set.
+	ja4Capture = sentinel.NewJA4Capture(getenvDefault("SENTINEL_JA4_CAPTURE", ""))
 
 	yara, err := sentinel.NewYaraEngine(yaraRules)
 	if err != nil {

--- a/packages/secubox-toolbox-ng/debian/changelog
+++ b/packages/secubox-toolbox-ng/debian/changelog
@@ -1,3 +1,14 @@
+secubox-toolbox-ng (0.1.33-1~bookworm1) bookworm; urgency=medium
+
+  * #826 fix the MVT/Pegasus feed URL (moved to AmnestyTech/investigations) so
+    the live spyware feed materialises (1438 Pegasus IOCs) — surfaced report-only.
+  * #826 new env-gated JA4 capture (SENTINEL_JA4_CAPTURE=<file>): records
+    observed host<TAB>ja4 pairs from live traffic so an operator can bootstrap
+    the browser-ja4.txt fingerprint set (needed to enable non_browser_ja) from
+    real browser handshakes rather than guessed values. Off by default.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Mon, 07 Jul 2026 16:00:00 +0200
+
 secubox-toolbox-ng (0.1.32-1~bookworm1) bookworm; urgency=medium
 
   * #826 report-only feed surfacing: new daemon IOCReporter analyzer correlates

--- a/packages/secubox-toolbox-ng/debian/sentinel.env
+++ b/packages/secubox-toolbox-ng/debian/sentinel.env
@@ -71,7 +71,7 @@ SENTINEL_C2_BROWSER_JA4=/usr/share/secubox/sentinel/browser-ja4.txt
 SENTINEL_FEED_THREATFOX_URL=https://threatfox.abuse.ch/export/json/recent/
 SENTINEL_FEED_FEODO_URL=https://feodotracker.abuse.ch/downloads/ipblocklist.json
 SENTINEL_FEED_SSLBL_URL=https://sslbl.abuse.ch/blacklist/sslblacklist.csv
-SENTINEL_FEED_MVT_URL=https://raw.githubusercontent.com/mvt-project/mvt-indicators/main/indicators/pegasus.stix2
+SENTINEL_FEED_MVT_URL=https://raw.githubusercontent.com/AmnestyTech/investigations/master/2021-07-18_nso/pegasus.stix2
 # Citizen Lab has no single canonical machine feed — point this at a published
 # STIX 2.x indicator bundle to enable it (empty = skipped).
 SENTINEL_FEED_CITIZENLAB_URL=

--- a/packages/secubox-toolbox-ng/internal/sentinel/ja4capture.go
+++ b/packages/secubox-toolbox-ng/internal/sentinel/ja4capture.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: LicenseRef-CMSD-1.0
+// Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+// Source-Disclosed License — All rights reserved except as expressly granted.
+// See LICENCE-CMSD-1.0.md for terms.
+
+package sentinel
+
+// JA4Capture is an optional, operator-triggered recorder of observed
+// (host, JA4) pairs. The C2 auto-learn "non_browser_ja" signal needs a set of
+// KNOWN-browser JA4 fingerprints to suppress admin-dashboard false positives,
+// but those fingerprints are version-specific and cannot be guessed — the
+// accurate source is the operator's OWN live traffic. Enabling capture
+// (SENTINEL_JA4_CAPTURE=<file>) writes newline-delimited "host<TAB>ja4" for a
+// while; the operator then keeps the fingerprints seen against known browser
+// destinations as browser-ja4.txt. Disabled (empty path) is a zero-cost no-op.
+
+import (
+	"os"
+	"sync"
+)
+
+// ja4CaptureCap bounds the in-memory dedup set (and thus the file) so a
+// long-running capture can never grow without limit.
+const ja4CaptureCap = 20000
+
+type JA4Capture struct {
+	mu   sync.Mutex
+	seen map[string]bool // "host\tja4" keys already written
+	f    *os.File
+}
+
+// NewJA4Capture opens path for append and returns a recorder, or nil (a safe
+// no-op) when path is empty or unopenable — capture must never break the daemon.
+func NewJA4Capture(path string) *JA4Capture {
+	if path == "" {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640)
+	if err != nil {
+		return nil
+	}
+	return &JA4Capture{seen: make(map[string]bool), f: f}
+}
+
+// Observe records one (host, ja4) pair, deduped and bounded. No-op on a nil
+// receiver, empty fields, or once the cap is reached. Never panics.
+func (c *JA4Capture) Observe(host, ja4 string) {
+	if c == nil || host == "" || ja4 == "" {
+		return
+	}
+	key := host + "\t" + ja4
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.seen[key] || len(c.seen) >= ja4CaptureCap {
+		return
+	}
+	c.seen[key] = true
+	_, _ = c.f.WriteString(key + "\n")
+}

--- a/packages/secubox-toolbox-ng/internal/sentinel/ja4capture_test.go
+++ b/packages/secubox-toolbox-ng/internal/sentinel/ja4capture_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LicenseRef-CMSD-1.0
+package sentinel
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestJA4CaptureDedupAndDisabled(t *testing.T) {
+	// disabled (empty path) → nil, and Observe is a safe no-op
+	var off *JA4Capture = NewJA4Capture("")
+	off.Observe("h", "j") // must not panic
+
+	p := filepath.Join(t.TempDir(), "ja4.tsv")
+	c := NewJA4Capture(p)
+	if c == nil {
+		t.Fatal("expected a capture")
+	}
+	c.Observe("news.example", "t13d_browserfp")
+	c.Observe("news.example", "t13d_browserfp") // dup → not written twice
+	c.Observe("cdn.example", "t13d_browserfp")
+	c.Observe("x", "") // empty ja4 → skipped
+	c.Observe("", "y") // empty host → skipped
+	b, _ := os.ReadFile(p)
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 unique lines, got %d: %q", len(lines), string(b))
+	}
+	if !strings.Contains(string(b), "news.example\tt13d_browserfp") {
+		t.Errorf("missing host<TAB>ja4 line: %q", string(b))
+	}
+}

--- a/packages/secubox-toolbox-ng/sbin/secubox-sentinel-feeds
+++ b/packages/secubox-toolbox-ng/sbin/secubox-sentinel-feeds
@@ -40,7 +40,7 @@ OVERLAY_DIR="${SENTINEL_OVERLAY_DIR:-/var/lib/secubox/sentinel/overlay}"
 FEED_THREATFOX_URL="${SENTINEL_FEED_THREATFOX_URL:-https://threatfox.abuse.ch/export/json/recent/}"
 FEED_FEODO_URL="${SENTINEL_FEED_FEODO_URL:-https://feodotracker.abuse.ch/downloads/ipblocklist.json}"
 FEED_SSLBL_URL="${SENTINEL_FEED_SSLBL_URL:-https://sslbl.abuse.ch/blacklist/sslblacklist.csv}"
-FEED_MVT_URL="${SENTINEL_FEED_MVT_URL:-https://raw.githubusercontent.com/mvt-project/mvt-indicators/main/indicators/pegasus.stix2}"
+FEED_MVT_URL="${SENTINEL_FEED_MVT_URL:-https://raw.githubusercontent.com/AmnestyTech/investigations/master/2021-07-18_nso/pegasus.stix2}"
 # Citizen Lab has no single canonical machine feed; operators point this at a
 # published STIX 2.x indicator bundle. Empty by default → skipped (last-good kept).
 FEED_CITIZENLAB_URL="${SENTINEL_FEED_CITIZENLAB_URL:-}"


### PR DESCRIPTION
## What

- **Fix the MVT/Pegasus feed URL.** The default pointed at `mvt-project/mvt-indicators/main/indicators/pegasus.stix2` which 404s (the indicators live in `AmnestyTech/investigations@master/2021-07-18_nso/pegasus.stix2`). Corrected in `debian/sentinel.env` + the feeds script default. Live result on gk2: the MVT feed now materialises **1438 real Amnesty Pegasus IOCs**, surfaced report-only by the daemon's Spyware analyzer.
- **Env-gated JA4 capture** (`SENTINEL_JA4_CAPTURE=<file>`): records observed `host<TAB>ja4` pairs from live traffic so `browser-ja4.txt` can be bootstrapped from real browser handshakes (guessed JA4 hashes are worse than useless). Off by default; bounded + deduped; fail-safe.

## Important finding — JA4 is NOT plumbed into the Sentinel pipeline

Deploying the capture revealed the real blocker for `non_browser_ja` / browser-ja4: sbxmitm's inline hook builds the Sentinel `FlowMeta` with only `Host`/`URL`/`MacHash` (see `cmd/sbxmitm/main.go:479-488` — *"JA4/JA3 … are not plumbed to this shared pipeline"*). JA4 is captured at the TLS handshake but only relayed to the cookies/ja4 sidecar, never to the Sentinel mirror. Consequences:
- The capture records nothing (JA4 always empty in the mirror) — correct behaviour, not a bug in the capture.
- **`non_browser_ja` is inert on real traffic today** regardless of `browser-ja4.txt`; C2 auto-learn currently corroborates on `dga` (and `rare` as support) only.

**Follow-up (real fix):** thread the per-handshake JA4 into the Sentinel `FlowMeta` (connection-scoped JA4 → per-request inspect/mirror). Once that lands, this capture bootstraps `browser-ja4.txt` and `non_browser_ja` becomes live. Tracked, not in this PR (sbxmitm hot-path change + worker redeploy).

## Also noted (not in this PR)

- Spyware feed detections surface with the IOC's `action=block` (policy action) — with inline blocking off they *display* as "blocked" though the daemon only observed. That's the deferred #823 blocker #5 (presentation-layer disposition honesty); the new `IOCReporter` already labels non-spyware feeds "observed".

## Tests

`ja4capture_test.go` (dedup/disabled/skip-empty). Full `./internal/sentinel/... ./cmd/sbx-sentinel/...` green under `-race`. Deployed + verified live (gk2 toolbox-ng 0.1.33): MVT feed loads 1438 IOCs; capture correctly records nothing (JA4 absent from mirror).

Refs #826