### PR TITLE
feat(billets): admin password reset + guideline reskin + doc

### DIFF
--- a/.claude/WEBUI-PANEL-GUIDELINES.md
+++ b/.claude/WEBUI-PANEL-GUIDELINES.md
@@ -1,15 +1,28 @@
 # SecuBox WebUI Panel Guidelines
 
-*Version 1.0 — 2026-07-10 · reference implementations: `/certs/` and `/wireguard/`*
+*Version 1.1 — 2026-07-12 · reference implementations: `/certs/`, `/wireguard/`, `/billets/`*
 
-The look-and-feel every admin panel (`admin.gk2.secubox.in/<module>/`) must follow.
-This is the **cyan "hybrid-dark" terminal** convention — a single self-contained
-`index.html` per module, dark glass + Courier Prime + emoji-guided density. It is
-distinct from the C3BOX hermetic charter (`DESIGN-CHARTER.md`, Cinzel/gold): admin
-panels use THIS.
+**This is the canonical, DEFAULT look-and-feel for all SecuBox webui module
+management.** Every admin panel (`admin.gk2.secubox.in/<module>/`) and every
+module's own admin interface MUST follow it: the **cyan "hybrid-dark" terminal**
+convention — dark glass + **Courier Prime** + **cyan `#00d4ff`** as the single
+accent + emoji-guided density. It is distinct from the C3BOX hermetic charter
+(`DESIGN-CHARTER.md`, Cinzel/gold): admin panels use THIS.
 
 Canonical examples to copy from: `packages/secubox-certs/www/certs/index.html`
-and `packages/secubox-wireguard/www/wireguard/index.html`.
+(the reference), `packages/secubox-wireguard/www/wireguard/index.html`, and
+`packages/secubox-billets/` (`www/billets/index.html` panel + `api/static/billets-admin.css`).
+
+### Two variants (same palette/typography/emoji)
+
+- **Aggregator-hosted panel** (`admin.gk2/<module>/`): link `/shared/hybrid-dark.css`
+  + `/shared/sidebar.js`, body `class="hybrid-dark"`, then the `:root` palette
+  from §2 (e.g. `/billets/` panel).
+- **Self-contained module vhost** (a module served on its OWN vhost, no `/shared/`,
+  e.g. `billets.gk2/admin`): inline the SAME `:root` palette + Courier Prime + the
+  component classes in a local stylesheet (`billets-admin.css`), no shared sidebar
+  — the module supplies its own top nav in the same style. **Same tokens, same
+  emoji, same components — just self-hosted.**
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@
 |---------|-------------|------------|
 | `docs/TOOLS.md` | Référence outils build/génération | Pour builder |
 | `.claude/QUICKSHEET-REFERENCE.md` | Quick ref commandes | Pour commandes |
-| `.claude/DESIGN-CHARTER.md` | Charte UI/UX | Pour frontend |
+| `.claude/DESIGN-CHARTER.md` | Charte UI/UX (C3BOX hermétique) | Pour frontend |
+| `.claude/WEBUI-PANEL-GUIDELINES.md` | **Look & feel DÉFAUT des webui de gestion des modules** (cyan hybrid-dark, Courier Prime, emoji ; réf. `/certs/`) | Avant tout panel/admin webui |
 | `.claude/WIKI-STYLE-GUIDE.md` | Style documentation | Pour docs |
 | `.claude/NOTES.md` | Notes de session | Pour contexte additionnel |
 

--- a/packages/secubox-billets/api/repo.py
+++ b/packages/secubox-billets/api/repo.py
@@ -124,6 +124,11 @@ async def get_author_by_id(conn: aiosqlite.Connection, author_id: str) -> Option
         return await cur.fetchone()
 
 
+async def update_password(conn: aiosqlite.Connection, author_id: str, password_hash: str) -> None:
+    await conn.execute("UPDATE author SET password_hash=? WHERE id=?", (password_hash, author_id))
+    await conn.commit()
+
+
 # ── admin billet mutations ─────────────────────────────────────────────────
 async def list_all(conn: aiosqlite.Connection, *, status: Optional[str] = None,
                    limit: int = 100) -> list[aiosqlite.Row]:

--- a/packages/secubox-billets/api/routes/admin.py
+++ b/packages/secubox-billets/api/routes/admin.py
@@ -295,3 +295,27 @@ def register_admin(app: FastAPI, templates: Jinja2Templates) -> None:
                 conn, "comment.approved" if decision == "approve" else "comment.rejected",
                 {"id": comment_id, "by": author["username"]}, ts=_now(request))
         return _redirect("/admin/comments")
+
+    @app.post("/admin/password")
+    async def change_password(request: Request, current: str = Form(...),
+                              new_password: str = Form(...), confirm: str = Form(""),
+                              csrf: str = Form("")):
+        author = await _current_author(request)
+        if author is None:
+            return _redirect("/admin/login")
+        if not sec.csrf_ok(request.cookies.get(CSRF_COOKIE), csrf):
+            return _redirect("/admin/login?error=csrf")
+        if len(new_password) < 10 or new_password != confirm:
+            return _redirect("/admin?pw=invalid")
+        ok = await asyncio.to_thread(sec.verify_password, author["password_hash"], current)
+        if not ok:
+            return _redirect("/admin?pw=bad")
+        new_hash = await asyncio.to_thread(sec.hash_password, new_password)
+        await repo.update_password(request.app.state.conn, author["id"], new_hash)
+        await eventlog.append_event(request.app.state.conn, "author.password_changed",
+                                    {"id": author["id"]}, ts=_now(request))
+        # Force re-login with the new password (this device); other sessions
+        # expire at the 12h cap.
+        resp = _redirect("/admin/login?pw=changed")
+        resp.delete_cookie(SESSION_COOKIE, path="/")
+        return resp

--- a/packages/secubox-billets/api/services/eventlog.py
+++ b/packages/secubox-billets/api/services/eventlog.py
@@ -21,7 +21,7 @@ _DIGEST_SIZE = 32
 EVENT_TYPES = frozenset({
     "billet.published", "billet.edited", "billet.deleted",
     "comment.approved", "comment.rejected", "comment.created",
-    "author.login", "author.login_failed",
+    "author.login", "author.login_failed", "author.password_changed",
 })
 
 

--- a/packages/secubox-billets/api/static/billets-admin.css
+++ b/packages/secubox-billets/api/static/billets-admin.css
@@ -1,0 +1,100 @@
+/* SPDX-License-Identifier: LicenseRef-CMSD-1.0 */
+/* billets admin — SecuBox WebUI Panel Guidelines (cyan hybrid-dark terminal).
+   Self-contained (the billets vhost has no /shared/); palette copied verbatim
+   from .claude/WEBUI-PANEL-GUIDELINES.md §2. */
+:root{
+  --p31-dim:#6b7b8b; --bg-dark:#0d1117; --bg-card:rgba(30,40,55,.8);
+  --bg-row:rgba(20,30,45,.6); --border:rgba(100,150,200,.2); --text:#e8e6d9;
+  --cyan:#00d4ff; --red:#ff4466; --orange:#ff9944; --yellow:#ffcc00;
+  --green:#00dd44; --blue:#4488ff; --purple:#a371f7;
+}
+*{box-sizing:border-box}
+body{font-family:'Courier Prime',monospace;background:var(--bg-dark);color:var(--text);
+  margin:0;min-height:100vh;
+  background-image:linear-gradient(135deg,rgba(10,15,25,.96),rgba(15,25,40,.92))}
+.wrap{max-width:60rem;margin:0 auto;padding:1.4rem 1.2rem 4rem}
+a{color:var(--cyan);text-decoration:none}
+
+/* header */
+.header{display:flex;align-items:center;gap:.8rem;flex-wrap:wrap;
+  padding:.8rem 0 1rem;border-bottom:1px solid var(--border);margin-bottom:1.2rem}
+.header h1{margin:0;font-size:1.4rem;color:var(--cyan);text-shadow:0 0 10px var(--cyan);font-weight:700}
+.header .sub{color:var(--p31-dim);font-size:.72rem;letter-spacing:.06em}
+.header .btn-group{margin-left:auto;display:flex;gap:.5rem;flex-wrap:wrap}
+.nav{display:flex;gap:.5rem;flex-wrap:wrap;margin:.2rem 0 1.2rem}
+
+/* buttons */
+.btn{font-family:'Courier Prime',monospace;text-transform:uppercase;font-size:.72rem;
+  letter-spacing:.05em;padding:.45rem .85rem;border-radius:6px;border:1px solid var(--border);
+  background:var(--bg-card);color:var(--text);cursor:pointer;transition:all .18s;text-decoration:none;
+  display:inline-flex;align-items:center;gap:.35rem}
+.btn:hover{border-color:var(--cyan);color:var(--cyan);box-shadow:0 0 8px rgba(0,212,255,.3)}
+.btn.primary{background:rgba(0,212,255,.15);border-color:var(--cyan);color:var(--cyan)}
+.btn.danger{background:rgba(255,68,102,.15);border-color:var(--red);color:var(--red)}
+.btn.danger:hover{box-shadow:0 0 8px rgba(255,68,102,.35)}
+.btn.good{background:rgba(0,221,68,.13);border-color:var(--green);color:var(--green)}
+.btn:disabled{opacity:.5;cursor:not-allowed}
+
+/* cards */
+.card{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;
+  padding:1.1rem 1.2rem;margin-bottom:1rem;backdrop-filter:blur(10px)}
+.card h3{margin:0 0 .7rem;color:var(--cyan);font-size:.95rem;letter-spacing:.03em}
+
+/* stat grid */
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:.7rem;margin-bottom:1.2rem}
+.stat-card{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;
+  padding:.7rem;text-align:center;backdrop-filter:blur(5px)}
+.stat-card .value{font-size:1.7rem;font-weight:700;font-variant-numeric:tabular-nums;
+  text-shadow:0 0 10px currentColor}
+.stat-card .label{font-size:.6rem;color:var(--p31-dim);letter-spacing:.1em;text-transform:uppercase;margin-top:.2rem}
+.stat-card.cyan .value{color:var(--cyan)} .stat-card.green .value{color:var(--green)}
+.stat-card.orange .value{color:var(--orange)} .stat-card.purple .value{color:var(--purple)}
+.stat-card.blue .value{color:var(--blue)}
+
+/* forms */
+.form-group{display:flex;flex-direction:column;gap:.3rem;margin-bottom:.8rem}
+label{font-size:.68rem;color:var(--p31-dim);letter-spacing:.06em;text-transform:uppercase}
+input,textarea,select{font-family:'Courier Prime',monospace;background:var(--bg-row);
+  border:1px solid var(--border);border-radius:6px;color:var(--text);padding:.55rem .65rem;font-size:.85rem}
+input:focus,textarea:focus{outline:none;border-color:var(--cyan);box-shadow:0 0 6px rgba(0,212,255,.25)}
+.form-actions{display:flex;gap:.5rem;flex-wrap:wrap;margin-top:.4rem}
+
+/* lists (billets / comments) */
+.item{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:.6rem;
+  padding:.5rem .7rem;background:var(--bg-row);border-radius:5px;margin-bottom:.45rem;
+  border-left:3px solid var(--border);transition:all .15s}
+.item:hover{background:rgba(0,212,255,.08);transform:translateX(2px)}
+.item.published{border-left-color:var(--green)}
+.item.draft{border-left-color:var(--p31-dim)}
+.item.archived{border-left-color:var(--orange)}
+.item .title{color:var(--cyan);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.item .meta{color:var(--p31-dim);font-size:.7rem}
+.item .row-actions{display:flex;gap:.35rem;align-items:center}
+.pill{font-size:.6rem;padding:.12rem .5rem;border-radius:999px;border:1px solid var(--border);
+  text-transform:uppercase;letter-spacing:.06em}
+.pill.published{color:var(--green);border-color:var(--green)}
+.pill.draft{color:var(--p31-dim)} .pill.archived{color:var(--orange);border-color:var(--orange)}
+
+/* comment blocks */
+.comment{background:var(--bg-row);border:1px solid var(--border);border-radius:6px;
+  border-left:3px solid var(--yellow);padding:.6rem .8rem;margin-bottom:.6rem}
+.comment .c-meta{font-size:.72rem;color:var(--p31-dim);margin:0 0 .3rem}
+.comment .c-body{margin:0;font-size:.85rem}
+.mod-actions{display:flex;gap:.5rem;margin-top:.4rem}
+
+/* flashes */
+.flash{padding:.55rem .9rem;border-radius:6px;margin-bottom:1rem;font-size:.8rem;
+  border:1px solid var(--border);background:var(--bg-card)}
+.flash.ok{border-color:var(--green);color:var(--green)}
+.flash.err{border-color:var(--red);color:var(--red)}
+.hp{position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden}
+.muted{color:var(--p31-dim)}
+
+/* login */
+.login-wrap{max-width:24rem;margin:6vh auto 0}
+.login-wrap .brand{text-align:center;margin-bottom:1.4rem}
+.login-wrap .brand .logo{font-size:2.4rem}
+.login-wrap .brand h1{color:var(--cyan);text-shadow:0 0 12px var(--cyan);font-size:1.5rem;margin:.3rem 0 0}
+.login-wrap .brand .sub{color:var(--p31-dim);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase}
+
+@media(max-width:600px){.wrap{padding:1rem .7rem}.item{grid-template-columns:auto 1fr}.item .row-actions{grid-column:1/-1;justify-content:flex-end}}

--- a/packages/secubox-billets/api/templates/admin_comments.html
+++ b/packages/secubox-billets/api/templates/admin_comments.html
@@ -1,27 +1,32 @@
 <!DOCTYPE html>
 <html lang="fr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>billets — modération</title><link rel="stylesheet" href="/static/billets.css">
+<title>SecuBox — Billets · modération</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/billets-admin.css?v=1">
 </head><body>
-<header class="site-header"><a class="site-title" href="/admin">billets</a>
-  <span class="tagline">modération · {{ pending|length }} en attente</span></header>
-<main>
-<p><a href="/admin">← tableau de bord</a></p>
-{% for c in pending %}
-<article class="comment mod">
-  <p class="c-meta"><strong>{{ c.author_name }}</strong>
-    <time datetime="{{ c.created_at }}">{{ c.created_at[:19]|replace('T',' ') }}</time></p>
-  <p class="c-body">{{ c.body }}</p>
-  <div class="mod-actions">
-    <form method="post" action="/admin/comments/{{ c.id }}/moderate">
-      <input type="hidden" name="csrf" value="{{ csrf }}">
-      <button type="submit" name="decision" value="approve">Approuver</button>
-    </form>
-    <form method="post" action="/admin/comments/{{ c.id }}/moderate">
-      <input type="hidden" name="csrf" value="{{ csrf }}">
-      <button type="submit" name="decision" value="reject" class="danger">Rejeter</button>
-    </form>
+<div class="wrap">
+  <header class="header">
+    <div><h1>💬 Modération</h1><div class="sub">📮 billets · {{ pending|length }} en attente ⏳</div></div>
+    <div class="btn-group"><a class="btn" href="/admin">← Tableau de bord</a></div>
+  </header>
+  <div class="card">
+    {% for c in pending %}
+    <article class="comment">
+      <p class="c-meta">🙂 <strong>{{ c.author_name }}</strong>
+        · <time datetime="{{ c.created_at }}">{{ c.created_at[:19]|replace('T',' ') }}</time></p>
+      <p class="c-body">{{ c.body }}</p>
+      <div class="mod-actions">
+        <form method="post" action="/admin/comments/{{ c.id }}/moderate">
+          <input type="hidden" name="csrf" value="{{ csrf }}">
+          <button type="submit" name="decision" value="approve" class="btn good">✅ Approuver</button></form>
+        <form method="post" action="/admin/comments/{{ c.id }}/moderate">
+          <input type="hidden" name="csrf" value="{{ csrf }}">
+          <button type="submit" name="decision" value="reject" class="btn danger">🚫 Rejeter</button></form>
+      </div>
+    </article>
+    {% else %}<p class="muted">🎉 Aucun commentaire en attente.</p>{% endfor %}
   </div>
-</article>
-{% else %}<p class="empty">Aucun commentaire en attente.</p>{% endfor %}
-</main></body></html>
+</div>
+</body></html>

--- a/packages/secubox-billets/api/templates/admin_dash.html
+++ b/packages/secubox-billets/api/templates/admin_dash.html
@@ -1,39 +1,69 @@
 <!DOCTYPE html>
 <html lang="fr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>billets — admin</title><link rel="stylesheet" href="/static/billets.css">
+<title>SecuBox — Billets · admin</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/billets-admin.css?v=1">
 </head><body>
-<header class="site-header">
-  <span class="site-title">billets</span><span class="tagline">admin · {{ author.username }}</span>
-  <form method="post" action="/admin/logout" style="margin-left:auto">
-    <input type="hidden" name="csrf" value="{{ csrf }}"><button type="submit">Déconnexion</button>
-  </form>
-</header>
-<main>
-<p><a href="/admin/billets/new">+ Nouveau billet</a> ·
-  <a href="/admin/comments">Modération commentaires</a> ·
-  filtres : <a href="/admin">tous</a>
-  <a href="/admin?status=draft">brouillons</a>
-  <a href="/admin?status=published">publiés</a>
-  <a href="/admin?status=archived">archivés</a></p>
-<table class="admin-list">
-  <thead><tr><th>Statut</th><th>Billet</th><th>Vues</th><th>Actions</th></tr></thead>
-  <tbody>
-  {% for b in billets %}
-  <tr>
-    <td><span class="pill {{ b.status }}">{{ b.status }}</span></td>
-    <td><a href="/admin/billets/{{ b.id }}/edit">{{ b.body[:60] }}</a></td>
-    <td>{{ b.view_count }}</td>
-    <td class="row-actions">
-      <a href="/b/{{ b.slug }}">voir</a>
-      <form method="post" action="/admin/billets/{{ b.id }}/delete"
-            onsubmit="return confirm('Supprimer ce billet ?')">
-        <input type="hidden" name="csrf" value="{{ csrf }}">
-        <button type="submit" class="danger">suppr</button>
-      </form>
-    </td>
-  </tr>
-  {% else %}<tr><td colspan="4" class="empty">Aucun billet.</td></tr>{% endfor %}
-  </tbody>
-</table>
-</main></body></html>
+<div class="wrap">
+  <header class="header">
+    <div><h1>📮 Billets</h1><div class="sub">🔐 admin · {{ author.username }}</div></div>
+    <div class="btn-group">
+      <a class="btn" href="/" target="_blank">🌐 Voir le blog</a>
+      <form method="post" action="/admin/logout"><input type="hidden" name="csrf" value="{{ csrf }}">
+        <button type="submit" class="btn danger">⏻ Déconnexion</button></form>
+    </div>
+  </header>
+
+  {% set pw = request.query_params.get('pw') %}
+  {% if pw == 'bad' %}<p class="flash err">❌ Mot de passe actuel incorrect.</p>
+  {% elif pw == 'invalid' %}<p class="flash err">❌ Nouveau mot de passe trop court (min 10) ou non confirmé.</p>{% endif %}
+
+  <div class="grid">
+    <div class="stat-card green"><div class="value">{{ billets|selectattr('status','equalto','published')|list|length }}</div><div class="label">📝 Publiés</div></div>
+    <div class="stat-card cyan"><div class="value">{{ billets|selectattr('status','equalto','draft')|list|length }}</div><div class="label">📄 Brouillons</div></div>
+    <div class="stat-card orange"><div class="value">{{ billets|selectattr('status','equalto','archived')|list|length }}</div><div class="label">🗄️ Archivés</div></div>
+    <div class="stat-card purple"><div class="value">{{ billets|length }}</div><div class="label">📮 Total</div></div>
+  </div>
+
+  <div class="nav">
+    <a class="btn primary" href="/admin/billets/new">✍️ Nouveau billet</a>
+    <a class="btn" href="/admin/comments">💬 Modération commentaires</a>
+    <a class="btn" href="/admin">📋 Tous</a>
+    <a class="btn" href="/admin?status=draft">📄 Brouillons</a>
+    <a class="btn" href="/admin?status=published">📝 Publiés</a>
+    <a class="btn" href="/admin?status=archived">🗄️ Archivés</a>
+  </div>
+
+  <div class="card">
+    <h3>📋 Billets</h3>
+    {% for b in billets %}
+    <div class="item {{ b.status }}">
+      <span class="pill {{ b.status }}">{{ b.status }}</span>
+      <a class="title" href="/admin/billets/{{ b.id }}/edit">{{ b.body[:64] }}</a>
+      <div class="row-actions">
+        <span class="meta">👁️ {{ b.view_count }}</span>
+        <a class="btn sm" href="/b/{{ b.slug }}" target="_blank">🌐</a>
+        <form method="post" action="/admin/billets/{{ b.id }}/delete" onsubmit="return confirm('🗑️ Supprimer ce billet ?')">
+          <input type="hidden" name="csrf" value="{{ csrf }}"><button type="submit" class="btn danger sm">🗑️</button></form>
+      </div>
+    </div>
+    {% else %}<p class="muted">Aucun billet — ✍️ créez le premier.</p>{% endfor %}
+  </div>
+
+  <div class="card">
+    <h3>🔑 Changer le mot de passe</h3>
+    <form method="post" action="/admin/password">
+      <input type="hidden" name="csrf" value="{{ csrf }}">
+      <div class="form-group"><label>Mot de passe actuel</label>
+        <input type="password" name="current" autocomplete="current-password" required></div>
+      <div class="form-group"><label>Nouveau (min 10 caractères)</label>
+        <input type="password" name="new_password" autocomplete="new-password" minlength="10" required></div>
+      <div class="form-group"><label>Confirmer</label>
+        <input type="password" name="confirm" autocomplete="new-password" minlength="10" required></div>
+      <div class="form-actions"><button type="submit" class="btn primary">🔐 Mettre à jour</button></div>
+    </form>
+  </div>
+</div>
+</body></html>

--- a/packages/secubox-billets/api/templates/admin_edit.html
+++ b/packages/secubox-billets/api/templates/admin_edit.html
@@ -1,34 +1,46 @@
 <!DOCTYPE html>
 <html lang="fr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>billets — {{ 'éditer' if billet else 'nouveau' }}</title>
-<link rel="stylesheet" href="/static/billets.css">
+<title>SecuBox — Billets · {{ 'éditer' if billet else 'nouveau' }}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/billets-admin.css?v=1">
 </head><body>
-<header class="site-header"><a class="site-title" href="/admin">billets</a><span class="tagline">éditeur</span></header>
-<main>
-{% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
-<form method="post" action="{{ '/admin/billets/' ~ billet.id if billet else '/admin/billets' }}" class="admin-form">
-  <input type="hidden" name="csrf" value="{{ csrf }}">
-  <label>Billet (markdown restreint)
-    <textarea name="body" rows="8" required>{{ billet.body if billet else '' }}</textarea></label>
-  <label>URL (référence ou embed)
-    <input name="url" type="url" placeholder="https://…"
-           value="{{ (billet.embed_url or billet.ref_url) if billet else '' }}"></label>
-  <fieldset class="url-kind">
-    <label><input type="radio" name="url_kind" value="ref"
-      {{ 'checked' if not billet or not billet.embed_url else '' }}> référence</label>
-    <label><input type="radio" name="url_kind" value="embed"
-      {{ 'checked' if billet and billet.embed_url else '' }}> embed</label>
-  </fieldset>
-  <div class="editor-actions">
-    {% if billet %}
-      <button type="submit" name="action" value="save">Enregistrer</button>
-      <button type="submit" name="action" value="publish">Publier</button>
-      <button type="submit" name="action" value="archive">Archiver</button>
-    {% else %}
-      <button type="submit" name="action" value="draft">Brouillon</button>
-      <button type="submit" name="action" value="publish">Publier</button>
-    {% endif %}
+<div class="wrap">
+  <header class="header">
+    <div><h1>{{ '✏️ Éditer' if billet else '✍️ Nouveau billet' }}</h1>
+      <div class="sub">📮 billets · éditeur</div></div>
+    <div class="btn-group"><a class="btn" href="/admin">← Tableau de bord</a></div>
+  </header>
+  {% if error %}<p class="flash err">❌ {{ error }}</p>{% endif %}
+  <div class="card">
+    <form method="post" action="{{ '/admin/billets/' ~ billet.id if billet else '/admin/billets' }}">
+      <input type="hidden" name="csrf" value="{{ csrf }}">
+      <div class="form-group"><label>📝 Billet (markdown restreint)</label>
+        <textarea name="body" rows="8" required>{{ billet.body if billet else '' }}</textarea></div>
+      <div class="form-group"><label>🔗 URL (référence ou embed)</label>
+        <input name="url" type="url" placeholder="https://…"
+               value="{{ (billet.embed_url or billet.ref_url) if billet else '' }}"></div>
+      <div class="form-group"><label>Type de lien</label>
+        <div class="form-actions">
+          <label class="muted"><input type="radio" name="url_kind" value="ref"
+            {{ 'checked' if not billet or not billet.embed_url else '' }}> 🌐 référence</label>
+          <label class="muted"><input type="radio" name="url_kind" value="embed"
+            {{ 'checked' if billet and billet.embed_url else '' }}> 🎬 embed média</label>
+        </div></div>
+      <div class="form-actions">
+        {% if billet %}
+          <button type="submit" name="action" value="save" class="btn">💾 Enregistrer</button>
+          <button type="submit" name="action" value="publish" class="btn primary">🚀 Publier</button>
+          <button type="submit" name="action" value="archive" class="btn">🗄️ Archiver</button>
+          {% if billet.embed_url %}
+          <button type="submit" name="action" value="save" class="btn" formaction="/admin/billets/{{ billet.id }}/refetch">🔄 Re-fetch embed</button>{% endif %}
+        {% else %}
+          <button type="submit" name="action" value="draft" class="btn">📄 Brouillon</button>
+          <button type="submit" name="action" value="publish" class="btn primary">🚀 Publier</button>
+        {% endif %}
+      </div>
+    </form>
   </div>
-</form>
-</main></body></html>
+</div>
+</body></html>

--- a/packages/secubox-billets/api/templates/admin_login.html
+++ b/packages/secubox-billets/api/templates/admin_login.html
@@ -1,16 +1,34 @@
 <!DOCTYPE html>
 <html lang="fr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>billets — connexion</title><link rel="stylesheet" href="/static/billets.css">
+<title>SecuBox — Billets · connexion</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/static/billets-admin.css?v=1">
 </head><body>
-<header class="site-header"><span class="site-title">billets</span><span class="tagline">admin</span></header>
-<main>
-{% if error %}<p class="error" role="alert">Échec : {{ error }}</p>{% endif %}
-<form method="post" action="/admin/login" class="admin-form">
-  <input type="hidden" name="csrf" value="{{ csrf }}">
-  <label>Utilisateur<input name="username" autocomplete="username" required autofocus></label>
-  <label>Mot de passe<input type="password" name="password" autocomplete="current-password" required></label>
-  <label>Code TOTP (si activé)<input name="totp" inputmode="numeric" autocomplete="one-time-code"></label>
-  <button type="submit">Se connecter</button>
-</form>
-</main></body></html>
+<div class="login-wrap">
+  <div class="brand">
+    <div class="logo">📮</div>
+    <h1>Billets</h1>
+    <div class="sub">🔐 admin · micro-blog gateway</div>
+  </div>
+  {% if request.query_params.get('pw') == 'changed' %}<p class="flash ok">✅ Mot de passe changé — reconnectez-vous.</p>{% endif %}
+  {% if error %}<p class="flash err">
+    {%- if error == 'bad' %}❌ Identifiants invalides.
+    {%- elif error == 'csrf' %}🛡️ Jeton CSRF invalide.
+    {%- elif error == 'ratelimit' %}⏳ Trop de tentatives — réessayez plus tard.
+    {%- else %}❌ Échec : {{ error }}{% endif %}</p>{% endif %}
+  <div class="card">
+    <form method="post" action="/admin/login">
+      <input type="hidden" name="csrf" value="{{ csrf }}">
+      <div class="form-group"><label>👤 Utilisateur</label>
+        <input name="username" autocomplete="username" required autofocus></div>
+      <div class="form-group"><label>🔑 Mot de passe</label>
+        <input type="password" name="password" autocomplete="current-password" required></div>
+      <div class="form-group"><label>🔢 Code TOTP (si activé)</label>
+        <input name="totp" inputmode="numeric" autocomplete="one-time-code"></div>
+      <div class="form-actions"><button type="submit" class="btn primary">➡️ Se connecter</button></div>
+    </form>
+  </div>
+</div>
+</body></html>

--- a/packages/secubox-billets/tests/test_admin.py
+++ b/packages/secubox-billets/tests/test_admin.py
@@ -190,3 +190,36 @@ async def test_totp_enforced_when_enrolled(admin, conn):
     # right password + right code -> success
     r2 = await _login(c, totp=pyotp.TOTP(secret).now())
     assert r2.headers["location"] == "/admin"
+
+
+async def test_change_password_forces_relogin(admin):
+    c, conn, _ = admin
+    await _login(c)
+    csrf = c.cookies.get("billets_csrf")
+    r = await c.post("/admin/password", data={"current": PW, "new_password": "NewSecret-2026x",
+                                              "confirm": "NewSecret-2026x", "csrf": csrf})
+    assert r.status_code == 303 and "pw=changed" in r.headers["location"]
+    assert not c.cookies.get("billets_session")           # logged out
+    assert (await _login(c, password=PW)).headers["location"].endswith("error=bad")   # old ko
+    assert (await _login(c, password="NewSecret-2026x")).headers["location"] == "/admin"  # new ok
+    async with conn.execute("SELECT COUNT(*) FROM event_log WHERE event_type='author.password_changed'") as cur:
+        assert (await cur.fetchone())[0] == 1
+
+
+async def test_change_password_wrong_current(admin):
+    c, conn, _ = admin
+    await _login(c)
+    csrf = c.cookies.get("billets_csrf")
+    r = await c.post("/admin/password", data={"current": "nope", "new_password": "NewSecret-2026x",
+                                              "confirm": "NewSecret-2026x", "csrf": csrf})
+    assert "pw=bad" in r.headers["location"]
+    assert c.cookies.get("billets_session")               # still logged in
+
+
+async def test_change_password_mismatch_rejected(admin):
+    c, conn, _ = admin
+    await _login(c)
+    csrf = c.cookies.get("billets_csrf")
+    r = await c.post("/admin/password", data={"current": PW, "new_password": "NewSecret-2026x",
+                                              "confirm": "different", "csrf": csrf})
+    assert "pw=invalid" in r.headers["location"]

--- a/packages/secubox-billets/www/billets/index.html
+++ b/packages/secubox-billets/www/billets/index.html
@@ -4,25 +4,27 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>📮 Billets — SecuBox</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/shared/hybrid-dark.css">
 <style>
-  :root{ --b1:#6e40c9; --b2:#e63946; --b3:#00d4ff; --b4:#c9a84c; --ink:#e8e6d9; }
+  :root{ --b1:#00d4ff; --b2:#4488ff; --b3:#00d4ff; --b4:#c9a84c; --ink:#e8e6d9; }
+  body{font-family:'Courier Prime',monospace}
   .billets-wrap{max-width:1000px;margin:0 auto;padding:1rem 1rem 4rem}
   /* HERO */
   .hero{position:relative;overflow:hidden;border-radius:22px;padding:2.4rem 2rem;
-    background:linear-gradient(120deg,#1b1030,#241436 40%,#101b28);
+    background:linear-gradient(120deg,#0d1b28,#10222f 40%,#0d1420);
     border:1px solid rgba(110,64,201,.4);box-shadow:0 20px 60px rgba(0,0,0,.45)}
   .hero h1{margin:0;font-size:2.9rem;font-weight:800;letter-spacing:-.02em;
-    background:linear-gradient(90deg,#b98bff,#6e40c9 40%,#00d4ff);-webkit-background-clip:text;
+    background:linear-gradient(90deg,#7fe9ff,#00d4ff 40%,#4488ff);-webkit-background-clip:text;
     background-clip:text;color:transparent}
-  .hero p{margin:.4rem 0 0;color:#b8b0d8;font-size:1.05rem}
+  .hero p{margin:.4rem 0 0;color:#8fb3c8;font-size:1.05rem}
   .emoji-strip{margin-top:1rem;font-size:1.7rem;letter-spacing:.35rem}
   .emoji-strip span{display:inline-block;animation:bob 3s ease-in-out infinite}
   .emoji-strip span:nth-child(2n){animation-delay:.4s}
   .emoji-strip span:nth-child(3n){animation-delay:.8s}
   @keyframes bob{0%,100%{transform:translateY(0) rotate(0)}50%{transform:translateY(-9px) rotate(-6deg)}}
   .hero .blob{position:absolute;border-radius:50%;filter:blur(42px);opacity:.5;z-index:0}
-  .hero .blob.a{width:220px;height:220px;background:#6e40c9;top:-70px;right:-40px}
+  .hero .blob.a{width:220px;height:220px;background:#00d4ff;top:-70px;right:-40px}
   .hero .blob.b{width:180px;height:180px;background:#00d4ff;bottom:-70px;left:20%}
   .hero>*{position:relative;z-index:1}
   /* STAT CARDS */
@@ -31,7 +33,7 @@
     padding:1.1rem;text-align:center;transition:transform .18s,border-color .18s}
   .card:hover{transform:translateY(-4px);border-color:rgba(0,212,255,.5)}
   .card .big{font-size:2.2rem;font-weight:800;color:var(--ink);font-variant-numeric:tabular-nums}
-  .card .lab{color:#9a93b8;font-size:.82rem;margin-top:.2rem}
+  .card .lab{color:#7fa8c0;font-size:.82rem;margin-top:.2rem}
   .card .em{font-size:1.5rem}
   /* REACTION BAR */
   .reacts{display:flex;flex-wrap:wrap;gap:.5rem;margin:.2rem 0 1.4rem}
@@ -42,7 +44,7 @@
   .actions{display:flex;flex-wrap:wrap;gap:.7rem;margin:1.2rem 0}
   .btn{display:inline-flex;align-items:center;gap:.5rem;text-decoration:none;font-weight:700;
     padding:.7rem 1.15rem;border-radius:12px;border:1px solid transparent;cursor:pointer;font-size:.98rem}
-  .btn.p{background:linear-gradient(120deg,#6e40c9,#8b5cf6);color:#fff}
+  .btn.p{background:linear-gradient(120deg,#00d4ff,#4488ff);color:#0d1117}
   .btn.s{background:rgba(255,255,255,.05);border-color:rgba(255,255,255,.14);color:var(--ink)}
   .btn:hover{transform:translateY(-2px);box-shadow:0 10px 26px rgba(110,64,201,.35)}
   /* LATEST */


### PR DESCRIPTION
Password-reset in the billets admin webui (verify current, argon2, event-logged, forces re-login — live-verified). Billets admin + /billets/ panel reskinned to the SecuBox WebUI Panel Guidelines (Courier Prime, cyan #00d4ff, glass, emoji; certs as reference; public blog stays funky). New self-contained billets-admin.css. Docs: WEBUI-PANEL-GUIDELINES v1.1 as the canonical default + CLAUDE.md pointer. 93 tests.