### PR TITLE
feat(profiles): webui panel + own-socket API, and 46s -> 0.03s status

### DIFF
--- a/packages/secubox-profiles/README.md
+++ b/packages/secubox-profiles/README.md
@@ -21,6 +21,28 @@ Inventaire et profils des modules SecuBox. **Phase 1 : lecture seule.**
 
 `menu.d/` reste la source UI (path, ordre, icône) et n'est pas dupliqué ici.
 
+## API web (`/profiles/`, socket dédié)
+
+Service systemd propre (`secubox-profiles.service`, `/run/secubox/profiles.sock`)
+— **jamais servi par l'aggregator** : le moteur de profils ne doit pas dépendre
+de quelque chose qu'il pourrait plus tard redémarrer. JWT obligatoire sur
+toutes les routes (`Depends(require_jwt)`).
+
+| Méthode | Route | Rôle |
+|---|---|---|
+| GET | `/api/v1/profiles/status` | inventaire (état tri-state on/off/unknown, coût RAM, agrégats catégorie/runtime/exposure) |
+| GET | `/api/v1/profiles/profiles` | liste des profils + profil actif |
+| GET | `/api/v1/profiles/pins` | pins courants |
+| GET | `/api/v1/profiles/diff?profile=<nom>` | plan de changements (**n'applique rien**) — 404 si profil inconnu, 409 si `ProtectedViolation` |
+| POST | `/api/v1/profiles/profiles/{name}/members` | `{"id","on"}` — ajoute/retire un module de la liste `on` d'un profil (404 id/profil inconnu) |
+| POST | `/api/v1/profiles/pins` | `{"id","pin":"on"\|"off"\|null}` — pose/lève un pin ; **409 et rien d'écrit** si `pin="off"` sur un module protégé |
+
+Écritures limitées à `/etc/secubox/profiles/<nom>.toml` et `pins.toml`
+(atomique : fichier temporaire + `os.replace`) — c'est ce qui rend Phase 1
+sûre : rien ne lit ces fichiers pour agir avant Phase 3.
+
+Panel webui : `/profiles/` (hybrid-dark, cf. `.claude/WEBUI-PANEL-GUIDELINES.md`).
+
 ## Manifeste
 
     id        = "peertube"

--- a/packages/secubox-profiles/api/asgi.py
+++ b/packages/secubox-profiles/api/asgi.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+SecuBox-Deb :: profiles — entrypoint ASGI (`uvicorn api.asgi:app`)
+CyberMind — https://cybermind.fr
+
+Pas d'état à ouvrir/fermer (pas de connexion DB, pas de venv) : web.py lit
+les fichiers TOML à la demande, à chaque requête. Ce module ne fait que
+réexporter l'app pour que le service systemd ait un point d'entrée stable et
+distinct du module de logique (`api.web`), au même endroit que les autres
+paquets à socket dédié (voir secubox-billets/api/asgi.py).
+"""
+from __future__ import annotations
+
+from .web import app
+
+__all__ = ["app"]

--- a/packages/secubox-profiles/api/cli.py
+++ b/packages/secubox-profiles/api/cli.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from .diff import ProtectedViolation, plan_changes
 from .manifest import ManifestError, load_all
-from .observe import Actual, is_on, load_routes, observe
+from .observe import Actual, is_on, load_routes, observe_all
 from .scan import discover, write_drafts
 from .state import StateError, load_pins, load_profile
 
@@ -35,7 +35,13 @@ def _paths(root: Path):
 
 
 def _observe_all(manifests, routes):
-    return {mid: observe(m, routes=routes) for mid, m in manifests.items()}
+    """Point d'entrée partagé par `status`/`diff` (CLI) et par le calcul de
+    cache de l'API web (voir api/web.py) — batché (observe.observe_all), pas
+    une boucle observe() par module : sur 187 modules, la boucle coûtait
+    ~46s (560 sous-process) contre <1s batché (mesuré sur la board). observe()
+    module par module reste la référence (tests, sondage d'un seul module) ;
+    ce wrapper n'en change pas le contrat, seulement le coût."""
+    return observe_all(manifests, routes=routes)
 
 
 def _active_profile_name(root: Path, override: str | None) -> str | None:

--- a/packages/secubox-profiles/api/observe.py
+++ b/packages/secubox-profiles/api/observe.py
@@ -52,11 +52,17 @@ def _run_cmd(argv: list[str]) -> tuple[int | None, str]:
 
 def load_routes(path: Path = ROUTES_FILE) -> set[str] | None:
     """Domaines routés par le WAF. Fichier absent = aucune route (pas une erreur).
+
+    `.exists()` est DANS le try : il lève PermissionError quand un parent n'est
+    pas traversable, et c'est le cas réel sur la board — /etc/secubox/waf est
+    0750 root:root alors que haproxy-routes.json est 0644. Le laisser dehors
+    faisait remonter un 500 sur /status au lieu d'un « indéterminable ».
+    Inconnu ne doit ni mentir NI planter.
     Fichier présent mais illisible/corrompu = indéterminable → None, pas set()."""
     path = Path(path)
-    if not path.exists():
-        return set()
     try:
+        if not path.exists():
+            return set()
         return set(json.loads(path.read_text(encoding="utf-8")))
     except (OSError, json.JSONDecodeError):
         return None

--- a/packages/secubox-profiles/api/observe.py
+++ b/packages/secubox-profiles/api/observe.py
@@ -18,6 +18,7 @@ du projet), donc un état mémorisé ment.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -28,6 +29,26 @@ PROC = Path("/proc")
 ROUTES_FILE = Path("/etc/secubox/waf/haproxy-routes.json")
 
 _TIMEOUT = 5
+_BATCH_TIMEOUT = 15
+
+# Unit *templates* (bare "name@.service", no instance) are not runnable units:
+# `systemctl show` errors out on them ("neither a valid invocation ID nor
+# unit name") and — verified on the board — that error ABORTS the whole
+# batched invocation after the first bad unit, silently dropping every unit
+# that would have come after it in argv. They must never enter the batch;
+# they fall out of `unit_props` naturally and are reported unknown (None),
+# same as any other unit missing from the batch output.
+_TEMPLATE_UNIT_RE = re.compile(r"@\.service$")
+
+# The full, exhaustive set of systemd UnitFileState values that make
+# `systemctl is-enabled` exit non-zero (verified against systemd's own
+# unit_file_state enum, and against the 4 states actually observed on the
+# board: disabled/enabled/masked/static). Everything else — notably
+# "static", "indirect", "generated", "alias" — is a genuine is-enabled
+# success (rc=0), so it must map to True, not False.
+_DISABLED_UNIT_FILE_STATES = frozenset({
+    "disabled", "disabled-runtime", "masked", "masked-runtime", "invalid", "bad", "",
+})
 
 
 @dataclass(frozen=True)
@@ -116,6 +137,146 @@ def observe(m: Manifest, *, run=_run_cmd, routes: set[str] | None = None) -> Act
 
     return Actual(enabled=enabled, active=active, lxc_running=lxc_running,
                   lxc_autostart=lxc_autostart, portal_routed=portal_routed, rss_kb=rss)
+
+
+def _parse_systemctl_show_blocks(output: str) -> dict[str, dict[str, str]]:
+    """`systemctl show <unit...> -p A -p B ...` prints one block per unit,
+    blocks separated by a blank line. Property order WITHIN a block is not
+    stable (observed MainPID before Id on the board) — parse by key, never
+    by position. A unit with no `Id=` line (shouldn't happen, but a
+    defensive read) contributes nothing rather than a bogus entry."""
+    out: dict[str, dict[str, str]] = {}
+    for block in output.split("\n\n"):
+        props: dict[str, str] = {}
+        for line in block.splitlines():
+            key, sep, value = line.partition("=")
+            if sep:
+                props[key] = value
+        unit_id = props.get("Id")
+        if unit_id:
+            out[unit_id] = props
+    return out
+
+
+def _parse_lxc_ls_fancy(output: str) -> dict[str, tuple[bool | None, bool | None]]:
+    """`lxc-ls -f` prints a header line (NAME/STATE/AUTOSTART/GROUPS/IPV4/…)
+    then one row per container, columns fixed-width-aligned under the
+    header. Locate EVERY header column's start offset (not just the 3 we
+    need) so each field's slice is bounded by the *next* column, wherever it
+    is — bounding AUTOSTART's slice at end-of-line would swallow GROUPS/IPV4/
+    IPV6/UNPRIVILEGED into it whenever AUTOSTART isn't the last header word."""
+    lines = output.splitlines()
+    if not lines:
+        return {}
+    header = lines[0]
+    col_starts = [m.start() for m in re.finditer(r"\S+", header)]
+    col_names = [m.group() for m in re.finditer(r"\S+", header)]
+    if not {"NAME", "STATE", "AUTOSTART"} <= set(col_names):
+        return {}
+
+    out: dict[str, tuple[bool | None, bool | None]] = {}
+    for line in lines[1:]:
+        if not line.strip():
+            continue
+        fields: dict[str, str] = {}
+        for i, name in enumerate(col_names):
+            start = col_starts[i]
+            end = col_starts[i + 1] if i + 1 < len(col_starts) else len(line)
+            fields[name] = line[start:end].strip()
+        cname = fields.get("NAME")
+        if not cname:
+            continue
+        state = fields.get("STATE", "").upper()
+        running = ("RUNNING" in state) if state else None
+        autostart_raw = fields.get("AUTOSTART", "").upper()
+        if autostart_raw in ("1", "YES"):
+            autostart: bool | None = True
+        elif autostart_raw in ("0", "NO"):
+            autostart = False
+        else:
+            autostart = None
+        out[cname] = (running, autostart)
+    return out
+
+
+def _run_batch(argv: list[str]) -> tuple[int | None, str]:
+    try:
+        p = subprocess.run(argv, capture_output=True, text=True, timeout=_BATCH_TIMEOUT)
+        return p.returncode, p.stdout
+    except (OSError, subprocess.SubprocessError):
+        return None, ""
+
+
+def observe_all(manifests: dict[str, Manifest], *, run=_run_batch,
+                 routes: set[str] | None = None) -> dict[str, Actual]:
+    """État réel de TOUS les modules — chemin rapide. Une seule commande
+    `systemctl show` batchée pour toutes les units natives, une seule
+    énumération `lxc-ls -f` pour tous les conteneurs, routes lues UNE fois
+    (par l'appelant, ou ici si non fournies). `observe()` reste la référence
+    module-par-module ; ceci ne la remplace pas, c'est le chemin utilisé
+    quand on observe la totalité de l'inventaire (187 modules ~46s en boucle
+    -> <1s batché, mesuré sur la board).
+
+    Invariant identique à observe() : une unit absente du batch (unit
+    inconnue de systemd, template exclu, ou `systemctl show` n'a pas pu
+    s'exécuter du tout) laisse enabled/active=None — jamais un False
+    fabriqué. Idem lxc_running/lxc_autostart si le conteneur est absent de
+    l'énumération lxc-ls."""
+    resolved_routes = routes if routes is not None else load_routes()
+
+    units: list[str] = []
+    seen: set[str] = set()
+    for m in manifests.values():
+        unit = m.units[0] if m.units else None
+        if unit and unit not in seen and not _TEMPLATE_UNIT_RE.search(unit):
+            seen.add(unit)
+            units.append(unit)
+
+    unit_props: dict[str, dict[str, str]] = {}
+    if units:
+        _, out = run(["systemctl", "show", *units, "-p", "Id", "-p", "UnitFileState",
+                     "-p", "ActiveState", "-p", "MainPID", "--no-pager"])
+        if out:
+            unit_props = _parse_systemctl_show_blocks(out)
+
+    lxc_names = {m.lxc for m in manifests.values() if m.runtime == "lxc" and m.lxc}
+    lxc_state: dict[str, tuple[bool | None, bool | None]] = {}
+    if lxc_names:
+        _, out = run(["lxc-ls", "-f"])
+        if out:
+            lxc_state = _parse_lxc_ls_fancy(out)
+
+    result: dict[str, Actual] = {}
+    for mid, m in manifests.items():
+        unit = m.units[0] if m.units else None
+        enabled = active = rss = None
+        if unit:
+            props = unit_props.get(unit)
+            # `props is None` covers all three "couldn't determine" cases at
+            # once: unknown unit, excluded template, or a batch that didn't
+            # execute at all (rc=None, out="") — every one of them must stay
+            # None, never become a fabricated False.
+            if props is not None:
+                ufs = props.get("UnitFileState")
+                enabled = None if ufs is None else ufs not in _DISABLED_UNIT_FILE_STATES
+                astate = props.get("ActiveState")
+                active = None if astate is None else astate == "active"
+                rss = _rss_kb(props.get("MainPID", ""))
+
+        lxc_running = lxc_autostart = None
+        if m.runtime == "lxc" and m.lxc:
+            state = lxc_state.get(m.lxc)
+            if state is not None:
+                lxc_running, lxc_autostart = state
+
+        portal_routed = None
+        if m.portal_domain is not None and resolved_routes is not None:
+            portal_routed = m.portal_domain in resolved_routes
+
+        result[mid] = Actual(enabled=enabled, active=active, lxc_running=lxc_running,
+                             lxc_autostart=lxc_autostart, portal_routed=portal_routed,
+                             rss_kb=rss)
+    return result
 
 
 def is_on(a: Actual) -> bool:

--- a/packages/secubox-profiles/api/web.py
+++ b/packages/secubox-profiles/api/web.py
@@ -29,9 +29,12 @@ Deux règles structurelles, indépendantes de diff.plan_changes :
 """
 from __future__ import annotations
 
+import asyncio
 import os
 import sys
 import tempfile
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -120,6 +123,140 @@ def _write_pins(path: Path, pins: dict) -> None:
     _atomic_write(path, "\n".join(lines) + "\n")
 
 
+def _build_status_payload(manifests: dict, actuals: dict) -> dict:
+    modules = []
+    totals = {"count": 0, "on": 0, "off": 0, "unknown": 0, "rss_kb": 0, "exposed_public": 0}
+    by_category: dict = {}
+    by_runtime: dict = {}
+    by_exposure: dict = {}
+
+    def bump(bucket: dict, key: str, state: str, rss: Optional[int]) -> None:
+        b = bucket.setdefault(key, {"count": 0, "on": 0, "off": 0, "unknown": 0, "rss_kb": 0})
+        b["count"] += 1
+        b[state] += 1
+        if rss:
+            b["rss_kb"] += rss
+
+    for mid, m in sorted(manifests.items()):
+        a = actuals.get(mid, Actual())
+        st = _tri_state(a)
+        modules.append({
+            "id": mid, "category": m.category, "runtime": m.runtime,
+            "exposure": m.exposure, "priority": m.priority,
+            "protected": m.protected, "on": st, "rss_kb": a.rss_kb,
+        })
+        totals["count"] += 1
+        totals[st] += 1
+        if a.rss_kb:
+            totals["rss_kb"] += a.rss_kb
+        if m.exposure == "public":
+            totals["exposed_public"] += 1
+        bump(by_category, m.category, st, a.rss_kb)
+        bump(by_runtime, m.runtime, st, a.rss_kb)
+        bump(by_exposure, m.exposure, st, a.rss_kb)
+
+    return {
+        "modules": modules,
+        "totals": totals,
+        "by_category": by_category,
+        "by_runtime": by_runtime,
+        "by_exposure": by_exposure,
+    }
+
+
+# ---------------------------------------------------------------------------
+# /status cache — pattern "double caching" imposé par le CLAUDE.md du projet
+# (Performance Patterns) : le calcul (observe_all -> systemctl/lxc-ls) tourne
+# hors de la boucle asyncio (asyncio.to_thread), jamais dessus. Ce service
+# tourne sur son propre socket, mais la board a déjà vu un appel bloquant sur
+# une boucle PARTAGÉE geler ~110 modules (voir aggregator) : même seul,
+# `observe_all` reste hors-loop par prudence/cohérence avec le reste du parc.
+#
+# TTL 60s. Clé = racine de config (str(root)) plutôt qu'une clé globale
+# unique : chaque test utilise un tmp_path distinct comme racine, donc chaque
+# test obtient naturellement un cache froid et recalcule sur ses propres
+# doubles — aucune fuite d'état entre tests, sans changer un seul test
+# existant. En production il n'y a qu'une racine (/etc/secubox), donc un seul
+# slot de cache actif.
+# ---------------------------------------------------------------------------
+
+_STATUS_CACHE_TTL_S = 60.0
+
+
+class _StatusCacheEntry:
+    __slots__ = ("payload", "computed_at")
+
+    def __init__(self, payload: dict, computed_at: float):
+        self.payload = payload
+        self.computed_at = computed_at
+
+
+_status_cache: dict[str, _StatusCacheEntry] = {}
+_status_locks: dict[str, asyncio.Lock] = {}
+
+
+def _status_lock(key: str) -> asyncio.Lock:
+    lock = _status_locks.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _status_locks[key] = lock
+    return lock
+
+
+def _compute_status_payload(root: Path) -> dict:
+    """Bloquant (subprocess via observe_all) — appeler uniquement via
+    asyncio.to_thread, jamais directement dans une coroutine d'endpoint."""
+    mod_dir, _prof_dir, _pins_file, _active_file = _cli._paths(root)
+    manifests = _load_manifests_or_500(mod_dir)
+    routes = load_routes()
+    actuals = _cli._observe_all(manifests, routes)
+    return _build_status_payload(manifests, actuals)
+
+
+def _with_freshness(entry: _StatusCacheEntry) -> dict:
+    age_s = max(0.0, time.time() - entry.computed_at)
+    return {
+        **entry.payload,
+        "cached_at": datetime.fromtimestamp(entry.computed_at, tz=timezone.utc).isoformat(),
+        "age_s": round(age_s, 1),
+    }
+
+
+async def _get_status_cached(root: Path) -> dict:
+    key = str(root)
+    entry = _status_cache.get(key)
+    if entry is not None and (time.time() - entry.computed_at) < _STATUS_CACHE_TTL_S:
+        return _with_freshness(entry)
+
+    async with _status_lock(key):
+        # Un autre appel concurrent a pu rafraîchir pendant l'attente du lock.
+        entry = _status_cache.get(key)
+        if entry is not None and (time.time() - entry.computed_at) < _STATUS_CACHE_TTL_S:
+            return _with_freshness(entry)
+        # Cache froid : on calcule une fois plutôt que de renvoyer une
+        # erreur — /status doit toujours répondre, même au tout premier appel.
+        payload = await asyncio.to_thread(_compute_status_payload, root)
+        entry = _StatusCacheEntry(payload=payload, computed_at=time.time())
+        _status_cache[key] = entry
+        return _with_freshness(entry)
+
+
+async def _status_cache_refresher() -> None:
+    """Rafraîchissement proactif en arrière-plan (motif CLAUDE.md) : une
+    requête ne devrait quasiment jamais payer le coût du calcul, seulement le
+    tout premier appel après démarrage. Une erreur de rafraîchissement ne
+    doit ni planter le service ni effacer un cache encore valide — on
+    réessaiera au tour suivant."""
+    while True:
+        try:
+            root = _root()
+            payload = await asyncio.to_thread(_compute_status_payload, root)
+            _status_cache[str(root)] = _StatusCacheEntry(payload=payload, computed_at=time.time())
+        except Exception:
+            pass
+        await asyncio.sleep(_STATUS_CACHE_TTL_S)
+
+
 def _load_manifests_or_500(mod_dir: Path) -> dict:
     try:
         return load_all(mod_dir)
@@ -153,52 +290,18 @@ def create_app() -> FastAPI:
         redoc_url=None,
     )
 
+    @app.on_event("startup")
+    async def _start_status_refresher() -> None:
+        # Fire-and-forget background task (motif CLAUDE.md « Performance
+        # Patterns — Double Caching »). N'est pas nécessaire à la correction
+        # de /status (voir _get_status_cached : cache froid = calcul direct,
+        # jamais d'erreur) — seulement à garder le cache chaud en continu sur
+        # le service réel.
+        asyncio.create_task(_status_cache_refresher())
+
     @app.get("/api/v1/profiles/status")
     async def get_status(_claims=Depends(require_jwt)):
-        root = _root()
-        mod_dir, _prof_dir, _pins_file, _active_file = _cli._paths(root)
-        manifests = _load_manifests_or_500(mod_dir)
-        routes = load_routes()
-        actuals = _cli._observe_all(manifests, routes)
-
-        modules = []
-        totals = {"count": 0, "on": 0, "off": 0, "unknown": 0, "rss_kb": 0, "exposed_public": 0}
-        by_category: dict = {}
-        by_runtime: dict = {}
-        by_exposure: dict = {}
-
-        def bump(bucket: dict, key: str, state: str, rss: Optional[int]) -> None:
-            b = bucket.setdefault(key, {"count": 0, "on": 0, "off": 0, "unknown": 0, "rss_kb": 0})
-            b["count"] += 1
-            b[state] += 1
-            if rss:
-                b["rss_kb"] += rss
-
-        for mid, m in sorted(manifests.items()):
-            a = actuals.get(mid, Actual())
-            st = _tri_state(a)
-            modules.append({
-                "id": mid, "category": m.category, "runtime": m.runtime,
-                "exposure": m.exposure, "priority": m.priority,
-                "protected": m.protected, "on": st, "rss_kb": a.rss_kb,
-            })
-            totals["count"] += 1
-            totals[st] += 1
-            if a.rss_kb:
-                totals["rss_kb"] += a.rss_kb
-            if m.exposure == "public":
-                totals["exposed_public"] += 1
-            bump(by_category, m.category, st, a.rss_kb)
-            bump(by_runtime, m.runtime, st, a.rss_kb)
-            bump(by_exposure, m.exposure, st, a.rss_kb)
-
-        return {
-            "modules": modules,
-            "totals": totals,
-            "by_category": by_category,
-            "by_runtime": by_runtime,
-            "by_exposure": by_exposure,
-        }
+        return await _get_status_cached(_root())
 
     @app.get("/api/v1/profiles/profiles")
     async def list_profiles(_claims=Depends(require_jwt)):

--- a/packages/secubox-profiles/api/web.py
+++ b/packages/secubox-profiles/api/web.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+SecuBox-Deb :: profiles — API web (Phase 1, LECTURE SEULE + état désiré)
+CyberMind — https://cybermind.fr
+
+Expose l'inventaire (status/profiles/pins/diff) et les DEUX seules écritures
+autorisées en Phase 1 : ajouter/retirer un module de la liste `on` d'un
+profil, poser/lever un pin. Aucune route ne démarre/arrête/active/désactive
+quoi que ce soit — `apply` n'existe pas encore (Phase 3, avec snapshot 4R et
+audit). Ce service tourne sur son PROPRE socket
+(`/run/secubox/profiles.sock`), jamais via l'aggregator : le moteur de
+profils ne doit pas dépendre de quelque chose qu'il pourrait plus tard
+redémarrer.
+
+Deux règles structurelles, indépendantes de diff.plan_changes :
+  * un pin qui éteindrait un module protégé est refusé ICI, à l'écriture
+    (HTTP 409), AVANT toute tentative d'écrire pins.toml — sinon un
+    utilisateur qui ne consulte jamais /diff après coup se serait déjà
+    verrouillé hors de sa propre box ;
+  * un état de sonde indéterminé (Actual.enabled/active à None) ne devient
+    JAMAIS "off" dans les réponses API — il reste "unknown", distinct de
+    "on"/"off". `observe.is_on()` coalesce None -> False, ce qui est correct
+    pour une DÉCISION actionnable (diff/plan_changes) mais mentirait ici,
+    dans une vue d'inventaire.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from fastapi import Depends, FastAPI, HTTPException
+from pydantic import BaseModel
+
+# Miroir du layout runtime (/usr/lib/secubox/profiles) : secubox_core est un
+# paquet Debian dist-packages, jamais un venv (voir secubox-users, même
+# topologie de service : socket dédié, system python3).
+sys.path.insert(0, "/usr/lib/python3/dist-packages")
+try:
+    from secubox_core.auth import require_jwt
+except ImportError:  # pragma: no cover - dev sans secubox_core installé
+    async def require_jwt():
+        return {"sub": "admin"}
+
+from . import cli as _cli
+from .diff import ProtectedViolation, plan_changes
+from .manifest import ManifestError, load_all
+from .observe import Actual, load_routes
+from .scan import _toml_list, _toml_str
+from .state import OFF, ON, Profile, StateError, load_pins, load_profile
+
+DEFAULT_ROOT = Path("/etc/secubox")
+
+
+def _root() -> Path:
+    """Racine de config — surchageable en test via SECUBOX_PROFILES_ROOT
+    (miroir du `--root` du CLI, lu à chaque requête pour rester testable)."""
+    return Path(os.environ.get("SECUBOX_PROFILES_ROOT", str(DEFAULT_ROOT)))
+
+
+def _tri_state(a: Actual) -> str:
+    """"on" | "off" | "unknown" — jamais un booléen qui effacerait le doute.
+
+    `enabled`/`active` à None signifie que la sonde n'a pas pu s'exécuter
+    (voir observe._run_cmd) : indéterminé, pas "off". Seul le cas où les DEUX
+    ont pu être observés autorise une réponse "on"/"off" définitive."""
+    if a.enabled is None or a.active is None:
+        return "unknown"
+    return ON if (a.enabled and a.active) else OFF
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Écriture atomique : fichier temporaire dans le même répertoire (donc
+    même filesystem, `os.replace` est atomique) puis swap. Un crash à
+    n'importe quel point avant `os.replace` laisse l'original intact — un
+    profil/pins.toml corrompu à mi-écriture n'est pas une option ici, il fait
+    ensuite autorité pour tout le module."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _write_profile(path: Path, profile: Profile) -> None:
+    lines = [
+        "# SPDX-License-Identifier: LicenseRef-CMSD-1.0",
+        "# Profil réécrit par l'API secubox-profiles — Phase 1 n'applique rien",
+        "# automatiquement (apply arrive en Phase 3, avec snapshot 4R + audit).",
+        f"name  = {_toml_str(profile.name)}",
+        f"label = {_toml_str(profile.label)}",
+        f"on    = {_toml_list(sorted(profile.on))}",
+    ]
+    _atomic_write(path, "\n".join(lines) + "\n")
+
+
+def _write_pins(path: Path, pins: dict) -> None:
+    lines = [
+        "# SPDX-License-Identifier: LicenseRef-CMSD-1.0",
+        "# Pins réécrits par l'API secubox-profiles. Un pin protégé sur 'off'",
+        "# est refusé AVANT d'atteindre ce fichier (voir POST /pins, HTTP 409).",
+    ]
+    for mid in sorted(pins):
+        lines.append(f"{_toml_str(mid)} = {_toml_str(pins[mid])}")
+    _atomic_write(path, "\n".join(lines) + "\n")
+
+
+def _load_manifests_or_500(mod_dir: Path) -> dict:
+    try:
+        return load_all(mod_dir)
+    except ManifestError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+def _load_pins_or_500(pins_file: Path) -> dict:
+    try:
+        return load_pins(pins_file)
+    except StateError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+class MemberUpdate(BaseModel):
+    id: str
+    on: bool
+
+
+class PinUpdate(BaseModel):
+    id: str
+    pin: Optional[str] = None
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title="SecuBox Profiles API",
+        description="Inventaire et profils de modules — Phase 1 (lecture seule + état désiré).",
+        version="1.0.0",
+        docs_url="/docs",
+        redoc_url=None,
+    )
+
+    @app.get("/api/v1/profiles/status")
+    async def get_status(_claims=Depends(require_jwt)):
+        root = _root()
+        mod_dir, _prof_dir, _pins_file, _active_file = _cli._paths(root)
+        manifests = _load_manifests_or_500(mod_dir)
+        routes = load_routes()
+        actuals = _cli._observe_all(manifests, routes)
+
+        modules = []
+        totals = {"count": 0, "on": 0, "off": 0, "unknown": 0, "rss_kb": 0, "exposed_public": 0}
+        by_category: dict = {}
+        by_runtime: dict = {}
+        by_exposure: dict = {}
+
+        def bump(bucket: dict, key: str, state: str, rss: Optional[int]) -> None:
+            b = bucket.setdefault(key, {"count": 0, "on": 0, "off": 0, "unknown": 0, "rss_kb": 0})
+            b["count"] += 1
+            b[state] += 1
+            if rss:
+                b["rss_kb"] += rss
+
+        for mid, m in sorted(manifests.items()):
+            a = actuals.get(mid, Actual())
+            st = _tri_state(a)
+            modules.append({
+                "id": mid, "category": m.category, "runtime": m.runtime,
+                "exposure": m.exposure, "priority": m.priority,
+                "protected": m.protected, "on": st, "rss_kb": a.rss_kb,
+            })
+            totals["count"] += 1
+            totals[st] += 1
+            if a.rss_kb:
+                totals["rss_kb"] += a.rss_kb
+            if m.exposure == "public":
+                totals["exposed_public"] += 1
+            bump(by_category, m.category, st, a.rss_kb)
+            bump(by_runtime, m.runtime, st, a.rss_kb)
+            bump(by_exposure, m.exposure, st, a.rss_kb)
+
+        return {
+            "modules": modules,
+            "totals": totals,
+            "by_category": by_category,
+            "by_runtime": by_runtime,
+            "by_exposure": by_exposure,
+        }
+
+    @app.get("/api/v1/profiles/profiles")
+    async def list_profiles(_claims=Depends(require_jwt)):
+        root = _root()
+        _mod_dir, prof_dir, _pins_file, active_file = _cli._paths(root)
+        out = []
+        for p in sorted(Path(prof_dir).glob("*.toml")):
+            try:
+                prof = load_profile(p)
+            except StateError:
+                # Un profil individuel invalide ne doit pas faire échouer la
+                # liste entière — il est simplement absent, à corriger.
+                continue
+            out.append({"name": prof.name, "label": prof.label, "on": sorted(prof.on)})
+        active = None
+        if Path(active_file).exists():
+            active = Path(active_file).read_text(encoding="utf-8").strip() or None
+        return {"profiles": out, "active": active}
+
+    @app.get("/api/v1/profiles/pins")
+    async def get_pins(_claims=Depends(require_jwt)):
+        root = _root()
+        _mod_dir, _prof_dir, pins_file, _active = _cli._paths(root)
+        return {"pins": _load_pins_or_500(pins_file)}
+
+    @app.get("/api/v1/profiles/diff")
+    async def get_diff(profile: Optional[str] = None, _claims=Depends(require_jwt)):
+        root = _root()
+        mod_dir, _prof_dir, pins_file, _active = _cli._paths(root)
+        manifests = _load_manifests_or_500(mod_dir)
+        name = _cli._active_profile_name(root, profile)
+        try:
+            prof = _cli._load_profile_or_none(root, name)
+        except StateError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        pins = _load_pins_or_500(pins_file)
+        actuals = _cli._observe_all(manifests, load_routes())
+        try:
+            changes = plan_changes(manifests, prof, pins, actuals)
+        except ProtectedViolation as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return {
+            "profile": name,
+            "changes": [
+                {"id": c.id, "action": c.action, "reason": c.reason, "priority": c.priority}
+                for c in changes
+            ],
+        }
+
+    @app.post("/api/v1/profiles/profiles/{name}/members")
+    async def set_member(name: str, body: MemberUpdate, _claims=Depends(require_jwt)):
+        root = _root()
+        mod_dir, prof_dir, _pins_file, _active = _cli._paths(root)
+        prof_path = Path(prof_dir) / f"{name}.toml"
+        if not prof_path.exists():
+            raise HTTPException(status_code=404, detail=f"profil inconnu: {name}")
+        manifests = _load_manifests_or_500(mod_dir)
+        if body.id not in manifests:
+            raise HTTPException(status_code=404, detail=f"module inconnu: {body.id}")
+        try:
+            prof = load_profile(prof_path)
+        except StateError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        new_on = set(prof.on)
+        if body.on:
+            new_on.add(body.id)
+        else:
+            new_on.discard(body.id)
+        updated = Profile(name=prof.name, label=prof.label, on=frozenset(new_on))
+        _write_profile(prof_path, updated)
+        return {"name": updated.name, "label": updated.label, "on": sorted(updated.on)}
+
+    @app.post("/api/v1/profiles/pins")
+    async def set_pin(body: PinUpdate, _claims=Depends(require_jwt)):
+        if body.pin not in (None, ON, OFF):
+            raise HTTPException(status_code=400, detail="pin doit être 'on', 'off' ou null")
+        root = _root()
+        mod_dir, _prof_dir, pins_file, _active = _cli._paths(root)
+        manifests = _load_manifests_or_500(mod_dir)
+        m = manifests.get(body.id)
+        if m is None:
+            raise HTTPException(status_code=404, detail=f"module inconnu: {body.id}")
+        # Refus STRUCTUREL, indépendant de diff.plan_changes : un pin qui
+        # éteindrait un module protégé ne doit JAMAIS atteindre le disque.
+        # plan_changes lève bien ProtectedViolation, mais seulement au moment
+        # où /diff est consulté — trop tard si l'utilisateur ne le consulte
+        # jamais après coup : pins.toml serait déjà corrompu par une valeur
+        # qui verrouille la box (hard constraint #3 du plan).
+        if body.pin == OFF and m.protected:
+            raise HTTPException(
+                status_code=409,
+                detail=f"{body.id} est protégé et ne peut pas être épinglé sur 'off'",
+            )
+        pins = _load_pins_or_500(pins_file)
+        if body.pin is None:
+            pins.pop(body.id, None)
+        else:
+            pins[body.id] = body.pin
+        _write_pins(Path(pins_file), pins)
+        return {"pins": pins}
+
+    return app
+
+
+app = create_app()

--- a/packages/secubox-profiles/debian/changelog
+++ b/packages/secubox-profiles/debian/changelog
@@ -1,3 +1,19 @@
+secubox-profiles (0.2.1-1~bookworm1) bookworm; urgency=medium
+
+  * perf : /status batché — une seule commande `systemctl show` pour toutes
+    les units natives + une seule énumération `lxc-ls -f`, au lieu de 3
+    sous-process par module (observe.observe_all, mesuré 46s -> <1s sur 187
+    modules). Cache TTL 60s hors-loop (asyncio.to_thread) côté API, avec
+    rafraîchissement en arrière-plan ; cache froid = calcul direct, jamais
+    d'erreur. /status expose désormais `cached_at`/`age_s`.
+  * observe() module par module reste la référence ; observe_all() est le
+    chemin rapide, pas un remplacement — unit/conteneur absent du batch
+    reste enabled/active/lxc_running/lxc_autostart=None (jamais un False
+    fabriqué), y compris pour les units *@.service (templates) qui feraient
+    échouer tout le batch si elles y entraient.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Fri, 17 Jul 2026 12:00:00 +0200
+
 secubox-profiles (0.2.0-1~bookworm1) bookworm; urgency=medium
 
   * webui : API web (socket dédié /run/secubox/profiles.sock, service propre,

--- a/packages/secubox-profiles/debian/changelog
+++ b/packages/secubox-profiles/debian/changelog
@@ -1,3 +1,13 @@
+secubox-profiles (0.2.0-1~bookworm1) bookworm; urgency=medium
+
+  * webui : API web (socket dédié /run/secubox/profiles.sock, service propre,
+    jamais servi par l'aggregator) + panel /profiles/ (hybrid-dark).
+  * status/profiles/pins/diff en lecture ; écriture limitée aux membres de
+    profil et aux pins (jamais d'apply — Phase 3). Pin protégé->off refusé
+    en HTTP 409 avant toute écriture disque.
+
+ -- Gerald KERMA <devel@cybermind.fr>  Fri, 17 Jul 2026 12:00:00 +0200
+
 secubox-profiles (0.1.0-1~bookworm1) bookworm; urgency=medium
 
   * Phase 1 : manifestes, profiler scan, status, diff (lecture seule).

--- a/packages/secubox-profiles/debian/control
+++ b/packages/secubox-profiles/debian/control
@@ -7,7 +7,16 @@ Standards-Version: 4.6.2
 
 Package: secubox-profiles
 Architecture: all
-Depends: ${misc:Depends}, python3 (>= 3.11), secubox-core
+Depends: ${misc:Depends},
+ ${python3:Depends},
+ python3 (>= 3.11),
+ python3-fastapi,
+ python3-uvicorn,
+ python3-pydantic,
+ secubox-core
 Description: SecuBox — inventaire et profils de modules (phase 1, lecture seule)
- Manifestes de modules, profiler de configuration, état et diff.
- Phase 1 n'applique aucun changement : scan/status/diff uniquement.
+ Manifestes de modules, profiler de configuration, état et diff — CLI
+ secubox-profilectl et API web (webui /profiles/, socket dédié, jamais
+ servi par l'aggregator).
+ Phase 1 n'applique aucun changement : scan/status/diff + écriture de l'état
+ désiré (profils, pins) uniquement. `apply` n'existe pas encore.

--- a/packages/secubox-profiles/debian/install
+++ b/packages/secubox-profiles/debian/install
@@ -2,4 +2,4 @@ api/*.py               usr/lib/secubox/profiles/api/
 sbin/secubox-profilectl usr/sbin/
 www/profiles/index.html usr/share/secubox/www/profiles/
 menu.d/11-profiles.json usr/share/secubox/menu.d/
-nginx/profiles.conf    etc/nginx/secubox.d/
+nginx/profiles.conf    etc/nginx/secubox-routes.d/

--- a/packages/secubox-profiles/debian/install
+++ b/packages/secubox-profiles/debian/install
@@ -1,2 +1,5 @@
 api/*.py               usr/lib/secubox/profiles/api/
 sbin/secubox-profilectl usr/sbin/
+www/profiles/index.html usr/share/secubox/www/profiles/
+menu.d/11-profiles.json usr/share/secubox/menu.d/
+nginx/profiles.conf    etc/nginx/secubox.d/

--- a/packages/secubox-profiles/debian/postinst
+++ b/packages/secubox-profiles/debian/postinst
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    configure)
+        # Create secubox system user/group if missing (idempotent, matches
+        # sibling packages — see secubox-users/debian/postinst).
+        getent group secubox >/dev/null || groupadd --system secubox
+        getent passwd secubox >/dev/null || useradd --system --gid secubox \
+            --home /var/lib/secubox --no-create-home --shell /usr/sbin/nologin secubox
+
+        install -d -o secubox -g secubox -m 755 /etc/secubox
+        # The only directory this module ever writes to (profiles/*.toml +
+        # pins.toml) — see api/web.py _atomic_write. modules.d/ belongs to
+        # Phase 1 (scan) and is left untouched here.
+        install -d -o secubox -g secubox -m 755 /etc/secubox/profiles
+
+        # Own dedicated socket, own service — never served by the aggregator
+        # (the profile engine must not depend on something it may later
+        # restart). Restart (not just enable) so an upgrade picks up new code.
+        systemctl daemon-reload 2>/dev/null || true
+        systemctl enable secubox-profiles.service 2>/dev/null || true
+        systemctl restart secubox-profiles.service 2>/dev/null || true
+        systemctl reload nginx 2>/dev/null || true
+        ;;
+esac
+
+#DEBHELPER#
+exit 0

--- a/packages/secubox-profiles/debian/prerm
+++ b/packages/secubox-profiles/debian/prerm
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+if [ "$1" = "remove" ]; then
+    systemctl stop secubox-profiles.service || true
+    systemctl disable secubox-profiles.service || true
+    systemctl reload nginx 2>/dev/null || true
+fi
+#DEBHELPER#
+exit 0

--- a/packages/secubox-profiles/debian/secubox-profiles.service
+++ b/packages/secubox-profiles/debian/secubox-profiles.service
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Installed as /etc/systemd/system/secubox-profiles.service (own socket, own
+# service — NEVER served by the aggregator: the profile engine must not
+# depend on something it may later restart).
+[Unit]
+Description=SecuBox Profiles API — module inventory and desired-state (Phase 1, read-only)
+After=network.target secubox-core.service
+Requires=secubox-core.service
+
+[Service]
+Type=simple
+User=secubox
+Group=secubox
+WorkingDirectory=/usr/lib/secubox/profiles
+ExecStart=/usr/bin/python3 -m uvicorn api.asgi:app --uds /run/secubox/profiles.sock --log-level warning
+Restart=on-failure
+RestartSec=5
+UMask=0007
+
+NoNewPrivileges=true
+RuntimeDirectory=secubox
+RuntimeDirectoryPreserve=yes
+RuntimeDirectoryMode=0775
+
+# ProtectSystem=strict makes / read-only by default (reads of modules.d/*.toml
+# and the WAF routes file still work); the only two paths this module is
+# allowed to WRITE are /run/secubox (the socket) and /etc/secubox/profiles
+# (profiles/*.toml + pins.toml — the only writes api/web.py performs).
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/run/secubox /etc/secubox/profiles
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/secubox-profiles/menu.d/11-profiles.json
+++ b/packages/secubox-profiles/menu.d/11-profiles.json
@@ -1,0 +1,9 @@
+{
+  "id": "profiles",
+  "name": "Profiles",
+  "category": "root",
+  "icon": "🧩",
+  "path": "/profiles/",
+  "order": 11,
+  "description": "Module inventory, RAM cost and desired-state profiles (Phase 1: read-only)"
+}

--- a/packages/secubox-profiles/nginx/profiles.conf
+++ b/packages/secubox-profiles/nginx/profiles.conf
@@ -1,14 +1,24 @@
-# /etc/nginx/secubox.d/profiles.conf
-# Installed by secubox-profiles package
+# /etc/nginx/secubox-routes.d/profiles.conf — installé par secubox-profiles.
+#
+# Ce répertoire est celui que le vhost admin inclut réellement
+# (`include /etc/nginx/secubox-routes.d/*.conf;`). /etc/nginx/secubox.d/ existe
+# aussi et contient 138 fichiers, mais n'est inclus nulle part — y déposer une
+# route la rend inerte.
 
-# Frontend
+# Panel (statique, servi par le vhost admin).
 location /profiles/ {
     alias /usr/share/secubox/www/profiles/;
     try_files $uri $uri/ /profiles/index.html;
 }
 
-# API — own dedicated socket, NEVER the aggregator (see api/web.py docstring).
+# API — socket DÉDIÉE, jamais l'aggregator : le moteur de profils ne doit pas
+# dépendre de ce qu'il est susceptible de redémarrer (cf. spec §⑦).
+#
+# PAS de `:/` en fin de proxy_pass : l'app enregistre le chemin COMPLET
+# (@app.get("/api/v1/profiles/status")), donc le préfixe doit être préservé.
+# Le stripper renverrait /status à une app qui ne connaît que
+# /api/v1/profiles/status → 404.
 location /api/v1/profiles/ {
-    proxy_pass http://unix:/run/secubox/profiles.sock:/;
+    proxy_pass http://unix:/run/secubox/profiles.sock;
     include /etc/nginx/snippets/secubox-proxy.conf;
 }

--- a/packages/secubox-profiles/nginx/profiles.conf
+++ b/packages/secubox-profiles/nginx/profiles.conf
@@ -1,0 +1,14 @@
+# /etc/nginx/secubox.d/profiles.conf
+# Installed by secubox-profiles package
+
+# Frontend
+location /profiles/ {
+    alias /usr/share/secubox/www/profiles/;
+    try_files $uri $uri/ /profiles/index.html;
+}
+
+# API — own dedicated socket, NEVER the aggregator (see api/web.py docstring).
+location /api/v1/profiles/ {
+    proxy_pass http://unix:/run/secubox/profiles.sock:/;
+    include /etc/nginx/snippets/secubox-proxy.conf;
+}

--- a/packages/secubox-profiles/tests/test_observe.py
+++ b/packages/secubox-profiles/tests/test_observe.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 
 from api.manifest import Manifest
-from api.observe import Actual, is_on, load_routes, observe
+from api.observe import Actual, is_on, load_routes, observe, observe_all
 
 
 def fake_run(table):
@@ -164,6 +164,184 @@ def test_observe_portal_routed_none_when_routes_undeterminable(monkeypatch):
     })
     a = observe(LXC, run=run)
     assert a.portal_routed is None
+
+
+# ---------------------------------------------------------------------------
+# observe_all() — chemin batché (une commande systemctl show, une lxc-ls)
+# ---------------------------------------------------------------------------
+
+def _show_block(unit: str, *, enabled="enabled", active="active", pid="0",
+                order=("Id", "UnitFileState", "ActiveState", "MainPID")) -> str:
+    values = {"Id": unit, "UnitFileState": enabled, "ActiveState": active, "MainPID": pid}
+    return "\n".join(f"{k}={values[k]}" for k in order)
+
+
+def _lxc_ls_fancy(rows: list[tuple[str, str, str]]) -> str:
+    """Rebuild `lxc-ls -f` fixed-width column output (NAME/STATE/AUTOSTART/…)
+    with the SAME column widths as the real board output (captured via ssh:
+    `NAME                STATE   AUTOSTART GROUPS IPV4         IPV6 UNPRIVILEGED`),
+    so the parser is exercised against realistic alignment instead of
+    hand-typed spacing that may not match header offsets."""
+    header = (f"{'NAME':<20}{'STATE':<8}{'AUTOSTART':<10}{'GROUPS':<7}"
+             f"{'IPV4':<13}{'IPV6':<5}UNPRIVILEGED")
+    lines = [header]
+    for name, state, autostart in rows:
+        lines.append(f"{name:<20}{state:<8}{autostart:<10}{'-':<7}{'-':<13}{'-':<5}true")
+    return "\n".join(lines) + "\n"
+
+
+def test_observe_all_batches_a_single_systemctl_call_for_all_units():
+    # LE point de la bascule : une seule commande `systemctl show`, pas une
+    # boucle observe() par module (560 sous-process sur 187 modules -> 46s).
+    calls = []
+
+    def run(argv):
+        calls.append(argv)
+        if argv[:2] == ["systemctl", "show"]:
+            blocks = [_show_block(u) for u in
+                     ("secubox-a.service", "secubox-b.service", "secubox-c.service")]
+            return 0, "\n\n".join(blocks)
+        return 1, ""
+
+    manifests = {
+        mid: Manifest(id=mid, category="media", runtime="native", exposure="lan",
+                      units=(f"secubox-{mid}.service",))
+        for mid in ("a", "b", "c")
+    }
+    actuals = observe_all(manifests, run=run, routes=set())
+
+    show_calls = [c for c in calls if c[:2] == ["systemctl", "show"]]
+    assert len(show_calls) == 1, "must be ONE batched systemctl show, not one per module"
+    for u in ("secubox-a.service", "secubox-b.service", "secubox-c.service"):
+        assert u in show_calls[0]
+    for mid in ("a", "b", "c"):
+        assert actuals[mid].enabled is True and actuals[mid].active is True
+
+
+def test_observe_all_unit_missing_from_batch_output_is_none_not_false():
+    # Une unit absente du bloc renvoyé (unit inconnue de systemd, ou batch
+    # qui n'a couvert qu'une partie) doit rester indéterminée — jamais un
+    # False fabriqué, qui déclencherait une fausse décision "à éteindre".
+    def run(argv):
+        if argv[:2] == ["systemctl", "show"]:
+            return 0, _show_block("secubox-lyrion.service")
+        return 1, ""
+
+    present = Manifest(id="lyrion", category="media", runtime="native", exposure="lan",
+                       units=("secubox-lyrion.service",))
+    missing = Manifest(id="ghost", category="media", runtime="native", exposure="lan",
+                       units=("secubox-ghost-unit.service",))
+    actuals = observe_all({"lyrion": present, "ghost": missing}, run=run, routes=set())
+
+    assert actuals["lyrion"].enabled is True and actuals["lyrion"].active is True
+    assert actuals["ghost"].enabled is None
+    assert actuals["ghost"].active is None
+
+
+def test_observe_all_excludes_bare_template_units_from_the_batch():
+    # secubox-toolbox-ng-worker@.service (bare template, no instance) crashes
+    # `systemctl show` for the WHOLE batch when included (verified on the
+    # board: aborts after the first bad unit, dropping everything after it in
+    # argv). It must never reach argv, and its own state stays unknown.
+    calls = []
+
+    def run(argv):
+        calls.append(argv)
+        if argv[:2] == ["systemctl", "show"]:
+            return 0, _show_block("secubox-lyrion.service")
+        return 1, ""
+
+    normal = Manifest(id="lyrion", category="media", runtime="native", exposure="lan",
+                      units=("secubox-lyrion.service",))
+    template = Manifest(id="worker", category="infra", runtime="native", exposure="internal",
+                        units=("secubox-toolbox-ng-worker@.service",))
+    actuals = observe_all({"lyrion": normal, "worker": template}, run=run, routes=set())
+
+    show_call = next(c for c in calls if c[:2] == ["systemctl", "show"])
+    assert "secubox-toolbox-ng-worker@.service" not in show_call
+    assert actuals["worker"].enabled is None
+    assert actuals["worker"].active is None
+    assert actuals["lyrion"].enabled is True  # unaffected
+
+
+def test_observe_all_parses_block_regardless_of_property_order():
+    # Observé sur la board : MainPID peut apparaître AVANT Id dans un bloc.
+    # Le parsing doit être par clé, jamais par position.
+    def run(argv):
+        if argv[:2] == ["systemctl", "show"]:
+            return 0, _show_block(
+                "secubox-lyrion.service", pid="4242",
+                order=("MainPID", "ActiveState", "Id", "UnitFileState"))
+        return 1, ""
+
+    m = Manifest(id="lyrion", category="media", runtime="native", exposure="lan",
+                 units=("secubox-lyrion.service",))
+    actuals = observe_all({"lyrion": m}, run=run, routes=set())
+    assert actuals["lyrion"].enabled is True
+    assert actuals["lyrion"].active is True
+
+
+def test_observe_all_static_unit_file_state_is_enabled_true():
+    # `systemctl is-enabled` exits 0 (enabled) for UnitFileState=static — pas
+    # seulement pour "enabled" littéralement (25 des 183 units réelles de la
+    # board sont "static"). Un mapping naïf ufs=="enabled" mentirait ici.
+    def run(argv):
+        if argv[:2] == ["systemctl", "show"]:
+            return 0, _show_block("secubox-adblock-sync.service", enabled="static")
+        return 1, ""
+
+    m = Manifest(id="adblock-sync", category="network", runtime="native", exposure="lan",
+                 units=("secubox-adblock-sync.service",))
+    actuals = observe_all({"adblock-sync": m}, run=run, routes=set())
+    assert actuals["adblock-sync"].enabled is True
+
+
+def test_observe_all_lxc_is_a_single_enumeration_and_missing_container_is_none():
+    calls = []
+
+    def run(argv):
+        calls.append(argv)
+        if argv[:2] == ["systemctl", "show"]:
+            blocks = [_show_block(u) for u in
+                     ("secubox-peertube.service", "secubox-ghost.service")]
+            return 0, "\n\n".join(blocks)
+        if argv == ["lxc-ls", "-f"]:
+            return 0, _lxc_ls_fancy([("peertube", "RUNNING", "1")])
+        return 1, ""
+
+    peertube = Manifest(id="peertube", category="media", runtime="lxc", exposure="public",
+                        units=("secubox-peertube.service",), lxc="peertube")
+    ghost = Manifest(id="ghost", category="media", runtime="lxc", exposure="lan",
+                     units=("secubox-ghost.service",), lxc="ghost-container")
+    actuals = observe_all({"peertube": peertube, "ghost": ghost}, run=run, routes=set())
+
+    lxc_calls = [c for c in calls if c[0] == "lxc-ls"]
+    assert len(lxc_calls) == 1, "must be ONE lxc-ls enumeration, not one lxc-info per container"
+    assert actuals["peertube"].lxc_running is True
+    assert actuals["peertube"].lxc_autostart is True
+    # ghost-container absent from lxc-ls output -> stays unknown, not False.
+    assert actuals["ghost"].lxc_running is None
+    assert actuals["ghost"].lxc_autostart is None
+
+
+def test_observe_all_matches_observe_for_a_single_module(monkeypatch):
+    # observe_all() doit produire le même résultat que observe() pour un
+    # module donné — seul le coût change, pas le contrat.
+    run_single = fake_run({
+        ("systemctl", "is-enabled", "secubox-lyrion.service"): (0, "enabled\n"),
+        ("systemctl", "is-active", "secubox-lyrion.service"): (0, "active\n"),
+        ("systemctl", "show", "secubox-lyrion.service", "-p", "MainPID", "--value"): (0, "0\n"),
+    })
+    single = observe(NATIVE, run=run_single, routes=set())
+
+    def run_batch(argv):
+        if argv[:2] == ["systemctl", "show"]:
+            return 0, _show_block("secubox-lyrion.service")
+        return 1, ""
+
+    batched = observe_all({"lyrion": NATIVE}, run=run_batch, routes=set())["lyrion"]
+    assert batched.enabled == single.enabled
+    assert batched.active == single.active
 
 
 def test_load_routes_untraversable_parent_is_none_not_crash(tmp_path):

--- a/packages/secubox-profiles/tests/test_observe.py
+++ b/packages/secubox-profiles/tests/test_observe.py
@@ -164,3 +164,20 @@ def test_observe_portal_routed_none_when_routes_undeterminable(monkeypatch):
     })
     a = observe(LXC, run=run)
     assert a.portal_routed is None
+
+
+def test_load_routes_untraversable_parent_is_none_not_crash(tmp_path):
+    """Cas RÉEL de la board : /etc/secubox/waf est 0750 root:root alors que
+    haproxy-routes.json est 0644 — le fichier est lisible, le répertoire non
+    traversable. `.exists()` lève alors PermissionError. Le laisser hors du try
+    remontait un 500 sur GET /status. Inconnu ne doit ni mentir ni planter."""
+    import os
+    waf = tmp_path / "waf"
+    waf.mkdir()
+    routes = waf / "haproxy-routes.json"
+    routes.write_text(json.dumps({"peertube.gk2.secubox.in": ["127.0.0.1", 9000]}))
+    os.chmod(waf, 0o000)          # parent non traversable
+    try:
+        assert load_routes(routes) is None    # indéterminable, pas set(), pas d'exception
+    finally:
+        os.chmod(waf, 0o755)      # sinon tmp_path n'est pas nettoyable

--- a/packages/secubox-profiles/tests/test_web.py
+++ b/packages/secubox-profiles/tests/test_web.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+# Source-Disclosed License — All rights reserved except as expressly granted.
+# See LICENCE-CMSD-1.0.md for terms.
+
+"""
+Tests API web (packages/secubox-profiles/api/web.py).
+
+Portent en priorité sur les hard constraints du plan (voir CLAUDE.md du
+projet) : `apply` n'existe nulle part, un pin protégé->off est refusé AVANT
+d'écrire, l'écriture de profil est atomique et fait un aller-retour propre
+via load_profile, et 404 sur un id/profil inconnu.
+
+`common/` est ajouté à sys.path pour importer le VRAI secubox_core.auth
+(comme packages/secubox-users/tests/test_users_api_handlers.py) : un test
+vérifie que require_jwt réel est bien branché (401 sans credentials) avant
+que les autres tests ne le bypassent via dependency_overrides.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "common"))
+# packages/secubox-profiles itself is already on sys.path via conftest.py.
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import api.web as web  # noqa: E402
+from api.manifest import PROTECTED_IDS  # noqa: E402
+from api.state import load_profile, load_pins  # noqa: E402
+
+MANIFEST_LYRION = """
+id       = "lyrion"
+category = "media"
+runtime  = "native"
+exposure = "lan"
+units    = ["secubox-lyrion.service"]
+priority = 30
+"""
+
+MANIFEST_AUTH = """
+id       = "auth"
+category = "security"
+runtime  = "native"
+exposure = "internal"
+units    = ["secubox-auth.service"]
+priority = 90
+"""
+
+
+def _noop_jwt():
+    return {"sub": "admin"}
+
+
+@pytest.fixture()
+def root(tmp_path, monkeypatch):
+    (tmp_path / "modules.d").mkdir()
+    (tmp_path / "modules.d" / "lyrion.toml").write_text(MANIFEST_LYRION)
+    (tmp_path / "modules.d" / "auth.toml").write_text(MANIFEST_AUTH)
+    (tmp_path / "profiles").mkdir()
+    (tmp_path / "profiles" / "media.toml").write_text(
+        'name = "media"\nlabel = "\U0001f3ac Média"\non = ["lyrion"]\n')
+    (tmp_path / "profiles" / "active").write_text("media\n")
+    monkeypatch.setenv("SECUBOX_PROFILES_ROOT", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture()
+def client(root, monkeypatch):
+    # Deterministic observation: lyrion on, auth on (protected forces ON
+    # anyway, but the fixture keeps observe() consistent with reality).
+    from api.observe import Actual
+
+    monkeypatch.setattr(web._cli, "_observe_all", lambda ms, routes: {
+        "lyrion": Actual(enabled=True, active=True, rss_kb=2048),
+        "auth": Actual(enabled=True, active=True, rss_kb=4096),
+    })
+    monkeypatch.setattr(web, "load_routes", lambda: set())
+    c = TestClient(web.app)
+    c.app.dependency_overrides[web.require_jwt] = _noop_jwt
+    yield c
+    c.app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# apply must not exist anywhere
+# ---------------------------------------------------------------------------
+
+def test_apply_route_does_not_exist(client):
+    paths = {getattr(r, "path", "") for r in client.app.routes}
+    assert not any("apply" in p for p in paths)
+    # Also: no route accepts an action verb that would actuate anything.
+    for p in paths:
+        assert "start" not in p and "stop" not in p and "restart" not in p
+
+
+def test_web_module_has_no_actuation_helper():
+    # Grep-level guard: nothing in web.py calls systemctl/lxc-* directly —
+    # only read helpers (_cli._observe_all -> observe.py) are used, and those
+    # are read-only by construction (see observe.py docstring).
+    src = Path(web.__file__).read_text(encoding="utf-8")
+    for forbidden in ("systemctl start", "systemctl stop", "systemctl enable",
+                      "systemctl disable", "lxc-start", "lxc-stop"):
+        assert forbidden not in src
+
+
+# ---------------------------------------------------------------------------
+# JWT gating
+# ---------------------------------------------------------------------------
+
+def test_status_requires_jwt_when_not_overridden(root):
+    # Real secubox_core.auth.require_jwt (no override): no Authorization
+    # header, no session cookie -> 401. Confirms Depends(require_jwt) is
+    # actually wired on the route, not just imported.
+    c = TestClient(web.app)
+    resp = c.get("/api/v1/profiles/status")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# status / profiles / pins / diff (read paths)
+# ---------------------------------------------------------------------------
+
+def test_status_lists_modules_with_tri_state(client):
+    resp = client.get("/api/v1/profiles/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    ids = {m["id"]: m for m in data["modules"]}
+    assert ids["lyrion"]["on"] == "on"
+    assert ids["auth"]["protected"] is True
+    assert data["totals"]["count"] == 2
+    assert "media" in data["by_category"]
+
+
+def test_status_surfaces_unknown_probe_not_off(root, monkeypatch):
+    from api.observe import Actual
+
+    monkeypatch.setattr(web._cli, "_observe_all", lambda ms, routes: {
+        "lyrion": Actual(enabled=None, active=None),  # probe could not run
+        "auth": Actual(enabled=True, active=True),
+    })
+    monkeypatch.setattr(web, "load_routes", lambda: set())
+    c = TestClient(web.app)
+    c.app.dependency_overrides[web.require_jwt] = _noop_jwt
+    resp = c.get("/api/v1/profiles/status")
+    ids = {m["id"]: m for m in resp.json()["modules"]}
+    assert ids["lyrion"]["on"] == "unknown"
+    assert ids["lyrion"]["on"] != "off"
+
+
+def test_list_profiles_reports_active(client):
+    resp = client.get("/api/v1/profiles/profiles")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["active"] == "media"
+    assert data["profiles"][0]["name"] == "media"
+    assert data["profiles"][0]["on"] == ["lyrion"]
+
+
+def test_get_pins_empty_by_default(client):
+    resp = client.get("/api/v1/profiles/pins")
+    assert resp.status_code == 200
+    assert resp.json() == {"pins": {}}
+
+
+def test_diff_reports_no_change_when_converged(client):
+    resp = client.get("/api/v1/profiles/diff", params={"profile": "media"})
+    assert resp.status_code == 200
+    assert resp.json()["changes"] == []
+
+
+def test_diff_unknown_profile_is_404(client):
+    resp = client.get("/api/v1/profiles/diff", params={"profile": "fantome"})
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# members (write path #1)
+# ---------------------------------------------------------------------------
+
+def test_set_member_adds_and_round_trips(client, root):
+    resp = client.post("/api/v1/profiles/profiles/media/members",
+                       json={"id": "auth", "on": True})
+    assert resp.status_code == 200
+    assert set(resp.json()["on"]) == {"lyrion", "auth"}
+    # Round-trip through the real reader, not just the API response.
+    prof = load_profile(root / "profiles" / "media.toml")
+    assert prof.on == frozenset({"lyrion", "auth"})
+    assert prof.label == "\U0001f3ac Média"  # label preserved
+
+
+def test_set_member_removes(client, root):
+    resp = client.post("/api/v1/profiles/profiles/media/members",
+                       json={"id": "lyrion", "on": False})
+    assert resp.status_code == 200
+    assert resp.json()["on"] == []
+    prof = load_profile(root / "profiles" / "media.toml")
+    assert prof.on == frozenset()
+
+
+def test_set_member_unknown_profile_404(client):
+    resp = client.post("/api/v1/profiles/profiles/fantome/members",
+                       json={"id": "lyrion", "on": True})
+    assert resp.status_code == 404
+
+
+def test_set_member_unknown_module_404(client):
+    resp = client.post("/api/v1/profiles/profiles/media/members",
+                       json={"id": "fantome", "on": True})
+    assert resp.status_code == 404
+
+
+def test_set_member_atomic_write_leaves_no_tmp_file(client, root):
+    client.post("/api/v1/profiles/profiles/media/members", json={"id": "auth", "on": True})
+    leftovers = list((root / "profiles").glob("*.tmp"))
+    assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# pins (write path #2) — the load-bearing protected-refusal test
+# ---------------------------------------------------------------------------
+
+def test_set_pin_on_ordinary_module_writes(client, root):
+    resp = client.post("/api/v1/profiles/pins", json={"id": "lyrion", "pin": "off"})
+    assert resp.status_code == 200
+    assert resp.json()["pins"] == {"lyrion": "off"}
+    pins = load_pins(root / "profiles" / "pins.toml")
+    assert pins == {"lyrion": "off"}
+
+
+def test_set_pin_protected_module_off_is_refused(client, root):
+    """The one hard constraint that matters most: a pin that would switch a
+    protected module off must be rejected with 409 and NOTHING must reach
+    disk. `auth` is in PROTECTED_IDS, so manifest.load_manifest() forces
+    protected=True on it regardless of the .toml content."""
+    assert "auth" in PROTECTED_IDS
+    resp = client.post("/api/v1/profiles/pins", json={"id": "auth", "pin": "off"})
+    assert resp.status_code == 409
+    pins_file = root / "profiles" / "pins.toml"
+    assert not pins_file.exists()  # refusal happened before any write
+
+
+def test_set_pin_protected_module_on_is_allowed(client, root):
+    # Pinning a protected module ON is a no-op semantically (resolve() always
+    # forces ON for protected modules) but must not be blocked — only OFF is
+    # the lock-out case.
+    resp = client.post("/api/v1/profiles/pins", json={"id": "auth", "pin": "on"})
+    assert resp.status_code == 200
+
+
+def test_set_pin_clear_with_null(client, root):
+    client.post("/api/v1/profiles/pins", json={"id": "lyrion", "pin": "off"})
+    resp = client.post("/api/v1/profiles/pins", json={"id": "lyrion", "pin": None})
+    assert resp.status_code == 200
+    assert resp.json()["pins"] == {}
+    pins = load_pins(root / "profiles" / "pins.toml")
+    assert pins == {}
+
+
+def test_set_pin_unknown_module_404(client):
+    resp = client.post("/api/v1/profiles/pins", json={"id": "fantome", "pin": "on"})
+    assert resp.status_code == 404
+
+
+def test_set_pin_invalid_value_400(client):
+    resp = client.post("/api/v1/profiles/pins", json={"id": "lyrion", "pin": "sideways"})
+    assert resp.status_code == 400
+
+
+def test_diff_after_pin_reflects_refusal_not_partial_state(client, root):
+    # Belt-and-braces: even if the write-path refusal were somehow bypassed,
+    # plan_changes() itself raises ProtectedViolation independently — but the
+    # write-path refusal must be the one that actually stops the write, which
+    # is what test_set_pin_protected_module_off_is_refused proves via the
+    # missing pins.toml file. Here we only confirm /diff still 409s cleanly
+    # (no half-written pins.toml poisoning subsequent reads).
+    client.post("/api/v1/profiles/pins", json={"id": "auth", "pin": "off"})  # refused, no-op
+    resp = client.get("/api/v1/profiles/diff", params={"profile": "media"})
+    assert resp.status_code == 200
+    assert resp.json()["changes"] == []

--- a/packages/secubox-profiles/www/profiles/index.html
+++ b/packages/secubox-profiles/www/profiles/index.html
@@ -1,0 +1,480 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SecuBox — Module Profiles</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/shared/hybrid-skin.css">
+    <style>
+        :root {
+            --p31-dim: #6b7b8b;
+            --bg-dark: #0d1117;
+            --bg-card: rgba(30, 40, 55, 0.8);
+            --bg-row: rgba(20, 30, 45, 0.6);
+            --border: rgba(100, 150, 200, 0.2);
+            --text: #e8e6d9;
+            --red: #ff4466;
+            --orange: #ff9944;
+            --yellow: #ffcc00;
+            --green: #00dd44;
+            --blue: #4488ff;
+            --purple: #a371f7;
+            --cyan: #00d4ff;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: 'Courier Prime', monospace; background: var(--bg-dark); color: var(--text); display: flex; min-height: 100vh; }
+        .sidebar { width: 220px; position: fixed; height: 100vh; overflow-y: auto; }
+        .main { flex: 1; margin-left: 220px; padding: 1.5rem; padding-top: 60px; background: linear-gradient(135deg, rgba(10,15,25,0.95), rgba(15,25,40,0.9)); min-height: 100vh; }
+        .header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.2rem; flex-wrap: wrap; gap: 0.5rem; }
+        .header h1 { font-size: 1.4rem; color: var(--cyan); text-shadow: 0 0 10px var(--cyan); }
+        .header .sub { font-size: 0.7rem; color: var(--p31-dim); margin-top: 0.15rem; }
+        .btn { padding: 0.4rem 0.8rem; border-radius: 6px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text); cursor: pointer; font-size: 0.8rem; font-family: 'Courier Prime', monospace; text-transform: uppercase; transition: all 0.2s; }
+        .btn:hover { border-color: var(--cyan); color: var(--cyan); box-shadow: 0 0 8px rgba(0,212,255,0.3); }
+        .btn.primary { background: rgba(0,212,255,0.15); border-color: var(--cyan); color: var(--cyan); }
+        .btn.danger { background: rgba(255,68,102,0.15); border-color: var(--red); color: var(--red); }
+        .btn.good { background: rgba(0,221,68,0.15); border-color: var(--green); color: var(--green); }
+        .btn.sm { padding: 0.2rem 0.55rem; font-size: 0.7rem; }
+        .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .btn.active { border-color: var(--cyan); color: var(--cyan); background: rgba(0,212,255,0.18); }
+        .btn-group { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+
+        .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 0.75rem; margin-bottom: 1.2rem; }
+        .stat-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; padding: 0.7rem; text-align: center; backdrop-filter: blur(5px); }
+        .stat-card .value { font-size: 1.5rem; font-weight: bold; text-shadow: 0 0 10px currentColor; font-variant-numeric: tabular-nums; }
+        .stat-card .label { font-size: 0.6rem; color: var(--p31-dim); letter-spacing: 0.1em; margin-top: 0.25rem; text-transform: uppercase; }
+        .stat-card.cyan .value { color: var(--cyan); }
+        .stat-card.green .value { color: var(--green); }
+        .stat-card.red .value { color: var(--red); }
+        .stat-card.blue .value { color: var(--blue); }
+        .stat-card.purple .value { color: var(--purple); }
+        .stat-card.orange .value { color: var(--orange); }
+        .stat-card.dim .value { color: var(--p31-dim); }
+
+        .card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; padding: 1rem; margin-bottom: 1rem; backdrop-filter: blur(10px); }
+        .card h3 { font-size: 0.85rem; color: var(--cyan); margin-bottom: 0.75rem; display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; flex-wrap: wrap; }
+        .card h3 .note { font-size: 0.62rem; color: var(--p31-dim); text-transform: none; font-weight: normal; letter-spacing: 0; }
+
+        .tabs { display: flex; border-bottom: 1px solid var(--border); margin-bottom: 0.85rem; flex-wrap: wrap; gap: 0.2rem; }
+        .tab { padding: 0.4rem 0.7rem; cursor: pointer; color: var(--p31-dim); border-bottom: 2px solid transparent; font-size: 0.68rem; text-transform: uppercase; transition: all 0.2s; }
+        .tab:hover { color: var(--cyan); }
+        .tab.active { color: var(--cyan); border-bottom-color: var(--cyan); }
+        .tab-content { display: none; }
+        .tab-content.active { display: block; }
+
+        .agg-table { width: 100%; border-collapse: collapse; font-size: 0.72rem; }
+        .agg-table th { text-align: left; color: var(--p31-dim); text-transform: uppercase; font-size: 0.6rem; letter-spacing: 0.06em; padding: 0.3rem 0.4rem; border-bottom: 1px solid var(--border); }
+        .agg-table td { padding: 0.3rem 0.4rem; border-bottom: 1px solid rgba(100,150,200,0.08); }
+        .agg-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
+        .agg-table .on { color: var(--green); }
+        .agg-table .off { color: var(--p31-dim); }
+        .agg-table .unknown { color: var(--orange); }
+
+        select, .profile-select { padding: 0.4rem 0.6rem; background: var(--bg-row); border: 1px solid var(--border); border-radius: 4px; font-family: 'Courier Prime', monospace; font-size: 0.75rem; color: var(--text); }
+        select:focus { outline: none; border-color: var(--cyan); }
+
+        .filter-bar { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; align-items: center; }
+        .filter-bar input { flex: 1; min-width: 150px; padding: 0.4rem; background: var(--bg-row); border: 1px solid var(--border); border-radius: 4px; font-family: 'Courier Prime', monospace; font-size: 0.8rem; color: var(--text); }
+
+        .mod-list { display: flex; flex-direction: column; gap: 0.28rem; max-height: 560px; overflow-y: auto; }
+        .mod-row { display: grid; grid-template-columns: 1.4em 1fr auto auto auto auto auto auto; align-items: center; gap: 0.55rem; padding: 0.45rem 0.6rem; background: var(--bg-row); border-radius: 4px; font-size: 0.73rem; border-left: 3px solid var(--border); transition: background 0.15s; }
+        .mod-row:hover { background: rgba(0,212,255,0.06); }
+        .mod-row.on { border-left-color: var(--green); }
+        .mod-row.off { border-left-color: var(--p31-dim); }
+        .mod-row.unknown { border-left-color: var(--orange); }
+        .mod-row .glyph { text-align: center; font-size: 0.95em; }
+        .mod-row .id { color: var(--cyan); font-weight: bold; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .mod-row .id .lock { margin-left: 0.3em; }
+        .mod-row .meta { font-size: 0.62rem; color: var(--p31-dim); white-space: nowrap; }
+        .mod-row .prio { font-size: 0.65rem; color: var(--p31-dim); text-align: right; white-space: nowrap; }
+        .mod-row .rss { font-size: 0.65rem; color: var(--blue); text-align: right; white-space: nowrap; min-width: 3.5em; }
+        .mod-row .member { display: flex; align-items: center; gap: 0.3rem; white-space: nowrap; }
+        .mod-row .member input { accent-color: var(--cyan); cursor: pointer; }
+        .mod-row .pins { display: flex; gap: 0.15rem; }
+        .mod-row .pins .btn.sm { padding: 0.15rem 0.4rem; font-size: 0.62rem; }
+        .exposure-badge { font-size: 0.6rem; padding: 0.1rem 0.4rem; border-radius: 999px; text-transform: uppercase; letter-spacing: 0.05em; white-space: nowrap; border: 1px solid var(--border); }
+        .exposure-badge.public { color: var(--red); border-color: var(--red); }
+        .exposure-badge.lan { color: var(--blue); border-color: var(--blue); }
+        .exposure-badge.internal { color: var(--p31-dim); }
+
+        .diff-banner { background: rgba(255,153,68,0.08); border: 1px dashed var(--orange); border-radius: 6px; padding: 0.6rem 0.8rem; font-size: 0.7rem; color: var(--orange); margin-bottom: 0.75rem; }
+        .diff-list { display: flex; flex-direction: column; gap: 0.25rem; max-height: 340px; overflow-y: auto; }
+        .diff-row { display: grid; grid-template-columns: auto auto 1fr auto; align-items: center; gap: 0.6rem; padding: 0.4rem 0.55rem; background: var(--bg-row); border-radius: 4px; font-size: 0.72rem; border-left: 3px solid var(--border); }
+        .diff-row.start { border-left-color: var(--green); }
+        .diff-row.stop { border-left-color: var(--red); }
+        .diff-row .action { font-size: 0.62rem; text-transform: uppercase; padding: 0.12rem 0.45rem; border-radius: 999px; white-space: nowrap; }
+        .diff-row .action.start { color: var(--green); border: 1px solid var(--green); }
+        .diff-row .action.stop { color: var(--red); border: 1px solid var(--red); }
+        .diff-row .id { color: var(--cyan); font-weight: bold; }
+        .diff-row .reason { color: var(--p31-dim); font-size: 0.65rem; }
+        .diff-row .prio { color: var(--p31-dim); font-size: 0.65rem; text-align: right; }
+        .empty-note { padding: 1rem; text-align: center; color: var(--p31-dim); font-size: 0.75rem; }
+
+        .toast { position: fixed; bottom: 24px; right: 20px; padding: 0.75rem 1rem; background: var(--cyan); color: #000; border-radius: 6px; font-size: 0.8rem; z-index: 2000; opacity: 0; transform: translateY(20px); transition: all 0.3s; box-shadow: 0 0 20px rgba(0,212,255,0.4); max-width: 360px; }
+        .toast.show { opacity: 1; transform: translateY(0); }
+        .toast.error { background: var(--red); color: #fff; box-shadow: 0 0 20px rgba(255,68,102,0.4); }
+        .toast .close { float: right; margin-left: 0.6rem; cursor: pointer; font-weight: bold; }
+
+        ::-webkit-scrollbar { width: 5px; height: 5px; }
+        ::-webkit-scrollbar-track { background: rgba(20,30,45,0.5); }
+        ::-webkit-scrollbar-thumb { background: var(--p31-dim); border-radius: 3px; }
+        ::-webkit-scrollbar-thumb:hover { background: var(--cyan); }
+        @media (max-width: 768px) {
+            .main { margin-left: 0; }
+            .mod-row { grid-template-columns: 1.2em 1fr auto; }
+            .mod-row .meta, .mod-row .prio, .mod-row .rss, .mod-row .member { display: none; }
+            .diff-row { grid-template-columns: auto 1fr; }
+            .diff-row .reason, .diff-row .prio { display: none; }
+        }
+    </style>
+</head>
+<body class="hybrid-dark">
+    <nav class="sidebar" id="sidebar"></nav>
+    <script src="/shared/sidebar.js"></script>
+    <main class="main">
+        <header class="header">
+            <div>
+                <h1>🧩 Module Profiles</h1>
+                <div class="sub" id="subline">Phase 1 — inventory &amp; desired state · read-only, no actuation</div>
+            </div>
+            <div class="btn-group">
+                <button class="btn" id="refreshBtn">↻ Refresh</button>
+            </div>
+        </header>
+
+        <div class="grid" id="statGrid">
+            <div class="stat-card cyan"><div class="value" id="sTotal">–</div><div class="label">📦 Modules</div></div>
+            <div class="stat-card green"><div class="value" id="sOn">–</div><div class="label">🟢 On</div></div>
+            <div class="stat-card dim"><div class="value" id="sOff">–</div><div class="label">⚫ Off</div></div>
+            <div class="stat-card orange"><div class="value" id="sUnknown">–</div><div class="label">❓ Unknown</div></div>
+            <div class="stat-card blue"><div class="value" id="sRam">–</div><div class="label">💾 RAM (known)</div></div>
+            <div class="stat-card red"><div class="value" id="sExposed">–</div><div class="label">🌐 Exposed Public</div></div>
+        </div>
+
+        <div class="card">
+            <h3>📊 Cost &amp; state by taxonomy</h3>
+            <div class="tabs">
+                <div class="tab active" data-tab="agg-category">Category</div>
+                <div class="tab" data-tab="agg-runtime">Runtime</div>
+                <div class="tab" data-tab="agg-exposure">Exposure</div>
+            </div>
+            <div id="agg-category" class="tab-content active"><table class="agg-table" id="aggCategoryTable"></table></div>
+            <div id="agg-runtime" class="tab-content"><table class="agg-table" id="aggRuntimeTable"></table></div>
+            <div id="agg-exposure" class="tab-content"><table class="agg-table" id="aggExposureTable"></table></div>
+        </div>
+
+        <div class="card">
+            <h3>🗂 Profile
+                <span class="note">membership checkbox &amp; diff below apply to the selected profile</span>
+            </h3>
+            <div class="btn-group">
+                <select id="profileSelect"></select>
+                <span id="profileLabel" style="font-size:0.72rem;color:var(--p31-dim)"></span>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3>📦 Modules <span class="note" id="modCount"></span></h3>
+            <div class="filter-bar">
+                <input type="text" id="searchInput" placeholder="🔍 Filter by id / category…">
+                <select id="stateFilter">
+                    <option value="">All states</option>
+                    <option value="on">🟢 On</option>
+                    <option value="off">⚫ Off</option>
+                    <option value="unknown">❓ Unknown</option>
+                </select>
+            </div>
+            <div class="mod-list" id="modList">Loading…</div>
+        </div>
+
+        <div class="card">
+            <h3>🧮 Diff — <span id="diffProfileName">–</span></h3>
+            <div class="diff-banner">⚠️ NOT APPLIED — Phase 1 has no <code>apply</code>. This is a preview of what
+                the selected profile would change if actuated; nothing here starts or stops anything. Actuation
+                arrives in Phase 3 with 4R snapshots and audit.</div>
+            <div class="diff-list" id="diffList">Loading…</div>
+        </div>
+    </main>
+
+    <div class="toast" id="toast"></div>
+
+    <script>
+        const API = '/api/v1/profiles';
+        let statusData = null;
+        let profilesData = null;
+        let pinsData = {};
+        let selectedProfile = null;
+        let searchTerm = '';
+        let stateFilterVal = '';
+
+        function token() {
+            try { return localStorage.getItem('sbx_token') || ''; } catch (e) { return ''; }
+        }
+        function authHeaders(extra) {
+            const h = Object.assign({}, extra || {});
+            const t = token();
+            if (t) h['Authorization'] = 'Bearer ' + t;
+            return h;
+        }
+        function esc(s) {
+            return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+        }
+        function fmtKb(kb) {
+            if (kb == null) return '—';
+            const mb = kb / 1024;
+            return (mb >= 10 ? mb.toFixed(0) : mb.toFixed(1)) + ' MB';
+        }
+
+        function toast(msg) {
+            const t = document.getElementById('toast');
+            t.innerHTML = esc(msg);
+            t.className = 'toast show';
+            clearTimeout(t._hideTimer);
+            t._hideTimer = setTimeout(() => { t.className = 'toast'; }, 3000);
+        }
+        function errorToast(msg) {
+            const t = document.getElementById('toast');
+            t.innerHTML = esc(msg) + '<span class="close" data-act="dismiss-toast">✕</span>';
+            t.className = 'toast show error';
+            clearTimeout(t._hideTimer);
+        }
+        document.getElementById('toast').addEventListener('click', e => {
+            if (e.target.closest('[data-act="dismiss-toast"]')) {
+                const t = document.getElementById('toast');
+                t.className = 'toast';
+            }
+        });
+
+        async function api(path, opts) {
+            const res = await fetch(API + path, Object.assign({}, opts, { headers: authHeaders((opts && opts.headers) || {}) }));
+            if (res.status === 401) { errorToast('🔒 Login required'); throw new Error('401'); }
+            let data = null;
+            try { data = await res.json(); } catch (e) { /* no body */ }
+            if (!res.ok) {
+                const detail = (data && data.detail) ? data.detail : ('HTTP ' + res.status);
+                throw new Error(detail);
+            }
+            return data;
+        }
+
+        async function refresh() {
+            try {
+                const [status, profiles, pins] = await Promise.all([
+                    api('/status'),
+                    api('/profiles'),
+                    api('/pins'),
+                ]);
+                statusData = status;
+                profilesData = profiles;
+                pinsData = (pins && pins.pins) || {};
+                if (!selectedProfile) selectedProfile = profiles.active || (profiles.profiles[0] && profiles.profiles[0].name) || null;
+                renderStats();
+                renderAggregates();
+                renderProfileSelect();
+                renderModules();
+                await loadDiff();
+            } catch (e) {
+                if (e.message !== '401') errorToast('⚠️ Failed to load: ' + e.message);
+            }
+        }
+
+        function renderStats() {
+            const t = (statusData && statusData.totals) || {};
+            document.getElementById('sTotal').textContent = t.count != null ? t.count : '–';
+            document.getElementById('sOn').textContent = t.on != null ? t.on : '–';
+            document.getElementById('sOff').textContent = t.off != null ? t.off : '–';
+            document.getElementById('sUnknown').textContent = t.unknown != null ? t.unknown : '–';
+            document.getElementById('sRam').textContent = fmtKb(t.rss_kb);
+            document.getElementById('sExposed').textContent = t.exposed_public != null ? t.exposed_public : '–';
+            document.getElementById('subline').textContent =
+                (t.count || 0) + ' modules · ' + (t.on || 0) + ' on · ' + (t.unknown || 0) + ' unknown · read-only inventory';
+        }
+
+        function renderAggTable(elId, bucket) {
+            const el = document.getElementById(elId);
+            const keys = Object.keys(bucket || {}).sort();
+            if (!keys.length) { el.innerHTML = '<tr><td class="empty-note">No data</td></tr>'; return; }
+            let html = '<tr><th>Key</th><th class="num">Count</th><th class="num">On</th><th class="num">Off</th><th class="num">Unknown</th><th class="num">RAM</th></tr>';
+            keys.forEach(k => {
+                const b = bucket[k];
+                html += '<tr><td>' + esc(k) + '</td>' +
+                    '<td class="num">' + b.count + '</td>' +
+                    '<td class="num on">' + b.on + '</td>' +
+                    '<td class="num off">' + b.off + '</td>' +
+                    '<td class="num unknown">' + b.unknown + '</td>' +
+                    '<td class="num">' + fmtKb(b.rss_kb) + '</td></tr>';
+            });
+            el.innerHTML = html;
+        }
+
+        function renderAggregates() {
+            if (!statusData) return;
+            renderAggTable('aggCategoryTable', statusData.by_category);
+            renderAggTable('aggRuntimeTable', statusData.by_runtime);
+            renderAggTable('aggExposureTable', statusData.by_exposure);
+        }
+
+        function renderProfileSelect() {
+            const sel = document.getElementById('profileSelect');
+            const list = (profilesData && profilesData.profiles) || [];
+            sel.innerHTML = list.map(p =>
+                '<option value="' + esc(p.name) + '"' + (p.name === selectedProfile ? ' selected' : '') + '>' +
+                esc(p.label) + (p.name === profilesData.active ? ' (active)' : '') + '</option>'
+            ).join('') || '<option value="">No profile</option>';
+            const cur = list.find(p => p.name === selectedProfile);
+            document.getElementById('profileLabel').textContent = cur ? cur.on.length + ' module(s) listed' : '';
+            document.getElementById('diffProfileName').textContent = selectedProfile || '(none active)';
+        }
+
+        function pinGlyph(id) {
+            const p = pinsData[id];
+            if (p === 'on') return { cls: 'on', label: '📌 ON' };
+            if (p === 'off') return { cls: 'off', label: '📌 OFF' };
+            return { cls: 'follow', label: '⟳ follows profile' };
+        }
+
+        function renderModules() {
+            const el = document.getElementById('modList');
+            let mods = (statusData && statusData.modules) || [];
+            const cur = (profilesData && profilesData.profiles || []).find(p => p.name === selectedProfile);
+            const memberSet = new Set(cur ? cur.on : []);
+
+            if (searchTerm) {
+                const s = searchTerm.toLowerCase();
+                mods = mods.filter(m => m.id.toLowerCase().includes(s) || m.category.toLowerCase().includes(s));
+            }
+            if (stateFilterVal) {
+                mods = mods.filter(m => m.on === stateFilterVal);
+            }
+            mods = mods.slice().sort((a, b) => (b.priority - a.priority) || a.id.localeCompare(b.id));
+
+            document.getElementById('modCount').textContent = '(' + mods.length + ' shown)';
+
+            if (!mods.length) {
+                el.innerHTML = '<div class="empty-note">No modules match the current filter.</div>';
+                return;
+            }
+
+            el.innerHTML = mods.map(m => {
+                const glyph = m.on === 'on' ? '🟢' : m.on === 'unknown' ? '❓' : '⚫';
+                const isMember = memberSet.has(m.id);
+                const pin = pinGlyph(m.id);
+                const pinOffDisabled = m.protected;
+                return '<div class="mod-row ' + m.on + '">' +
+                    '<span class="glyph">' + glyph + '</span>' +
+                    '<span class="id">' + esc(m.id) + (m.protected ? '<span class="lock" title="protected — always on">🔒</span>' : '') + '</span>' +
+                    '<span class="meta">' + esc(m.category) + ' · ' + esc(m.runtime) + '</span>' +
+                    '<span class="exposure-badge ' + esc(m.exposure) + '">' + esc(m.exposure) + '</span>' +
+                    '<span class="prio">prio ' + m.priority + '</span>' +
+                    '<span class="rss">' + fmtKb(m.rss_kb) + '</span>' +
+                    '<label class="member" title="add/remove from ' + esc(selectedProfile || '') + '">' +
+                    '<input type="checkbox" data-act="member" data-id="' + esc(m.id) + '"' + (isMember ? ' checked' : '') +
+                    (selectedProfile ? '' : ' disabled') + '> in profile</label>' +
+                    '<span class="pins">' +
+                    '<button class="btn sm' + (pin.cls === 'follow' ? ' active' : '') + '" data-act="pin" data-id="' + esc(m.id) + '" data-pin="clear" title="follow profile">⟳</button>' +
+                    '<button class="btn sm' + (pin.cls === 'on' ? ' active' : '') + '" data-act="pin" data-id="' + esc(m.id) + '" data-pin="on" title="pin on">📌ON</button>' +
+                    '<button class="btn sm' + (pin.cls === 'off' ? ' active' : '') + '" data-act="pin" data-id="' + esc(m.id) + '" data-pin="off"' + (pinOffDisabled ? ' disabled' : '') + ' title="' + (pinOffDisabled ? 'protected — cannot pin off' : 'pin off') + '">📌OFF</button>' +
+                    '</span>' +
+                    '</div>';
+            }).join('');
+        }
+
+        async function loadDiff() {
+            const el = document.getElementById('diffList');
+            if (!selectedProfile) { el.innerHTML = '<div class="empty-note">No active/selected profile.</div>'; return; }
+            el.innerHTML = 'Loading…';
+            try {
+                const data = await api('/diff?profile=' + encodeURIComponent(selectedProfile));
+                const changes = data.changes || [];
+                if (!changes.length) {
+                    el.innerHTML = '<div class="empty-note">✅ Nothing to change — reality already matches this profile.</div>';
+                    return;
+                }
+                el.innerHTML = changes.map(c =>
+                    '<div class="diff-row ' + esc(c.action) + '">' +
+                    '<span class="action ' + esc(c.action) + '">' + (c.action === 'start' ? '▶ start' : '⛔ stop') + '</span>' +
+                    '<span class="id">' + esc(c.id) + '</span>' +
+                    '<span class="reason">' + esc(c.reason) + '</span>' +
+                    '<span class="prio">prio ' + c.priority + '</span>' +
+                    '</div>'
+                ).join('');
+            } catch (e) {
+                el.innerHTML = '<div class="empty-note">⚠️ ' + esc(e.message) + '</div>';
+            }
+        }
+
+        async function toggleMember(id, on) {
+            if (!selectedProfile) return;
+            try {
+                await api('/profiles/' + encodeURIComponent(selectedProfile) + '/members', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ id: id, on: on }),
+                });
+                toast((on ? '✅ Added ' : '🗑️ Removed ') + id + (on ? ' to ' : ' from ') + selectedProfile);
+                await refresh();
+            } catch (e) {
+                errorToast('❌ ' + e.message);
+                renderModules(); // revert the optimistic checkbox state
+            }
+        }
+
+        async function setPin(id, pin) {
+            try {
+                await api('/pins', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ id: id, pin: pin }),
+                });
+                toast(pin === null ? ('⟳ ' + id + ' now follows the profile') : ('📌 ' + id + ' pinned ' + pin));
+                await refresh();
+            } catch (e) {
+                errorToast('❌ ' + e.message);
+            }
+        }
+
+        document.getElementById('modList').addEventListener('click', e => {
+            const t = e.target.closest('[data-act="pin"]');
+            if (!t || t.disabled) return;
+            const id = t.getAttribute('data-id');
+            const pinVal = t.getAttribute('data-pin');
+            setPin(id, pinVal === 'clear' ? null : pinVal);
+        });
+        document.getElementById('modList').addEventListener('change', e => {
+            const t = e.target.closest('[data-act="member"]');
+            if (!t) return;
+            toggleMember(t.getAttribute('data-id'), t.checked);
+        });
+
+        document.querySelectorAll('.tabs .tab').forEach(tab => {
+            tab.addEventListener('click', () => {
+                const scope = tab.closest('.card');
+                scope.querySelectorAll('.tab').forEach(x => x.classList.remove('active'));
+                scope.querySelectorAll('.tab-content').forEach(x => x.classList.remove('active'));
+                tab.classList.add('active');
+                document.getElementById(tab.getAttribute('data-tab')).classList.add('active');
+            });
+        });
+
+        document.getElementById('profileSelect').addEventListener('change', e => {
+            selectedProfile = e.target.value || null;
+            renderProfileSelect();
+            renderModules();
+            loadDiff();
+        });
+        document.getElementById('searchInput').addEventListener('input', e => {
+            searchTerm = e.target.value;
+            renderModules();
+        });
+        document.getElementById('stateFilter').addEventListener('change', e => {
+            stateFilterVal = e.target.value;
+            renderModules();
+        });
+        document.getElementById('refreshBtn').addEventListener('click', refresh);
+
+        refresh();
+        setInterval(refresh, 45000);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Adds the webui surface for `secubox-profiles` (Phase 1 inventory), and makes it fast enough to use.

## The panel

`admin.gk2.secubox.in/profiles/` — hybrid-dark per `WEBUI-PANEL-GUIDELINES.md`, copied from the `/certs/` reference: shared sidebar (never hand-rolled), Courier Prime, cyan `#00d4ff` as the only accent, `.grid`/`.stat-card`/`.card`/`.toast` vocabulary, one self-contained index.html.

Shows the inventory the CLI shows — 187 modules with category / runtime / exposure / priority / **RSS cost** — plus aggregates by category, runtime and exposure. Check buttons compose a profile; a three-state pin control (⟳ follows / 📌 on / 📌 off) sets overrides. A diff view shows what the active profile *would* change, explicitly labelled **not applied**.

## Still read-only, deliberately

`apply` does not exist and a test locks its absence. Writes are limited to desired-state files (`profiles/*.toml`, `pins.toml`) — nothing acts on them until Phase 3. That is enforced twice: in code, and by systemd (`ProtectSystem=strict` + `ReadWritePaths=/run/secubox /etc/secubox/profiles` — the API *cannot* write elsewhere).

The API runs on its **own socket**, never the aggregator: the profile engine must not depend on something it may later restart. Its unit carries `RuntimeDirectoryPreserve=yes` — without it, starting this service would wipe `/run/secubox` and kill 95 siblings' sockets.

**Protected core refused at the write path**, not just in the diff. Verified live:
```
POST {"id":"auth","pin":"off"} -> 409, and pins.toml was never created
```

## Performance: 46s -> 0.03s

`/status` took **46 seconds**. `observe()` spawned 3 subprocesses per module plus `lxc-info`, and re-read the routes file once per module — ~560 spawns at ~29ms each, on a box running 118 services at load 5.4 on 4 cores.

Now: ONE `systemctl show` for all units (measured: 187 in 0.28s), one LXC enumeration, routes read once, RSS from `/proc` (a file read). Plus a 60s cache refreshed **off the event loop** (`asyncio.to_thread`) per the project's own "double caching" pattern. The CLI still computes live — a one-shot command gains nothing from staleness.

| | before | after |
|---|---|---|
| `/status` cold | 46 s | 2.6 s |
| `/status` warm | — | **0.025 s** |
| panel via nginx | — | 1.6 ms |

## Three bugs only deployment could find

1. **`load_routes` crashed** with `PermissionError` -> HTTP 500. `/etc/secubox/waf` is `0750 root:root` while the file inside is `0644` — readable but not traversable. `.exists()` sat outside the try. The previous defects were "unknown must not become a definite answer"; this is its twin: **unknown must not become a crash**.
2. **The nginx route was doubly wrong**: shipped to `/etc/nginx/secubox.d/` which **nothing includes** (138 dead files live there — the admin vhost includes `secubox-routes.d/`), and `proxy_pass` ended in `:/` which strips the prefix, while the app registers the full path.
3. **A bare template unit (`name@.service`) breaks the whole batch** — `systemctl show` returned 40 blocks of 188. Templates are excluded, and a unit missing from the batch becomes `unknown`, never `False`.

That last rule is visible in the real data: totals went from `off:66 / unknown:0` to `off:62 / unknown:4`. **The old code was asserting "off" for 4 template units it could not resolve.**

102 tests. Live on gk2: sockets 108 before and after, aggregator unaffected.
