### PR TITLE
feat(sbxwaf): per-category detect mode — try a WAF rule without blocking

### DIFF
--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/ban.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/ban.go
@@ -87,3 +87,13 @@ func (b *Ban) Record(ip string, nowUnix int64) (count int, banned bool) {
 	banned = count >= b.threshold
 	return count, banned
 }
+
+// Count reports the number of recorded hits currently stored for ip, without
+// pruning or mutating state. It exists so tests (and diagnostics) can assert
+// that a code path never called Record for a given IP — a detect-mode match
+// must leave this at zero.
+func (b *Ban) Count(ip string) int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.hits[ip])
+}

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/main.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/main.go
@@ -241,6 +241,13 @@ func (s *Server) handler() http.Handler {
 		if s.routes != nil {
 			s.routes.Maybe()
 		}
+		// Same for the rules file: an operator flipping a category to detect (or
+		// editing any rule) must take effect without restarting the WAF that
+		// fronts every vhost. Match takes an RLock, Apply takes the Lock — the
+		// swap is race-safe (go test -race clean). Same one-stat cost as routes.
+		if s.rules != nil {
+			s.rules.Maybe()
+		}
 
 		// Strip port from Host header to get the bare hostname for lookup.
 		host, _, err := net.SplitHostPort(r.Host)

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/main.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/main.go
@@ -373,13 +373,33 @@ func (s *Server) handler() http.Handler {
 					}
 				}
 
-				cat, sev, hit := s.rules.Match(
+				cat, sev, mode, hit := s.rules.Match(
 					r.Method,
 					rawPath,
 					r.URL.RawQuery,
 					string(bodyBytes),
 					r.Header.Get("User-Agent"),
 				)
+				if hit && mode == modeDetect {
+					// Observe only: log it, let it through. A detect category
+					// must be as harmless as enabled:false, minus the log line
+					// — so NO ban, NO CrowdSec report, NO nft decision, NO
+					// ban-counter increment.
+					if s.threatLog != nil {
+						s.threatLog.Record(ThreatRecord{
+							ClientIP: ip,
+							Host:     r.Host,
+							Method:   r.Method,
+							Path:     rawPath,
+							Category: cat,
+							Severity: sev,
+							RuleID:   "",
+							Action:   "detect",
+							UA:       r.Header.Get("User-Agent"),
+						})
+					}
+					hit = false // fall through to the normal proxy path
+				}
 				if hit {
 					// Task 3.2 — graduated WARNING/BAN response.
 					//

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/main_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/main_test.go
@@ -8,8 +8,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestProxyPassthrough verifies that a request whose Host is in the route map
@@ -186,5 +189,140 @@ func TestParseTrustedHosts(t *testing.T) {
 	}
 	if len(m) != 3 {
 		t.Errorf("expected 3 entries, got %d", len(m))
+	}
+}
+
+// ─── detect mode (Task 2) ────────────────────────────────────────────────────
+//
+// newDetectTestServer builds a Server wired the same way TestHandlerWarningThenBan
+// (threatlog_test.go) and TestTrustedHostSkipsWAF (above) do: a routeLookup
+// closure pointing at a stub backend, real Rules loaded from rulesPath, and a
+// Ban tracker. There is no shared "newTestServer" helper in this package —
+// every handler test in this file constructs *Server directly — so the detect
+// tests follow that same pattern instead of inventing a new helper.
+func newDetectTestServer(t *testing.T, backendURL, rulesPath string) *Server {
+	t.Helper()
+	backendAddr := strings.TrimPrefix(backendURL, "http://")
+	h, p, err := splitHostPort(backendAddr)
+	if err != nil {
+		t.Fatalf("splitHostPort: %v", err)
+	}
+	return &Server{
+		routeLookup: func(host string) (string, int, bool) {
+			return h, p, true
+		},
+		rules: LoadRules(rulesPath),
+		ban:   NewBan(300*time.Second, 3),
+	}
+}
+
+// detectTestReq builds a request for /mgmt/tm/util/bash against app.example.com
+// from a given public (non-RFC1918) client IP, so privateCIDR does not skip
+// WAF inspection (mirrors the "203.0.113.x" TEST-NET-3 convention used
+// elsewhere in this package, e.g. TestTrustedHostSkipsWAF / TestHandlerWarningThenBan).
+func detectTestReq(clientIP string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "http://app.example.com/mgmt/tm/util/bash", nil)
+	req.Host = "app.example.com"
+	req.RemoteAddr = clientIP + ":12345"
+	return req
+}
+
+// A detect category matches but the request MUST pass through, and NOTHING may
+// be banned. A detect category must be as harmless as enabled:false, minus the
+// log line.
+func TestDetectModeLetsRequestThroughAndDoesNotBan(t *testing.T) {
+	rulesPath := writeRulesFile(t, `{"cve_2024":{"name":"CVE","severity":"critical","mode":"detect",
+		"patterns":[{"id":"cve-1","pattern":"/mgmt/tm/util/bash","desc":"F5 RCE"}]}}`)
+
+	upstreamHit := false
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHit = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "upstream reached")
+	}))
+	defer backend.Close()
+
+	const testClientIP = "203.0.113.77"
+	s := newDetectTestServer(t, backend.URL, rulesPath)
+	handler := s.handler()
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, detectTestReq(testClientIP))
+
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("detect mode returned 403; it must let the request through")
+	}
+	if !upstreamHit {
+		t.Fatal("detect mode did not reach the upstream; the request was swallowed")
+	}
+	if s.ban != nil && s.ban.Count(testClientIP) != 0 {
+		t.Fatalf("detect mode incremented the ban counter (%d); detect must never punish",
+			s.ban.Count(testClientIP))
+	}
+}
+
+// The same pattern in block mode must still block — the detect path must not
+// leak into the default behaviour.
+func TestBlockModeStillBlocks(t *testing.T) {
+	rulesPath := writeRulesFile(t, `{"cve_2024":{"name":"CVE","severity":"critical","mode":"block",
+		"patterns":[{"id":"cve-1","pattern":"/mgmt/tm/util/bash","desc":"F5 RCE"}]}}`)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("upstream must never be reached in block mode")
+	}))
+	defer backend.Close()
+
+	s := newDetectTestServer(t, backend.URL, rulesPath)
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, detectTestReq("203.0.113.78"))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("block mode: got %d, want 403", rec.Code)
+	}
+}
+
+// A category with no mode must block — non-regression for the 17 shipped ones.
+func TestAbsentModeStillBlocks(t *testing.T) {
+	rulesPath := writeRulesFile(t, `{"cve_2024":{"name":"CVE","severity":"critical",
+		"patterns":[{"id":"cve-1","pattern":"/mgmt/tm/util/bash","desc":"F5 RCE"}]}}`)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("upstream must never be reached when mode is absent (defaults to block)")
+	}))
+	defer backend.Close()
+
+	s := newDetectTestServer(t, backend.URL, rulesPath)
+	rec := httptest.NewRecorder()
+	s.handler().ServeHTTP(rec, detectTestReq("203.0.113.79"))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("absent mode: got %d, want 403", rec.Code)
+	}
+}
+
+// The threat record must say "detect" — otherwise stats conflate "blocked" with
+// "would have blocked" and the 198k threat counter becomes a lie.
+func TestDetectModeLogsActionDetect(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "threats.jsonl")
+	rulesPath := writeRulesFile(t, `{"cve_2024":{"name":"CVE","severity":"critical","mode":"detect",
+		"patterns":[{"id":"cve-1","pattern":"/mgmt/tm/util/bash","desc":"F5 RCE"}]}}`)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	s := newDetectTestServer(t, backend.URL, rulesPath)
+	s.threatLog = NewThreatLog(logPath)
+
+	s.handler().ServeHTTP(httptest.NewRecorder(), detectTestReq("203.0.113.80"))
+
+	raw, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("threat log not written: %v", err)
+	}
+	if !strings.Contains(string(raw), `"detect"`) {
+		t.Fatalf("threat record must carry action=detect, got: %s", raw)
+	}
+	if strings.Contains(string(raw), `"banned"`) || strings.Contains(string(raw), `"warning"`) {
+		t.Fatalf("detect must not be logged as warning/banned, got: %s", raw)
 	}
 }

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/main_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/main_test.go
@@ -326,3 +326,54 @@ func TestDetectModeLogsActionDetect(t *testing.T) {
 		t.Fatalf("detect must not be logged as warning/banned, got: %s", raw)
 	}
 }
+
+// A live edit to the rules file must take effect through ServeHTTP WITHOUT a
+// restart — the whole point of wiring s.rules.Maybe() into the request path.
+// Without it, an operator flipping a category to detect would see no change
+// until the WAF that fronts every vhost is restarted.
+func TestServerHotReloadsRuleModeWithoutRestart(t *testing.T) {
+	// Start in block mode.
+	rulesPath := writeRulesFile(t, `{"cve_2024":{"name":"CVE","severity":"critical","mode":"block",
+		"patterns":[{"id":"cve-1","pattern":"/mgmt/tm/util/bash","desc":"F5 RCE"}]}}`)
+
+	reached := false
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	s := newDetectTestServer(t, backend.URL, rulesPath)
+
+	// First request: block mode → 403, backend not reached.
+	handler := s.handler()
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, detectTestReq("203.0.113.50"))
+	if rec1.Code != http.StatusForbidden {
+		t.Fatalf("before reload (block): got %d, want 403", rec1.Code)
+	}
+	if reached {
+		t.Fatal("before reload: backend reached in block mode")
+	}
+
+	// Operator flips the same category to detect on disk.
+	if err := os.WriteFile(rulesPath, []byte(`{"_meta":{"version":"t"},"categories":{"cve_2024":{"name":"CVE","severity":"critical","mode":"detect","patterns":[{"id":"cve-1","pattern":"/mgmt/tm/util/bash","desc":"F5 RCE"}]}}}`), 0o644); err != nil {
+		t.Fatalf("rewrite rules: %v", err)
+	}
+	// Bump mtime past filesystem granularity so the watcher notices.
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(rulesPath, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	// Second request through ServeHTTP (which now calls s.rules.Maybe()):
+	// detect mode → passes through, backend reached, no restart.
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, detectTestReq("203.0.113.51"))
+	if rec2.Code == http.StatusForbidden {
+		t.Fatalf("after reload (detect): got 403; the live edit did not take effect without a restart")
+	}
+	if !reached {
+		t.Fatal("after reload: backend not reached; detect mode did not apply")
+	}
+}

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/parity_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/parity_test.go
@@ -199,7 +199,7 @@ func runDecision(rules *Rules, ban *Ban, fx parityFixture, now int64) string {
 	// Step 4: WAF rule matching.
 	// rawPath and rawQuery are passed as-is; Rules.Match applies unquote_plus
 	// internally (matches Python urllib.parse.unquote_plus in check_request).
-	_, _, hit := rules.Match(fx.Method, fx.Path, fx.Query, fx.Body, fx.UA)
+	_, _, _, hit := rules.Match(fx.Method, fx.Path, fx.Query, fx.Body, fx.UA)
 	if !hit {
 		return "allow"
 	}
@@ -276,13 +276,13 @@ func TestWAFParityRulesLoad(t *testing.T) {
 	rules := LoadRules(rulesPath)
 
 	// Probe with a known-good payload to confirm the rules are live.
-	_, _, hit := rules.Match("GET", "/search", "q=union+select+1,2,3", "", "")
+	_, _, _, hit := rules.Match("GET", "/search", "q=union+select+1,2,3", "", "")
 	if !hit {
 		t.Errorf("rules loaded from %q but union+select did not match — check waf-rules.json", rulesPath)
 	}
 
 	// Probe with a benign request to confirm no false positive on load.
-	_, _, fp := rules.Match("GET", "/", "q=hello+world", "", "Mozilla/5.0")
+	_, _, _, fp := rules.Match("GET", "/", "q=hello+world", "", "Mozilla/5.0")
 	if fp {
 		t.Errorf("false positive on benign request after loading %q", rulesPath)
 	}

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/rules.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/rules.go
@@ -63,6 +63,20 @@ import (
 	"github.com/CyberMind-FR/secubox-deb/secubox-toolbox-ng/internal/reload"
 )
 
+// Rule evaluation modes for a category.
+//
+//	modeBlock  — a match blocks the request (the historical, only behaviour).
+//	modeDetect — a match is counted and logged, the request PASSES, and nothing
+//	             is banned. Lets an operator try a rule against real traffic
+//	             before arming it.
+//
+// A category with no "mode" is modeBlock. A detect default would silently turn
+// the whole WAF into an observer — a mute security outage.
+const (
+	modeBlock  = "block"
+	modeDetect = "detect"
+)
+
 // compiledPattern holds a compiled regex and its metadata.
 type compiledPattern struct {
 	id      string
@@ -76,6 +90,7 @@ type compiledPattern struct {
 type compiledCategory struct {
 	name     string
 	severity string
+	mode     string // modeBlock | modeDetect — never empty after loadFile
 	patterns []compiledPattern
 }
 
@@ -142,6 +157,7 @@ func loadRulesJSON(path string) *rulesData {
 		Name     string        `json:"name"`
 		Severity string        `json:"severity"`
 		Enabled  *bool         `json:"enabled"` // pointer: nil means absent (default true)
+		Mode     *string       `json:"mode"`    // pointer: nil means absent (default block)
 		Patterns []patternJSON `json:"patterns"`
 	}
 
@@ -185,9 +201,27 @@ func loadRulesJSON(path string) *rulesData {
 			sev = "medium"
 		}
 
+		// Resolve the evaluation mode. Absent, null or "" ⇒ block: the 17
+		// shipped categories carry no "mode" and must keep blocking.
+		//
+		// An UNKNOWN value also ⇒ block, loudly. Fail closed: a typo like
+		// "monitor" must never silently drop a protection nor downgrade it to
+		// observation. This is the same instinct as Enabled's pointer default.
+		mode := modeBlock
+		if cat.Mode != nil && *cat.Mode != "" {
+			switch *cat.Mode {
+			case modeBlock, modeDetect:
+				mode = *cat.Mode
+			default:
+				log.Printf("sbxwaf/rules: category %q has unknown mode %q — falling back to %q (known modes: %q, %q)",
+					catID, *cat.Mode, modeBlock, modeBlock, modeDetect)
+			}
+		}
+
 		cc := compiledCategory{
 			name:     cat.Name,
 			severity: sev,
+			mode:     mode,
 		}
 		if cc.name == "" {
 			cc.name = catID

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/rules.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/rules.go
@@ -316,9 +316,11 @@ func unquotePlus(s string) string {
 // calls urllib.parse.unquote_plus inside the function).  body and ua are
 // already plain text (no additional decoding applied).
 //
-// Returns: cat (category ID), sev (severity string), hit (true on first match).
-// Returns "", "", false when no rule fires.
-func (r *Rules) Match(method, rawPath, rawQuery, body, ua string) (cat, sev string, hit bool) {
+// Returns: cat (category ID), sev (severity string), mode (modeBlock or
+// modeDetect — only meaningful when hit is true; the caller decides what to
+// do with it), hit (true on first match). Returns "", "", "", false when no
+// rule fires.
+func (r *Rules) Match(method, rawPath, rawQuery, body, ua string) (cat, sev, mode string, hit bool) {
 	// Decode path and query (unquote_plus semantics: '+' → space, then %XX).
 	decodedPath := unquotePlus(rawPath)
 	decodedQuery := unquotePlus(rawQuery)
@@ -335,15 +337,15 @@ func (r *Rules) Match(method, rawPath, rawQuery, body, ua string) (cat, sev stri
 	r.mu.RUnlock()
 
 	if cur == nil {
-		return "", "", false
+		return "", "", "", false
 	}
 
 	for _, c := range cur.cats {
 		for _, p := range c.data.patterns {
 			if p.re.MatchString(scanText) {
-				return c.id, p.severity, true
+				return c.id, p.severity, c.data.mode, true
 			}
 		}
 	}
-	return "", "", false
+	return "", "", "", false
 }

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/rules_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/rules_test.go
@@ -7,6 +7,7 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -320,5 +321,96 @@ func TestRulesHotReload(t *testing.T) {
 	}
 	if sev != "critical" {
 		t.Fatalf("after reload: expected sev='critical', got %q", sev)
+	}
+}
+
+// writeRulesFile writes a waf-rules.json with the given categories body and returns its path.
+func writeRulesFile(t *testing.T, categories string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "waf-rules.json")
+	body := `{"_meta":{"version":"test"},"categories":` + categories + `}`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	return p
+}
+
+// catMode returns the compiled mode for category id, or "" if absent.
+func catMode(r *Rules, id string) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, c := range r.current.cats {
+		if c.id == id {
+			return c.data.mode
+		}
+	}
+	return ""
+}
+
+// A category with no "mode" MUST block. This is the most important test in the
+// file: a detect default would silently disarm all 17 existing categories.
+func TestModeAbsentDefaultsToBlock(t *testing.T) {
+	p := writeRulesFile(t, `{"sqli":{"name":"SQLi","severity":"critical",
+		"patterns":[{"id":"sqli-001","pattern":"union select","desc":"x"}]}}`)
+	r := LoadRules(p)
+	if got := catMode(r, "sqli"); got != modeBlock {
+		t.Fatalf("absent mode: got %q, want %q", got, modeBlock)
+	}
+}
+
+func TestModeBlockExplicit(t *testing.T) {
+	p := writeRulesFile(t, `{"sqli":{"name":"SQLi","mode":"block",
+		"patterns":[{"id":"sqli-001","pattern":"union select","desc":"x"}]}}`)
+	if got := catMode(LoadRules(p), "sqli"); got != modeBlock {
+		t.Fatalf("got %q, want %q", got, modeBlock)
+	}
+}
+
+func TestModeDetectIsParsed(t *testing.T) {
+	p := writeRulesFile(t, `{"cve_2024":{"name":"CVE","mode":"detect",
+		"patterns":[{"id":"cve-1","pattern":"/mgmt/tm/util/bash","desc":"x"}]}}`)
+	if got := catMode(LoadRules(p), "cve_2024"); got != modeDetect {
+		t.Fatalf("got %q, want %q", got, modeDetect)
+	}
+}
+
+// A typo must NOT disarm the category and must NOT become detect: fail closed.
+func TestModeUnknownFailsClosedToBlock(t *testing.T) {
+	for _, bad := range []string{"monitor", "dryrun", "BLOCK ", "xyz"} {
+		p := writeRulesFile(t, `{"sqli":{"name":"SQLi","mode":"`+bad+`",
+			"patterns":[{"id":"sqli-001","pattern":"union select","desc":"x"}]}}`)
+		r := LoadRules(p)
+		if got := catMode(r, "sqli"); got != modeBlock {
+			t.Fatalf("mode %q: got %q, want %q (must fail closed)", bad, got, modeBlock)
+		}
+		// And the category must still be evaluated — a typo must not remove protection.
+		if _, _, hit := r.Match("GET", "/x", "q=union+select", "", ""); !hit {
+			t.Fatalf("mode %q: category was dropped; a typo must not disable a rule", bad)
+		}
+	}
+}
+
+// "" and null are "absent", not errors.
+func TestModeEmptyAndNullDefaultToBlock(t *testing.T) {
+	for _, body := range []string{`"mode":"",`, `"mode":null,`} {
+		p := writeRulesFile(t, `{"sqli":{"name":"SQLi",`+body+`
+			"patterns":[{"id":"sqli-001","pattern":"union select","desc":"x"}]}}`)
+		if got := catMode(LoadRules(p), "sqli"); got != modeBlock {
+			t.Fatalf("%s got %q, want %q", body, got, modeBlock)
+		}
+	}
+}
+
+// enabled:false wins over mode — the category is not evaluated at all.
+func TestEnabledFalseWinsOverMode(t *testing.T) {
+	p := writeRulesFile(t, `{"sqli":{"name":"SQLi","enabled":false,"mode":"detect",
+		"patterns":[{"id":"sqli-001","pattern":"union select","desc":"x"}]}}`)
+	r := LoadRules(p)
+	if got := catMode(r, "sqli"); got != "" {
+		t.Fatalf("disabled category should not be loaded at all, got mode %q", got)
+	}
+	if _, _, hit := r.Match("GET", "/x", "q=union+select", "", ""); hit {
+		t.Fatal("disabled category must not match")
 	}
 }

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/rules_test.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/rules_test.go
@@ -50,7 +50,7 @@ func TestRulesMatchSQLi(t *testing.T) {
 	r := LoadRules(path)
 
 	// Hit: query contains "union select" (Match decodes raw inputs internally)
-	cat, sev, hit := r.Match("GET", "/x", "id=1+union+select", "", "")
+	cat, sev, _, hit := r.Match("GET", "/x", "id=1+union+select", "", "")
 	if !hit {
 		t.Fatal("expected hit for UNION SELECT in query, got miss")
 	}
@@ -62,13 +62,13 @@ func TestRulesMatchSQLi(t *testing.T) {
 	}
 
 	// Hit: uppercase variant (case-insensitive)
-	_, _, hit = r.Match("GET", "/x", "id=1+UNION+SELECT", "", "")
+	_, _, _, hit = r.Match("GET", "/x", "id=1+UNION+SELECT", "", "")
 	if !hit {
 		t.Fatal("expected hit for uppercase UNION SELECT")
 	}
 
 	// Miss: benign request
-	cat, sev, hit = r.Match("GET", "/", "q=hello", "", "Mozilla/5.0")
+	cat, sev, _, hit = r.Match("GET", "/", "q=hello", "", "Mozilla/5.0")
 	if hit {
 		t.Fatalf("expected miss for benign request, got hit cat=%q sev=%q", cat, sev)
 	}
@@ -89,7 +89,7 @@ func TestRulesDisabledCategory(t *testing.T) {
 	path := writeRulesJSON(t, doc)
 	r := LoadRules(path)
 
-	_, _, hit := r.Match("GET", "/x", "id=1 union select", "", "")
+	_, _, _, hit := r.Match("GET", "/x", "id=1 union select", "", "")
 	if hit {
 		t.Fatal("disabled category must never match")
 	}
@@ -116,7 +116,7 @@ func TestRulesUncompilablePatternSkipped(t *testing.T) {
 	r := LoadRules(path)
 
 	// Good pattern must still fire
-	_, _, hit := r.Match("GET", "/x", "id=1 union select", "", "")
+	_, _, _, hit := r.Match("GET", "/x", "id=1 union select", "", "")
 	if !hit {
 		t.Fatal("good pattern after a skipped bad one must still match")
 	}
@@ -138,7 +138,7 @@ func TestRulesMatchInPath(t *testing.T) {
 	r := LoadRules(path)
 
 	// URL-encoded path: /..%2Fetc%2Fpasswd — after unquote_plus → /../etc/passwd
-	_, _, hit := r.Match("GET", "/..%2Fetc%2Fpasswd", "", "", "")
+	_, _, _, hit := r.Match("GET", "/..%2Fetc%2Fpasswd", "", "", "")
 	if !hit {
 		t.Fatal("expected hit for URL-encoded etc/passwd in path")
 	}
@@ -159,7 +159,7 @@ func TestRulesMatchInBody(t *testing.T) {
 	path := writeRulesJSON(t, doc)
 	r := LoadRules(path)
 
-	_, _, hit := r.Match("POST", "/submit", "", "data=eval(base64_decode(xyz))", "")
+	_, _, _, hit := r.Match("POST", "/submit", "", "data=eval(base64_decode(xyz))", "")
 	if !hit {
 		t.Fatal("expected hit for eval( in body")
 	}
@@ -180,7 +180,7 @@ func TestRulesMatchInUA(t *testing.T) {
 	path := writeRulesJSON(t, doc)
 	r := LoadRules(path)
 
-	_, _, hit := r.Match("GET", "/", "", "", "sqlmap/1.7")
+	_, _, _, hit := r.Match("GET", "/", "", "", "sqlmap/1.7")
 	if !hit {
 		t.Fatal("expected hit for sqlmap in User-Agent")
 	}
@@ -202,7 +202,7 @@ func TestRulesDefaultEnabledTrue(t *testing.T) {
 	path := writeRulesJSON(t, doc)
 	r := LoadRules(path)
 
-	_, _, hit := r.Match("GET", "/x", "id=1 union select", "", "")
+	_, _, _, hit := r.Match("GET", "/x", "id=1 union select", "", "")
 	if !hit {
 		t.Fatal("category without explicit 'enabled' must default to enabled=true")
 	}
@@ -222,7 +222,7 @@ func TestRulesDefaultSeverityMedium(t *testing.T) {
 	path := writeRulesJSON(t, doc)
 	r := LoadRules(path)
 
-	_, sev, hit := r.Match("GET", "/evil", "", "", "")
+	_, sev, _, hit := r.Match("GET", "/evil", "", "", "")
 	if !hit {
 		t.Fatal("expected hit")
 	}
@@ -237,7 +237,7 @@ func TestRulesEmptyFile(t *testing.T) {
 	r := LoadRules("/tmp/nonexistent-waf-rules-12345.json")
 
 	// Must not panic; must return miss for everything.
-	_, _, hit := r.Match("GET", "/", "id=1 union select 1,2,3", "", "")
+	_, _, _, hit := r.Match("GET", "/", "id=1 union select 1,2,3", "", "")
 	if hit {
 		t.Fatal("LoadRules on missing file: Match should always miss")
 	}
@@ -267,13 +267,13 @@ func TestRulesHotReload(t *testing.T) {
 	r := LoadRules(path)
 
 	// SQLi should miss before reload.
-	_, _, hit := r.Match("GET", "/", "id=1 union select", "", "")
+	_, _, _, hit := r.Match("GET", "/", "id=1 union select", "", "")
 	if hit {
 		t.Fatal("before reload: union select should miss (no sqli rules loaded)")
 	}
 
 	// XSS should fire.
-	_, _, hit = r.Match("GET", "/<script>", "", "", "")
+	_, _, _, hit = r.Match("GET", "/<script>", "", "", "")
 	if !hit {
 		t.Fatal("before reload: script tag in path should hit xss")
 	}
@@ -312,7 +312,7 @@ func TestRulesHotReload(t *testing.T) {
 	r.Maybe()
 
 	// Now sqli should fire.
-	cat, sev, hit := r.Match("GET", "/", "id=1 union select", "", "")
+	cat, sev, _, hit := r.Match("GET", "/", "id=1 union select", "", "")
 	if !hit {
 		t.Fatal("after reload: union select should hit sqli")
 	}
@@ -385,7 +385,7 @@ func TestModeUnknownFailsClosedToBlock(t *testing.T) {
 			t.Fatalf("mode %q: got %q, want %q (must fail closed)", bad, got, modeBlock)
 		}
 		// And the category must still be evaluated — a typo must not remove protection.
-		if _, _, hit := r.Match("GET", "/x", "q=union+select", "", ""); !hit {
+		if _, _, _, hit := r.Match("GET", "/x", "q=union+select", "", ""); !hit {
 			t.Fatalf("mode %q: category was dropped; a typo must not disable a rule", bad)
 		}
 	}
@@ -410,7 +410,7 @@ func TestEnabledFalseWinsOverMode(t *testing.T) {
 	if got := catMode(r, "sqli"); got != "" {
 		t.Fatalf("disabled category should not be loaded at all, got mode %q", got)
 	}
-	if _, _, hit := r.Match("GET", "/x", "q=union+select", "", ""); hit {
+	if _, _, _, hit := r.Match("GET", "/x", "q=union+select", "", ""); hit {
 		t.Fatal("disabled category must not match")
 	}
 }

--- a/packages/secubox-toolbox-ng/cmd/sbxwaf/threatlog.go
+++ b/packages/secubox-toolbox-ng/cmd/sbxwaf/threatlog.go
@@ -20,7 +20,7 @@
 //	category   — WAF category ID (e.g. "sqli", "xss")
 //	severity   — "low"|"medium"|"high"|"critical"
 //	rule_id    — matched rule ID (empty string when Match() did not return one)
-//	action     — "warning" | "banned"
+//	action     — "detect" | "warning" | "banned"
 //	user_agent — User-Agent header
 package main
 
@@ -43,7 +43,7 @@ type ThreatRecord struct {
 	Category string
 	Severity string
 	RuleID   string
-	Action   string // "warning" | "banned"
+	Action   string // "detect" | "warning" | "banned"
 	UA       string
 }
 

--- a/packages/secubox-waf/api/main.py
+++ b/packages/secubox-waf/api/main.py
@@ -351,6 +351,7 @@ def _get_threat_stats() -> dict:
     if state.get("today_iso") != today:
         state["today_iso"] = today
         state["threats_today"] = 0
+        state["observed_today"] = 0   # detect-mode matches seen today (not blocked)
 
     counters = state.get("counters", {})
     by_category = defaultdict(int, counters.get("by_category", {}))
@@ -360,6 +361,12 @@ def _get_threat_stats() -> dict:
     top_vhosts = defaultdict(int, counters.get("top_vhosts", {}))
     total_threats = counters.get("total_threats", 0)
     threats_today = state.get("threats_today", 0)
+    # detect-mode matches: seen and logged but NOT blocked — kept apart from the
+    # block counters so blocked_24h stays truthful. Persisted like the rest
+    # because the reader is incremental (byte_position) and would otherwise
+    # only count the newest lines.
+    observed_threats = counters.get("observed_threats", 0)
+    observed_today = state.get("observed_today", 0)
     ip_countries: Dict[str, str] = dict(state.get("ip_countries", {}))
 
     log_path = Path(THREATS_LOG)
@@ -368,6 +375,7 @@ def _get_threat_stats() -> dict:
         return _finalize_stats(
             total_threats, threats_today, by_category, by_severity,
             top_ips, top_countries, top_vhosts, ip_countries,
+            observed_threats, observed_today,
         )
 
     geoip_reader = _get_geoip_reader()
@@ -382,6 +390,8 @@ def _get_threat_stats() -> dict:
             top_countries.clear(); top_vhosts.clear()
             total_threats = 0
             threats_today = 0
+            observed_threats = 0
+            observed_today = 0
             byte_position = 0
             ip_countries.clear()
 
@@ -391,6 +401,18 @@ def _get_threat_stats() -> dict:
                 for line in f:
                     try:
                         entry = json.loads(line.strip())
+
+                        # A "detect" record was MATCHED but let through — the
+                        # request was NOT blocked. Counting it as a block would
+                        # conflate "blocked" with "would have blocked" and make
+                        # blocked_24h a lie the moment an operator arms a detect
+                        # category. It gets its own observed-only counter.
+                        if entry.get("action") == "detect":
+                            observed_threats += 1
+                            if entry.get("timestamp", "").startswith(today):
+                                observed_today += 1
+                            continue
+
                         total_threats += 1
 
                         if entry.get("timestamp", "").startswith(today):
@@ -425,9 +447,11 @@ def _get_threat_stats() -> dict:
     _save_stats_disk_cache({
         "today_iso": today,
         "threats_today": threats_today,
+        "observed_today": observed_today,
         "byte_position": byte_position,
         "counters": {
             "total_threats": total_threats,
+            "observed_threats": observed_threats,
             "by_category": dict(by_category),
             "by_severity": dict(by_severity),
             "top_ips": dict(top_ips),
@@ -441,6 +465,7 @@ def _get_threat_stats() -> dict:
     return _finalize_stats(
         total_threats, threats_today, by_category, by_severity,
         top_ips, top_countries, top_vhosts, ip_countries,
+        observed_threats, observed_today,
     )
 
 
@@ -448,12 +473,16 @@ def _finalize_stats(
     total_threats: int, threats_today: int,
     by_category, by_severity, top_ips, top_countries, top_vhosts,
     ip_countries: dict,
+    observed_threats: int = 0, observed_today: int = 0,
 ) -> dict:
     """Shape the dashboard-friendly result : top-10 lists + plain dicts."""
     top_ips_sorted = sorted(top_ips.items(), key=lambda x: -x[1])[:10]
     return {
         "total_threats": total_threats,
         "threats_today": threats_today,
+        # detect-mode: matched but let through. Separate from the block counts.
+        "observed_threats": observed_threats,
+        "observed_today": observed_today,
         "by_category": dict(by_category),
         "by_severity": dict(by_severity),
         "top_ips": {ip: count for ip, count in top_ips_sorted},

--- a/packages/secubox-waf/tests/test_detect_exclusion.py
+++ b/packages/secubox-waf/tests/test_detect_exclusion.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: LicenseRef-CMSD-1.0
+# Copyright (c) 2026 CyberMind — Gérald Kerma <devel@cybermind.fr>
+#
+# detect-mode records must never inflate the WAF dashboard's block counters.
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make the package importable without an install step
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Stub out secubox_core before importing waf.api — production deps
+# (auth, config) aren't needed for these unit tests.
+from types import ModuleType
+
+if "secubox_core" not in sys.modules:
+    secubox_core = ModuleType("secubox_core")
+    auth_mod = ModuleType("secubox_core.auth")
+    auth_mod.require_jwt = lambda: None
+    config_mod = ModuleType("secubox_core.config")
+    config_mod.get_config = lambda *_a, **_k: {}
+    secubox_core.auth = auth_mod
+    secubox_core.config = config_mod
+    sys.modules["secubox_core"] = secubox_core
+    sys.modules["secubox_core.auth"] = auth_mod
+    sys.modules["secubox_core.config"] = config_mod
+
+# geoip2 may or may not be installed in CI; stub it out.
+if "geoip2" not in sys.modules:
+    geoip2 = ModuleType("geoip2")
+    geoip2_db = ModuleType("geoip2.database")
+    geoip2_db.Reader = object
+    geoip2_err = ModuleType("geoip2.errors")
+    class _AddressNotFoundError(Exception): ...
+    geoip2_err.AddressNotFoundError = _AddressNotFoundError
+    sys.modules["geoip2"] = geoip2
+    sys.modules["geoip2.database"] = geoip2_db
+    sys.modules["geoip2.errors"] = geoip2_err
+
+from api import main as waf_main  # noqa: E402
+import time
+
+
+def _write_log(tmp_path, *entries):
+    import json as _json
+    p = tmp_path / "threats.log"
+    p.write_text("\n".join(_json.dumps(e) for e in entries) + "\n")
+    return p
+
+
+def test_detect_records_excluded_from_block_counters(tmp_path, monkeypatch):
+    """A detect-mode match is observed, not blocked. Counting it as a block
+    would make blocked_24h a lie the instant an operator arms a detect
+    category — the whole reason action='detect' exists."""
+    today = time.strftime("%Y-%m-%d")
+    logp = _write_log(
+        tmp_path,
+        {"action": "banned", "category": "sqli", "severity": "critical",
+         "timestamp": today + "T10:00:00", "client_ip": "203.0.113.1"},
+        {"action": "detect", "category": "cve_2024", "severity": "critical",
+         "timestamp": today + "T10:00:01", "client_ip": "203.0.113.2"},
+        {"action": "detect", "category": "cve_2024", "severity": "critical",
+         "timestamp": today + "T10:00:02", "client_ip": "203.0.113.3"},
+    )
+    monkeypatch.setattr(waf_main, "THREATS_LOG", str(logp))
+    monkeypatch.setattr(waf_main, "STATS_DISK_CACHE", str(tmp_path / "cache.json"))
+
+    stats = waf_main._get_threat_stats()
+
+    assert stats["total_threats"] == 1, "detect records leaked into total_threats"
+    assert stats["observed_threats"] == 2
+    assert "cve_2024" not in stats["by_category"]
+    assert stats["by_category"].get("sqli") == 1
+
+
+def test_detect_only_log_reports_zero_blocked(tmp_path, monkeypatch):
+    """A log of pure detect matches must report zero blocks, not N."""
+    today = time.strftime("%Y-%m-%d")
+    logp = _write_log(
+        tmp_path,
+        {"action": "detect", "category": "cve_2024", "severity": "high",
+         "timestamp": today + "T09:00:00", "client_ip": "203.0.113.9"},
+    )
+    monkeypatch.setattr(waf_main, "THREATS_LOG", str(logp))
+    monkeypatch.setattr(waf_main, "STATS_DISK_CACHE", str(tmp_path / "cache.json"))
+
+    stats = waf_main._get_threat_stats()
+    assert stats["total_threats"] == 0
+    assert stats["observed_threats"] == 1


### PR DESCRIPTION
Adds a per-category `mode` to sbxwaf: `block` (default) or `detect` (match, log `action=detect`, **let the request through, never ban**). Lets an operator try a rule against real traffic before arming it — and, per the user, is the basis for *fingerprinting* an attacker on a probe for a product the box doesn't run (zero false positives possible, precisely because the product is absent).

**Deployed and verified live on gk2.**

## The four commits

1. **`2dc2654b` parse** — `mode` field. Absent/`""`/`null` ⇒ `block`; unknown value ⇒ `block` **loudly** (fail-closed — a typo must never drop a protection). The 17 shipped categories carry no `mode`, so they keep blocking, byte-identical.
2. **`2f44ee7d` honour** — `Match` reports the mode; a `detect` hit writes one threat record (`action=detect`) then `hit = false`, **before** the block path that owns `ban.Record`/`crowdsec.Report`. A detect category is as harmless as `enabled:false`, minus the log line. Single production call site (`main.go:376`).
3. **`f3bb74e0` hot-reload** — the spec claimed a rules change needs no restart; it was false (`Rules.Maybe()` defined but never called). One line beside the existing `routes.Maybe()`, race-safe. Now true.
4. **`81a50f63` consumer** — the final review caught that the dashboard counted every log line as blocked (`blocked_24h = total_threats`), so arming a detect category would inflate "blocked" — the exact conflation `action=detect` exists to prevent. Detect records now feed a separate `observed_threats`/`observed_today`, excluded from the block counts.

## Live proof on gk2

```
Hot-reload without restart (edit disk, no systemctl):
  cve_2024 block   /mgmt/tm/util/bash -> 403
  cve_2024 detect  /mgmt/tm/util/bash -> 404   (passes to backend)
  SQLi (no mode)                      -> 403   (still blocks)
  restored         /mgmt/tm/util/bash -> 403

Consumer: /stats now exposes observed_threats + observed_today alongside blocked_24h.
```

## Review trail

Every task passed a two-stage review; the final whole-branch review (opus) returned CHANGES-NEEDED on the two findings above, both fixed and mutation-verified. Each behavioural test was proven able to fail by reverting its target and confirming the failure.

**Deferred minors** (non-blocking): `Ban.Count` is a prod method added for a test (could live in `_test.go`); one log test substring-matches instead of unmarshalling; the pre-existing `test_stats_cache.py` fails to collect on master (stale `import StatsCache`, since renamed to a no-op shim) — its own cleanup, not touched here.

The CVE→WAF rule generator that motivated this is a separate future spec; the user's key correction — that the useful filter for *fingerprinting* is **product absent** (0 FP), the inverse of the *protect* filter — is recorded for it.