### PR TITLE
feat(spiderfoot): public UI vhost spiderfoot.gk2.secubox.in (#845)

### DIFF
--- a/packages/secubox-spiderfoot/debian/rules
+++ b/packages/secubox-spiderfoot/debian/rules
@@ -14,8 +14,14 @@ override_dh_auto_install:
 	cp -r www/spiderfoot/. debian/secubox-spiderfoot/usr/share/secubox/www/spiderfoot/
 	install -d debian/secubox-spiderfoot/usr/share/secubox/menu.d
 	[ -d menu.d ] && cp -r menu.d/. debian/secubox-spiderfoot/usr/share/secubox/menu.d/ || true
+	# secubox.d/ holds LOCATION snippets (included inside a server block).
 	install -d debian/secubox-spiderfoot/etc/nginx/secubox.d
-	[ -d nginx ] && cp -r nginx/. debian/secubox-spiderfoot/etc/nginx/secubox.d/ || true
+	install -m 644 nginx/spiderfoot.conf debian/secubox-spiderfoot/etc/nginx/secubox.d/spiderfoot.conf
+	# spiderfoot-lan.conf is a full server{} block → sites-available/ (operator
+	# enables it with a symlink into sites-enabled/, see the file header).
+	install -d debian/secubox-spiderfoot/etc/nginx/sites-available
+	install -m 644 nginx/spiderfoot-lan.conf debian/secubox-spiderfoot/etc/nginx/sites-available/spiderfoot-lan.conf
+	install -m 644 nginx/spiderfoot.gk2.conf debian/secubox-spiderfoot/etc/nginx/sites-available/spiderfoot.gk2.conf
 
 	install -d debian/secubox-spiderfoot/usr/sbin
 	install -m 755 sbin/spiderfootctl debian/secubox-spiderfoot/usr/sbin/spiderfootctl

--- a/packages/secubox-spiderfoot/nginx/spiderfoot-lan.conf
+++ b/packages/secubox-spiderfoot/nginx/spiderfoot-lan.conf
@@ -1,0 +1,31 @@
+# /etc/nginx/sites-available/spiderfoot-lan.conf — SpiderFoot UI (LAN-direct)
+# Installed by secubox-spiderfoot; operator enables with:
+#   ln -s ../sites-available/spiderfoot-lan.conf /etc/nginx/sites-enabled/
+#   nft add rule inet filter input tcp dport 9043 accept   # LAN allow
+#   systemctl reload nginx
+#
+# SpiderFoot emits ABSOLUTE asset paths (/static/...), so it MUST be proxied at
+# vhost ROOT — never under a subpath (that's why admin.gk2/spiderfoot-ui/ 404s:
+# the portal SPA owns admin.gk2 and absolute /static breaks). This LAN-direct
+# server (the current lyrion-lanonly pattern, #793) serves it at root on a host
+# port reachable from the LAN. Public HTTPS exposure = `secubox-exposure
+# emancipate spiderfoot 5001 spiderfoot.gk2.secubox.in` (HAProxy + cert + gate).
+server {
+    listen 0.0.0.0:9043;
+    server_name 192.168.1.200 spiderfoot.local localhost _;
+
+    location / {
+        proxy_pass http://10.100.0.43:5001/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto http;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_read_timeout 300s;
+    }
+
+    access_log /var/log/nginx/spiderfoot_lan_access.log;
+    error_log  /var/log/nginx/spiderfoot_lan_error.log;
+}

--- a/packages/secubox-spiderfoot/nginx/spiderfoot.conf
+++ b/packages/secubox-spiderfoot/nginx/spiderfoot.conf
@@ -33,29 +33,10 @@ location /api/v1/spiderfoot/ {
     include /etc/nginx/snippets/secubox-proxy.conf;
 }
 
-# SpiderFoot's OWN web UI + REST — reverse-proxied to the container LAN IP.
-# The UI is reachable ONLY through this auth-gated location; SpiderFoot is
-# NEVER bound to a host port (see spiderfootctl: `sf.py -l <ip>:<port>`).
-#
-# DEPLOY NOTE: SpiderFoot generates ABSOLUTE URLs for its own assets/links, so
-# serving it under a stripped subpath (/spiderfoot-ui/ -> /) may need adjusting
-# at deploy time — either configure SpiderFoot's own root/base path (its `-l`
-# / config supports a URL prefix) or front it on a dedicated subdomain. This
-# location is the validated BASELINE; the exact subpath rewrite is VALIDATED
-# AT DEPLOY.
-location /spiderfoot-ui/ {
-    auth_request /__sbx_auth_verify;
-    error_page 401 = @sbx_auth_login;
-    proxy_pass http://10.100.0.43:5001/;
-    # Headers set inline (NOT the secubox-proxy snippet) so we can override
-    # proxy_read_timeout for long SpiderFoot scans without a duplicate directive.
-    proxy_http_version 1.1;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header Authorization $http_authorization;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "";
-    proxy_read_timeout 300s;
-}
+# SpiderFoot's OWN web UI is NOT proxied here. SpiderFoot emits ABSOLUTE asset
+# paths (/static/...), so it cannot live under a subpath of admin.gk2 (the
+# portal SPA owns admin.gk2 → a /spiderfoot-ui/ subpath returns "module not
+# found"). It is served AT ROOT by the LAN-direct vhost `spiderfoot-lan.conf`
+# (host :9043 → 10.100.0.43:5001), the current lyrion-lanonly pattern. Public
+# HTTPS exposure = `secubox-exposure emancipate spiderfoot 5001
+# spiderfoot.gk2.secubox.in` (HAProxy + cert + auth gate at vhost root).

--- a/packages/secubox-spiderfoot/nginx/spiderfoot.gk2.conf
+++ b/packages/secubox-spiderfoot/nginx/spiderfoot.gk2.conf
@@ -1,0 +1,55 @@
+# /etc/nginx/sites-available/spiderfoot.gk2.conf — SpiderFoot public vhost
+# Installed by secubox-spiderfoot; operator enables with:
+#   ln -s ../sites-available/spiderfoot.gk2.conf /etc/nginx/sites-enabled/
+#   systemctl reload nginx
+# Public chain: Browser → HAProxy:443 (wildcard *.gk2 cert) → sbxwaf (WAF) →
+# nginx:9080 (this vhost) → SpiderFoot LXC 10.100.0.43:5001.
+# Requires: sbxwaf route (haproxy-routes.json "spiderfoot.gk2.secubox.in" →
+# [192.168.1.200, 9080]) + HAProxy ACL (use_backend mitmproxy_inspector).
+#
+# SpiderFoot emits ABSOLUTE asset paths (/static/...), so it is proxied AT ROOT
+# (never a subpath). SpiderFoot has no native auth → the exposure snippet
+# (LAN allow-list, deny WAN) is the gate (CSPN: LAN-only).
+server {
+    listen 0.0.0.0:9080;
+    listen [::]:9080;
+    server_name spiderfoot.gk2.secubox.in;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /usr/share/secubox/www;
+        try_files $uri =404;
+    }
+
+    sub_filter_types text/html;
+    sub_filter_once on;
+    sub_filter "</body>" '<script src="/shared/health-banner.js"></script></body>';
+
+    location /shared/ {
+        allow 127.0.0.1;
+        allow 10.0.0.0/8;
+        allow 172.16.0.0/12;
+        allow 192.168.0.0/16;
+        deny all;
+        add_header Access-Control-Allow-Origin "*" always;
+        alias /usr/share/secubox/www/shared/;
+    }
+
+    location / {
+        include /etc/nginx/snippets/exposure/spiderfoot.gk2.secubox.in.conf;
+
+        proxy_pass http://10.100.0.43:5001/;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host  $host;
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        "upgrade";
+        proxy_buffering off;
+        proxy_read_timeout 300s;
+    }
+
+    access_log /var/log/nginx/spiderfoot_access.log;
+    error_log  /var/log/nginx/spiderfoot_error.log;
+}

--- a/packages/secubox-spiderfoot/www/spiderfoot/index.html
+++ b/packages/secubox-spiderfoot/www/spiderfoot/index.html
@@ -84,7 +84,7 @@
             <p class="subhead">The full SpiderFoot web UI (scan wizard, correlation graph, REST) runs
                inside the sandbox and is reachable only through this WAF/SecuBox-auth-fronted proxy.
                Available once the UI is up.</p>
-            <a class="btn open-ui" id="btn-open-ui" href="/spiderfoot-ui/" target="_blank" rel="noopener"
+            <a class="btn open-ui" id="btn-open-ui" href="https://spiderfoot.gk2.secubox.in/" target="_blank" rel="noopener"
                style="display:none">🌀 Open SpiderFoot</a>
             <span class="muted" id="ui-hint">Waiting for the SpiderFoot UI to come up…</span>
         </div>


### PR DESCRIPTION
SpiderFoot UI now at https://spiderfoot.gk2.secubox.in/ (proxied at root — absolute /static paths need it; the /spiderfoot-ui/ subpath hit the portal SPA's 'module not found'). Public chain HAProxy(wildcard cert)→sbxwaf→nginx→container, LAN-gated. + LAN-direct :9043 fallback. Panel link updated. Verified live 200.