### PR TITLE
fix(metalogue): arm64 container installs via piwheels + ip_forward note (#845)

### DIFF
--- a/packages/secubox-maigret/sbin/maigretctl
+++ b/packages/secubox-maigret/sbin/maigretctl
@@ -79,16 +79,26 @@ cmd_install() {
     _write_lxc_config
     lxc_running || lxc-start -n "$CONTAINER" -P "$LXC_PATH" 2>/dev/null
     sleep 2
-    echo "[maigret] installing maigret (pip)…"
-    # Prefer a system-wide pip install; fall back to a dedicated venv and expose
-    # a /usr/local/bin/maigret wrapper so `command -v maigret` resolves either way.
+    echo "[maigret] installing build deps + maigret (pip via piwheels)…"
+    # maigret pulls C-extension deps (lxml, pandas, …) with no stock arm64
+    # wheels on PyPI, so a minbase container can't `pip install` it without a
+    # toolchain. Two-pronged: (1) piwheels supplies prebuilt aarch64 wheels
+    # (fast, no compile); (2) dev headers as a fallback for anything piwheels
+    # lacks. Log goes to the caller's stdout (the install log), not /dev/null,
+    # so a failure is diagnosable.
+    local PIW="--extra-index-url https://www.piwheels.org/simple"
     lxc_attach 'export DEBIAN_FRONTEND=noninteractive
-        if pip3 install --break-system-packages maigret >/dev/null 2>&1; then
+        apt-get update -qq >/dev/null 2>&1
+        apt-get install -y --no-install-recommends \
+            build-essential python3-dev libxml2-dev libxslt1-dev libjpeg-dev zlib1g-dev \
+            >/dev/null 2>&1 || echo "[maigret] warn: build-deps apt failed (piwheels may still cover it)"'
+    lxc_attach 'export DEBIAN_FRONTEND=noninteractive
+        if pip3 install --break-system-packages '"$PIW"' maigret; then
             exit 0
         fi
-        python3 -m venv /opt/maigret >/dev/null 2>&1 \
-            && /opt/maigret/bin/pip install --upgrade pip >/dev/null 2>&1 \
-            && /opt/maigret/bin/pip install maigret >/dev/null 2>&1 || exit 1
+        python3 -m venv /opt/maigret \
+            && /opt/maigret/bin/pip install --upgrade pip \
+            && /opt/maigret/bin/pip install '"$PIW"' maigret || exit 1
         printf "#!/bin/sh\nexec /opt/maigret/bin/maigret \"\$@\"\n" > /usr/local/bin/maigret
         chmod 0755 /usr/local/bin/maigret'
     lxc_attach 'command -v maigret >/dev/null' \

--- a/packages/secubox-spiderfoot/sbin/spiderfootctl
+++ b/packages/secubox-spiderfoot/sbin/spiderfootctl
@@ -80,13 +80,22 @@ cmd_install() {
     # Idempotent: only clone + build the venv if the checkout is absent.
     if [ ! -d "$LXC_PATH/$CONTAINER/rootfs/opt/spiderfoot/.git" ]; then
         echo "[spiderfoot] cloning SpiderFoot + building venv (this can take a while)…"
+        # SpiderFoot's requirements pull C-extension deps (lxml, cryptography,
+        # netaddr, …) with no stock arm64 wheels — a minbase container can't
+        # build them. piwheels supplies prebuilt aarch64 wheels; dev headers are
+        # the fallback. Egress via the host masquerade requires ip_forward=1
+        # (99-secubox-zz-lxc-forward.conf). Log is visible (not /dev/null).
+        lxc_attach 'export DEBIAN_FRONTEND=noninteractive
+            apt-get update -qq >/dev/null 2>&1
+            apt-get install -y --no-install-recommends \
+                build-essential python3-dev libxml2-dev libxslt1-dev libjpeg-dev zlib1g-dev libssl-dev libffi-dev \
+                >/dev/null 2>&1 || echo "[spiderfoot] warn: build-deps apt failed (piwheels may still cover it)"'
         lxc_attach 'set -e
-            export DEBIAN_FRONTEND=noninteractive
             rm -rf /opt/spiderfoot
             git clone --depth 1 https://github.com/smicallef/spiderfoot /opt/spiderfoot
             python3 -m venv /opt/spiderfoot/venv
-            /opt/spiderfoot/venv/bin/pip install --upgrade pip >/dev/null 2>&1 || true
-            /opt/spiderfoot/venv/bin/pip install -r /opt/spiderfoot/requirements.txt' \
+            /opt/spiderfoot/venv/bin/pip install --upgrade pip || true
+            /opt/spiderfoot/venv/bin/pip install --extra-index-url https://www.piwheels.org/simple -r /opt/spiderfoot/requirements.txt' \
             || { err "spiderfoot install failed"; return 1; }
     fi
 


### PR DESCRIPTION
Deploy fix: maigret/SpiderFoot LXC installs failed on gk2 because their C-extension deps have no stock arm64 wheels (minbase container can't compile) AND container egress was dead (ip_forward drifted to 0). Fixes: pip --extra-index-url piwheels + dev-header fallback in both <mod>ctl; re-applied sysctl (ip_forward=1). Verified live: maigret 0.6.2 installed + real lookup works; SpiderFoot installed, service active, UI up on 10.100.0.43:5001.