### PR TITLE
fix(spiderfoot): nginx duplicate proxy_read_timeout (deploy fix, #845)

### DIFF
--- a/packages/secubox-spiderfoot/nginx/spiderfoot.conf
+++ b/packages/secubox-spiderfoot/nginx/spiderfoot.conf
@@ -47,6 +47,15 @@ location /spiderfoot-ui/ {
     auth_request /__sbx_auth_verify;
     error_page 401 = @sbx_auth_login;
     proxy_pass http://10.100.0.43:5001/;
-    include /etc/nginx/snippets/secubox-proxy.conf;
+    # Headers set inline (NOT the secubox-proxy snippet) so we can override
+    # proxy_read_timeout for long SpiderFoot scans without a duplicate directive.
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Authorization $http_authorization;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "";
     proxy_read_timeout 300s;
 }


### PR DESCRIPTION
Follow-up to #846: the /spiderfoot-ui/ location included secubox-proxy.conf AND set proxy_read_timeout 300s → duplicate directive, nginx -t failed. Headers now inline. Verified live on gk2 (nginx -t OK, reloaded). Both modules deployed + aggregator-activated (health 200, containers pending deliberate install).