### PR TITLE
fix(podcaster): stage YouTube imports on the SSD, not the eMMC root

### DIFF
--- a/packages/secubox-podcaster/api/importer.py
+++ b/packages/secubox-podcaster/api/importer.py
@@ -223,7 +223,14 @@ def run_import(url: str, media_dir: str, mirror_peertube: bool, create_billets: 
     JOB.update({"running": True, "url": url, "total": 0, "done": 0, "current": "",
                 "errors": [], "feed_id": None, "started": int(time.time()),
                 "finished": 0, "log": []})
-    workdir = Path(media_dir).parent / "youtube-import"
+    # Stage on the SAME real filesystem as the media store. media_dir is usually
+    # a symlink onto the SSD (…/media -> /data/secubox/podcaster/media); taking
+    # .parent BEFORE resolving lands the staging back on the eMMC root — which is
+    # exactly how a large YouTube import filled the root fs to 99% and stalled
+    # (staging on eMMC, store on SSD). .resolve() follows the symlink so staging
+    # and store share the SSD. Durable: it derives from the real path, so a
+    # package reinstall that re-lays the symlink cannot revert it.
+    workdir = Path(media_dir).resolve().parent / "youtube-import"
     try:
         entries = _enumerate(url)
         if not entries:


### PR DESCRIPTION
**Root cause of a recurring disk-full on gk2.** `run_import` in `importer.py` computed its staging workdir as `Path(media_dir).parent / "youtube-import"`. `media_dir` is the symlink `…/podcaster/media` → the SSD; taking `.parent` **before** resolving lands the staging back on the eMMC root fs.

A large playlist import then downloaded ~1.4G into eMMC staging, filled `/` to **99%**, and stalled before moving anything to the SSD store — 22 half-imported videos stuck on the wrong filesystem. A symlink alone never fixed this because the path is computed in code, so a reinstall (or the code itself) put staging back on the eMMC every time.

## The fix

```python
workdir = Path(media_dir).resolve().parent / "youtube-import"
```

`.resolve()` follows the symlink so staging and store share the SSD, and it derives from the **real** path — so a package reinstall that re-lays the symlink can't revert it (unlike the symlink-only attempt in the ledger).

Verified with a temp layout (`media -> SSD`): the workdir resolves onto the SSD, not the eMMC.

## Board recovery (already done on gk2)

- Deployed the fix; podcaster restarted, `/status` 200 through nginx.
- Moved the 22 stuck staging dirs eMMC → `/data/secubox/podcaster/youtube-import` (SSD): nothing lost.
- Confirmed a future import now stages on the SSD (`/data/...`, checked with the deployed code).

Root fs went **99% → 79%** across this + an unrelated cleanup of 1.4G stale `/var/tmp/mkinitramfs_*` scratch. `/data` (SSD) at 16%, 731G free.

Note: `main.py:439` still uses a hardcoded `/var/lib/secubox/podcaster` for a transient export-zip temp — small and short-lived, left as a separate minor follow-up.